### PR TITLE
Limit topics' excerpts to 25'ish words

### DIFF
--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -1,9 +1,9 @@
 module TopicsHelper
   def format_content(content)
-    strip_tags(content).truncate(300)
+    strip_tags(content).truncate(140, separator:' ', omission:'&#8230;')
   end
 
   def topic_classes(topics)
-    topics.pluck(:slug).join(" ")
+    topics.pluck(:slug).join(' ')
   end
 end

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe TopicsHelper, '#format_content' do
+  let(:ellipsis) { '&#8230;' }
+
+  it 'strips tags from content' do
+    content   = '<strong>Hello</strong> there'
+    expected  = 'Hello there'
+    helper.format_content(content).should == expected
+  end
+
+  it 'truncates the number of words to 23' do
+    content   = 'On the new learn homepage, the topic excerpts are too long. It would be additionally great to add a function into the view that controls the numbers of words present, so a designer can fool with it.'
+    expected  = "On the new learn homepage, the topic excerpts are too long. It would be additionally great to add a function into the view that#{ellipsis}"
+    helper.format_content(content).should == expected
+  end
+
+  it 'does not include an ellipsis if the content is short' do
+    content = 'Hello there.'
+    expected = 'Hello there.'
+    helper.format_content(content).should == expected
+  end
+end


### PR DESCRIPTION
- Currently limiting to 23 words to get (reliably) close to 3 lines of text
- Add some tests
