### PR TITLE
purchases associated with users on creation

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -47,6 +47,14 @@ class Purchase < ActiveRecord::Base
     @@host = host
   end
 
+  def self.stripe
+    where("stripe_customer is not null")
+  end
+
+  def self.by_email(email)
+    where(email: email)
+  end
+
   def price
     full_price = product.send(:"#{variant}_price")
     if coupon
@@ -120,21 +128,23 @@ class Purchase < ActiveRecord::Base
 
   def create_and_charge_customer
     begin
-      customer = Stripe::Customer.create(
-        card: stripe_token,
-        description: email,
-        email: email
-      )
+      if stripe_customer.blank?
+        customer = Stripe::Customer.create(
+          card: stripe_token,
+          description: email,
+          email: email
+        )
+        self.stripe_customer = customer.id
+      end
 
       charge = Stripe::Charge.create(
         amount: price * 100, # in cents
         currency: "usd",
-        customer: customer.id,
+        customer: stripe_customer,
         description: product_name
       )
-
       self.payment_transaction_id = charge.id
-      self.stripe_customer = customer.id
+
       self.paid = true
     rescue Stripe::StripeError => e
       errors[:base] << "There was a problem processing your credit card, #{e.message.downcase}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,21 @@ class User < ActiveRecord::Base
 
   attr_accessible :last_name, :password, :email, :first_name
 
+  has_many :purchases
+
   validates_presence_of :first_name, :last_name
+
+  after_create :associate_previous_purchases
 
   def name
     [first_name, last_name].join(' ')
+  end
+
+  private
+
+  def associate_previous_purchases
+    previous_purchases = Purchase.by_email(email)
+    self.purchases << previous_purchases
+    self.update_column(:stripe_customer, previous_purchases.stripe.last.try(:stripe_customer))
   end
 end

--- a/db/migrate/20120806193215_add_purchases_to_users.rb
+++ b/db/migrate/20120806193215_add_purchases_to_users.rb
@@ -1,0 +1,5 @@
+class AddPurchasesToUsers < ActiveRecord::Migration
+  def change
+    add_column :purchases, :user_id, :integer
+  end
+end

--- a/db/migrate/20120806194223_add_stripe_customer_to_users.rb
+++ b/db/migrate/20120806194223_add_stripe_customer_to_users.rb
@@ -1,0 +1,5 @@
+class AddStripeCustomerToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :stripe_customer, :string
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -129,6 +129,7 @@ FactoryGirl.define do
 
   factory :download do
   end
+
   factory :purchase, aliases: [:individual_purchase] do
     product
     name "Test User"

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -216,3 +216,31 @@ describe Purchase, 'with no price' do
     it { should_not be_valid }
   end
 end
+
+describe "Purchases with various payment methods" do
+  before do
+    @stripe = create(:purchase, payment_method: "stripe")
+    @paypal = create(:purchase, payment_method: "paypal")
+  end
+
+  it "includes only stripe payments in the stripe finder" do
+    Purchase.stripe.should == [@stripe]
+  end
+end
+
+describe "Purchases for various emails" do
+  context "#by_email" do
+    let(:email) { "user@example.com" }
+
+    before do
+      @prev_purchases = [create(:purchase, email: email),
+                         create(:purchase, email: email)]
+      @other_purchase = create(:purchase)
+    end
+
+    it "#by_email" do
+      Purchase.by_email(email).should =~ @prev_purchases
+      Purchase.by_email(email).should_not include @other_purchase
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe User do
+  context "associations" do
+    it { should have_many(:purchases) }
+  end
+
+  context "validations" do
+    it { should validate_presence_of(:last_name) }
+    it { should validate_presence_of(:first_name) }
+  end
+
+  context "#name" do
+    it "has a name that is the first and last name" do
+      user = User.new(first_name: "first", last_name: "last")
+      user.name.should == "first last"
+    end
+  end
+
+  context "when there are previous purchases" do
+    let(:email) { "newuser@example.com" }
+
+    before do
+      @prev_purchases = [create(:purchase, email: email, stripe_customer: "stripecustomer"),
+                         create(:purchase, email: email, stripe_customer: nil, payment_method: "paypal")]
+      @other_purchase = create(:purchase)
+    end
+
+    it "associates only purchases for a new user with the same email" do
+      user = create(:user, email: email)
+      user.purchases.should =~ @prev_purchases
+      user.purchases.should_not include @other_purchase
+    end
+
+    it "retrieves the stripe customer id from previous purchases" do
+      user = create(:user, email: email)
+      user.reload.stripe_customer.should == "stripecustomer"
+    end
+  end
+
+  context "when there are no previous purchases" do
+    it "doesn't associate a created user with any purchases" do
+      user = create(:user)
+      user.purchases.should be_empty
+      user.stripe_customer.should be_blank
+    end
+  end
+end


### PR DESCRIPTION
associate previous purchases with new users with the same email
use the previous stripe_customer  on new users if one exists
