### PR TITLE
Test coverage for emails received on user purchase

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -16,7 +16,7 @@ class PurchasesController < ApplicationController
   def create
     @product = Product.find(params[:product_id])
     @purchase = @product.purchases.build(params[:purchase])
-    @purchase.user = current_user if signed_in?
+    @purchase.user = current_user
     @purchase.coupon = Coupon.find_by_id_and_active(params[:coupon_id], true) unless params[:coupon_id].blank?
 
     if @purchase.save

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -210,6 +210,10 @@ Then /^(?:I|they) should see "([^"]*?)" in the email body$/ do |text|
   current_email.default_part_body.to_s.should include(text)
 end
 
+Then /^(?:I|they) should not see "([^"]*?)" in the email body$/ do |text|
+  current_email.default_part_body.to_s.should_not include(text)
+end
+
 Then /^(?:I|they) should see \/([^"]*?)\/ in the email body$/ do |text|
   current_email.default_part_body.to_s.should =~ Regexp.new(text)
 end

--- a/features/visitor/purchase_product.feature
+++ b/features/visitor/purchase_product.feature
@@ -62,6 +62,33 @@ Feature: Purchase a Product
     And I should see "test.txt"
     And I should see "test desc"
     And I should see the link to the video page
+    When "mr.the.plague@example.com" opens the email
+    Then they should see "You can also create a user account" in the email body
+    When I follow "Watch or download video"
+    Then I should see a video
+    And I should see the download links for video with id "1194803"
+    And I should see a list of other products
+
+  @selenium
+  Scenario: A user purchases a product with paypal
+    Given I have signed up with "user@example.com"
+    And I sign in with "user@example.com"
+    When I go to the home page
+    And I follow "Test Fetch"
+    And I follow "Purchase for Yourself"
+    Then I should see "$15"
+    When I go to the home page
+    And I follow "Test Fetch"
+    And I follow "Your Company"
+    Then I should see "$50"
+    When I pay using Paypal
+    And I submit the Paypal form
+    Then I should see that product "Test Fetch" is successfully purchased
+    And I should see "test.txt"
+    And I should see "test desc"
+    And I should see the link to the video page
+    When "mr.the.plague@example.com" opens the email
+    Then they should not see "You can also create a user account" in the email body
     When I follow "Watch or download video"
     Then I should see a video
     And I should see the download links for video with id "1194803"


### PR DESCRIPTION
- Visitors are notified in receipt that they can sign in / sign up to view purchases
- Signed in users will not be notified in their receipt
