### PR TITLE
Improve registration notification email messaging

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -2,7 +2,11 @@ class Mailer < ActionMailer::Base
   default from: Clearance.configuration.mailer_sender
 
   def registration_notification(registration)
-    @registration = registration
+    @comments = registration.comments
+    @student_name = registration.name
+    @course_name = registration.section.course_name
+    @city = registration.section.city
+    @running_date_range = registration.section.date_range
 
     mail(
       to: 'learn@thoughtbot.com',

--- a/app/views/mailer/registration_notification.text.erb
+++ b/app/views/mailer/registration_notification.text.erb
@@ -1,6 +1,6 @@
-<%= @registration.name %> just registered for <%= @registration.section.course.name %>.
+<%= @student_name %> just registered for <%= @course_name %> in <%= @city %>, running <%= @running_date_range %>.
 
-<% if @registration.comments.present? -%>
+<% if @comments.present? -%>
 Comments:
-<%= @registration.comments %>
+<%= @comments %>
 <% end -%>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -150,21 +150,23 @@ FactoryGirl.define do
     teacher
   end
 
-  factory :section do
-    address '41 Winter St'
+  factory :section_without_teacher, class: Section do
     association :course
-    ends_on { 1.day.from_now }
-    start_at '9:00'
-    starts_on { 1.day.ago }
-    stop_at '17:00'
+    starts_on { 1.day.ago.to_date }
+    ends_on   { 1.day.from_now.to_date }
+    start_at    '9:00'
+    stop_at     '17:00'
+    address     '41 Winter St'
 
-    after(:build) do |s|
-      s.teachers << build(:teacher)
-    end
+    factory :section do
+      after(:build) do |s|
+        s.teachers << build(:teacher)
+      end
 
-    factory :future_section do
-      ends_on { 4.days.from_now }
-      starts_on { 2.days.from_now }
+      factory :future_section do
+        starts_on { 2.days.from_now.to_date }
+        ends_on   { 4.days.from_now.to_date }
+      end
     end
   end
 

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Mailer, 'registration_notification' do
+  around do |example|
+    Timecop.freeze Date.parse('2012-09-12') do
+      example.run
+    end
+  end
+
+  it 'includes starts_on and ends_on in the email body' do
+    registration = build_registration
+
+    email = Mailer.registration_notification(registration)
+    email.body.should include registration.section.date_range
+  end
+
+  it 'includes section city in the email body' do
+    registration = build_registration_in 'San Antonio'
+
+    email = Mailer.registration_notification(registration)
+    email.body.should include 'San Antonio'
+  end
+
+  def build_registration
+    build_stubbed(:registration)
+  end
+
+  def build_registration_in(city)
+    build_registration.tap do |registration|
+      registration.section.city = city
+    end
+  end
+end


### PR DESCRIPTION
If multiple workshops are running simultaneously, it's pretty difficult to
figure out what workshop (and where) the student signed up for, e.g. two
Test-Driven Rails workshops are running back-to-back, one in SF and the other
in Boston. This improves email messaging to include the city the workshop is
running in, as well as the dates.
