### PR TITLE
Sort sections by starts_on in admin area

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -28,11 +28,19 @@ class Section < ActiveRecord::Base
   after_create :send_teacher_notifications
 
   def self.active
-    where('sections.ends_on >= ?', Date.today).by_starts_on
+    where("sections.ends_on >= ?", Date.today).by_starts_on
   end
 
   def self.by_starts_on
-    order 'starts_on ASC'
+    order("starts_on asc")
+  end
+
+  def self.by_starts_on_desc
+    order('starts_on desc')
+  end
+
+  def self.in_public_course
+    joins(:course).where(courses: {public: true})
   end
 
   def date_range
@@ -49,10 +57,6 @@ class Section < ActiveRecord::Base
 
   def full?
     registrations.count >= seats_available
-  end
-
-  def self.in_public_course
-    joins(:course).where courses: { public: true }
   end
 
   def location

--- a/app/views/admin/courses/_course.html.erb
+++ b/app/views/admin/courses/_course.html.erb
@@ -4,6 +4,6 @@
     <%= link_to 'New Section', new_admin_course_section_path(course), class: 'new-section', id: "new-section-#{course.id}" %>
   </h3>
   <ul>
-    <%= render course.sections %>
+    <%= render course.sections.by_starts_on_desc %>
   </ul>
 <% end %>

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -125,3 +125,12 @@ describe Section do
     end
   end
 end
+
+describe Section, 'self.by_starts_on_desc' do
+  it 'returns sections newest to oldest by starts_on' do
+    old_section = create(:section, starts_on: 2.weeks.from_now)
+    new_section = create(:section, starts_on: 4.weeks.from_now)
+
+    Section.by_starts_on_desc.should == [new_section, old_section]
+  end
+end

--- a/spec/views/admin/courses/_course.html.erb_spec.rb
+++ b/spec/views/admin/courses/_course.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'admin/courses/_course.html.erb' do
+  it 'renders sections by starts_on' do
+    course = build_stubbed(:course)
+    sections = stub('sections', by_starts_on_desc: [])
+    course.stubs(sections: sections)
+
+    render 'admin/courses/course', course: course
+
+    sections.should have_received(:by_starts_on_desc).once
+  end
+end


### PR DESCRIPTION
This ensures that sections listed out are ordered by starts_on instead of
having a potentially random sort order.
