### PR TITLE
Remove "more..." links from teacher bios

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,19 +49,3 @@ function add_fields(link, association, content) {
   var regexp = new RegExp("new_" + association, "g")
   $(link).parent().before(content.replace(regexp, new_id));
 }
-
-$(function() {
-  $('.expand-bio a').live('click', function() {
-    $(this).parent().parent().children('.bio').height('auto');
-    $(this).text('...less');
-    $(this).parent().addClass('minimize-bio').removeClass('expand-bio');
-    return false;
-  });
-
-  $('.minimize-bio a').live('click', function() {
-    $(this).parent().parent().children('.bio').removeAttr('style');
-    $(this).text('more...');
-    $(this).parent().addClass('expand-bio').removeClass('minimize-bio');
-    return false;
-  });
-});

--- a/app/views/sections/_teachers.html.erb
+++ b/app/views/sections/_teachers.html.erb
@@ -6,7 +6,6 @@
       <section class="bio">
         <%= raw textilize teacher.bio %>
       </section>
-      <p class="expand-bio"><a href="#">more...</a></p>
     <% end %>
   <% end %>
 </ul>


### PR DESCRIPTION
The bios aren't terribly long and the links seem to have broken in the
redesign, so we're removing them.
