### PR TITLE
Convert github_url to use master instead of json branch

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -64,7 +64,7 @@ class Topic < ActiveRecord::Base
   end
 
   def github_url
-    "https://raw.github.com/thoughtbot/trail-map/json/trails/#{slug.parameterize}.json"
+    "https://raw.github.com/thoughtbot/trail-map/master/trails/#{slug.parameterize}.json"
   end
 
   def parse_and_assign_trail_map(raw_trail_map)


### PR DESCRIPTION
- This was done on production, but I seem to have forgotten to get it
  into master as it was a fire-drill change.
