### PR TITLE
Hide special requests box for online workshop signups

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -7,6 +7,7 @@ class Mailer < ActionMailer::Base
     @workshop_name = purchase.purchaseable_name
     @city = purchase.purchaseable.city
     @running_date_range = purchase.purchaseable.date_range
+    @fulfillment_method = purchase.purchaseable.fulfillment_method
 
     mail(
       to: 'learn@thoughtbot.com',

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -60,7 +60,11 @@ class Section < ActiveRecord::Base
   end
 
   def fulfillment_method
-    'in-person'
+    if workshop.in_person?
+      'in-person'
+    else
+      'online'
+    end
   end
 
   def product_type

--- a/app/views/mailer/registration_confirmation.text.erb
+++ b/app/views/mailer/registration_confirmation.text.erb
@@ -1,10 +1,12 @@
 <%= @purchase.name %> is now registered for <%= @purchase.purchaseable_name %>.
 
+<% if @section.fulfillment_method == 'in-person' -%>
 <% if @purchase.comments.present? -%>
 You provided us with the following comments:
 <%= @purchase.comments %>
 <% end %>
 If you have any special dietary restrictions, and you have not done so already, please let us know by replying to this email.
+<% end %>
 
 <% if @section && @section.reminder_email.present? -%>
 <%= @section.reminder_email %>

--- a/app/views/mailer/registration_notification.text.erb
+++ b/app/views/mailer/registration_notification.text.erb
@@ -1,6 +1,8 @@
 <%= @student_name %> just registered for <%= @workshop_name %> in <%= @city %>, running <%= @running_date_range %>.
 
+<% if @fulfillment_method == 'in-person' -%>
 <% if @comments.present? -%>
 Comments:
 <%= @comments %>
+<% end -%>
 <% end -%>

--- a/app/views/mailer/section_reminder.text.erb
+++ b/app/views/mailer/section_reminder.text.erb
@@ -1,10 +1,12 @@
 Hey - just a friendly reminder that <%= @purchase.name %> is registered for <%= @section.name %> on <%= @section.date_range %>.
 
+<% if @section.fulfillment_method == 'in-person' -%>
 <% if @purchase.comments.present? -%>
 You provided us with the following comments:
 <%= @purchase.comments %>
 <% end %>
 If you have any special dietary restrictions, and you have not done so already, please let us know by replying to this email.
+<% end %>
 
 <% if @section.reminder_email.present? -%>
   <%= @section.reminder_email %>

--- a/features/visitor/select_and_register_for_workshop.feature
+++ b/features/visitor/select_and_register_for_workshop.feature
@@ -173,3 +173,31 @@ Feature: Selecting a workshop and registering for it
     When I fill in the required workshop registration fields for "carlos@santana.com"
     And I press "Submit Payment"
     Then carlos@santana.com is registered for the Test-Driven Haskell workshop
+
+  Scenario: Visitor registers for an online workshop for an individual
+    Given today is January 11, 2013
+    And the following workshop exists:
+      | name            | online |
+      | Online Workshop | true   |
+    And the following section exists:
+      | workshop              | starts_on    |
+      | name: Online Workshop | 2013-01-12   |
+    When I go to the home page
+    And I view all products
+    And I follow "Online Workshop"
+    And I follow "Purchase for Yourself"
+    Then I should not see "Do you have any dietary restrictions or special requests?"
+
+  Scenario: Visitor registers for an online workshop for a company
+    Given today is January 11, 2013
+    And the following workshop exists:
+      | name            | online |
+      | Online Workshop | true   |
+    And the following section exists:
+      | workshop              | starts_on    |
+      | name: Online Workshop | 2013-01-12   |
+    When I go to the home page
+    And I view all products
+    And I follow "Online Workshop"
+    And I follow "Purchase for Your Company"
+    Then I should not see "Do you have any dietary restrictions or special requests?"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -69,6 +69,14 @@ FactoryGirl.define do
     factory :private_workshop do
       public false
     end
+
+    factory :in_person_workshop do
+      online false
+    end
+
+    factory :online_workshop do
+      online true
+    end
   end
 
   factory :download
@@ -127,6 +135,14 @@ FactoryGirl.define do
 
     factory :section_purchase do
       association :purchaseable, factory: :section
+
+      factory :in_person_section_purchase do
+        association :purchaseable, factory: :in_person_section
+      end
+
+      factory :online_section_purchase do
+        association :purchaseable, factory: :online_section
+      end
     end
 
     factory :book_purchase do
@@ -155,6 +171,14 @@ FactoryGirl.define do
       factory :future_section do
         starts_on { 2.days.from_now.to_date }
         ends_on   { 4.days.from_now.to_date }
+      end
+
+      factory :in_person_section do
+        association :workshop, factory: :in_person_workshop
+      end
+
+      factory :online_section do
+        association :workshop, factory: :online_workshop
       end
     end
   end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -179,6 +179,24 @@ describe Mailer do
         expect(email).to have_body_text(/#{announcement.message}/)
       end
     end
+
+    context 'for an online workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:online_section_purchase, comments: 'comments and requests')
+        email = Mailer.registration_confirmation(purchase)
+
+        expect(email).not_to have_body_text(/following comments|dietary restrictions/)
+      end
+    end
+
+    context 'for an in-person workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:in_person_section_purchase, comments: 'comments and requests')
+        email = Mailer.registration_confirmation(purchase)
+
+        expect(email).to have_body_text(/following comments|dietary restrictions/)
+      end
+    end
   end
 
   describe '.registration_notification' do
@@ -200,6 +218,24 @@ describe Mailer do
       end
     end
 
+    context 'for an online workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:online_section_purchase, comments: 'comments and requests')
+        email = Mailer.registration_notification(purchase)
+
+        expect(email).not_to have_body_text(/Comments:/)
+      end
+    end
+
+    context 'for an in-person workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:in_person_section_purchase, comments: 'comments and requests')
+        email = Mailer.registration_notification(purchase)
+
+        expect(email).to have_body_text(/Comments:/)
+      end
+    end
+
     def build_purchase_in(city)
       build_stubbed(:section_purchase).tap do |purchase|
         purchase.purchaseable.city = city
@@ -218,6 +254,26 @@ describe Mailer do
 
     it "has the registrant's name in the body" do
       expect(sent_email.body).to include('Benny Burns')
+    end
+
+    context 'for an online workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:online_section_purchase, comments: 'comments and requests')
+        section = purchase.purchaseable
+        email = Mailer.section_reminder(purchase.id, section.id)
+
+        expect(email).not_to have_body_text(/following comments|dietary restrictions/)
+      end
+    end
+
+    context 'for an in-person workshop' do
+      it 'does not contain a section about comments or dietary restrictions' do
+        purchase = create(:in_person_section_purchase, comments: 'comments and requests')
+        section = purchase.purchaseable
+        email = Mailer.section_reminder(purchase.id, section.id)
+
+        expect(email).to have_body_text(/following comments|dietary restrictions/)
+      end
     end
 
     def workshop_name

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -146,6 +146,22 @@ describe Section do
       inactive_section.should_not be_active
     end
   end
+
+  describe '#fulfillment_method' do
+    it 'returns in-person if the workshop is an in-person one' do
+      in_person_workshop = create(:workshop, online: false)
+      section = create(:section, workshop: in_person_workshop)
+
+      expect(section.fulfillment_method).to eq('in-person')
+    end
+
+    it 'returns online if the workshop is an online one' do
+      online_workshop = create(:workshop, online: true)
+      section = create(:section, workshop: online_workshop)
+
+      expect(section.fulfillment_method).to eq('online')
+    end
+  end
 end
 
 describe Section, 'self.by_starts_on_desc' do


### PR DESCRIPTION
The changes made removes the text box that shows up on the registration page (asking for comments and special requests), as well as prevents any of it from showing up in confirmation, notification, and reminder emails if the person signed up for an online workshop.
