### PR TITLE
Fix rake setup

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,6 +1,6 @@
 namespace :dev do
   desc 'Creates sample data for local development'
-  task prime: ['db:reset'] do
+  task prime: ['db:setup'] do
     unless Rails.env.development?
       raise 'This task can only be run in the development environment'
     end

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -8,8 +8,6 @@ task :setup do
   `git remote add production git@heroku.com:learn-production.git`
 
   puts "Preparing database"
-  Rake::Task["db:create:all"].invoke
-  Rake::Task["db:schema:load"].invoke
-  Rake::Task["db:test:prepare"].invoke
+  Rake::Task["db:setup"].invoke
   Rake::Task["dev:prime"].invoke
 end


### PR DESCRIPTION
- setup depends on dev:prime
- setup creates database, dev:prime drops and recreates
- Both setup and dev:prime depend on db:schema:load
- Was breaking because db:schema:load refused to run twice
- Result was an empty database
- This fix relies on db:setup instead
