### PR TITLE
Create a KissmetricsClientFactory

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,6 @@
 class ApplicationController < ActionController::Base
   include Clearance::Authentication
 
-  cattr_accessor :km_http_client
-
   helper :all
 
   protect_from_forgery
@@ -14,10 +12,6 @@ class ApplicationController < ActionController::Base
       flash[:error] = 'You do not have permission to view that page.'
       redirect_to root_url
     end
-  end
-
-  def km_http_client
-    @@km_http_client.new(KISSMETRICS_API_KEY)
   end
 
   def current_user_has_active_subscription?

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -69,7 +69,7 @@ class PurchasesController < ApplicationController
   end
 
   def notify_kissmetrics_of(purchase)
-    event_notifier = KissmetricsEventNotifier.new(km_http_client)
+    event_notifier = KissmetricsEventNotifier.new
     event_notifier.notify_of(purchase)
   end
 

--- a/app/models/kissmetrics_client_factory.rb
+++ b/app/models/kissmetrics_client_factory.rb
@@ -1,0 +1,9 @@
+class KissmetricsClientFactory
+  def self.client
+    if Rails.env.test?
+      FakeKissmetrics::HttpClient.new('fake-api-key')
+    else
+      Kissmetrics::HttpClient.new(KISSMETRICS_API_KEY)
+    end
+  end
+end

--- a/app/models/kissmetrics_event_notifier.rb
+++ b/app/models/kissmetrics_event_notifier.rb
@@ -1,5 +1,5 @@
 class KissmetricsEventNotifier
-  def initialize(kissmetrics_client)
+  def initialize(kissmetrics_client=KissmetricsClientFactory.client)
     @client = kissmetrics_client
   end
 

--- a/config/initializers/kissmetrics_http_client.rb
+++ b/config/initializers/kissmetrics_http_client.rb
@@ -1,8 +1,0 @@
-#if Rails.env.test?
-#  puts "KISSMETRICS_CLIENT_CLASS"
-#  KISSMETRICS_CLIENT_CLASS = FakeKissmetrics::HttpClient
-#else
-#  KISSMETRICS_CLIENT_CLASS = Kissmetrics::HttpClient
-#end
-
-ApplicationController.km_http_client = Kissmetrics::HttpClient

--- a/spec/models/kissmetrics_client_factory_spec.rb
+++ b/spec/models/kissmetrics_client_factory_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe '.client' do
+  it 'returns the fake client when running in the test environment' do
+    fake_kissmetrics_client = FakeKissmetrics::HttpClient
+    expect(KissmetricsClientFactory.client).to be_a fake_kissmetrics_client
+  end
+
+  it 'returns the real client when not in the test environment' do
+    change_to_non_test_environment do
+      real_kissmetrics_client = Kissmetrics::HttpClient
+      expect(KissmetricsClientFactory.client).to be_a real_kissmetrics_client
+    end
+  end
+
+  def change_to_non_test_environment
+    Rails.env = 'not-test'
+    yield
+  ensure
+    Rails.env = 'test'
+  end
+end

--- a/spec/support/fake_kissmetrics.rb
+++ b/spec/support/fake_kissmetrics.rb
@@ -69,5 +69,3 @@ class FakeKissmetrics
     end
   end
 end
-
-ApplicationController.km_http_client = FakeKissmetrics::HttpClient


### PR DESCRIPTION
- Moves the choice about whether to use the normal Kissmetrics client or a
  fake into a single place (rather than spread across two initializers).
- Removes a cattr_accessor from ApplicationController.
