### PR TITLE
Configure TDDium to run the correct version of Ruby

### DIFF
--- a/config/tddium.yml
+++ b/config/tddium.yml
@@ -1,0 +1,3 @@
+---
+:tddium:
+  :ruby_version: ruby-1.9.3-p327


### PR DESCRIPTION
- TDDium ignores .ruby-version
- Tests fail on 1.9.2 (the default)

All tests passing:

https://api.tddium.com/1/reports/231810#/suites/16032/sessions/231810
