### PR TITLE
Fix intermittent build failure

### DIFF
--- a/spec/requests/subscriber_accesses_content_spec.rb
+++ b/spec/requests/subscriber_accesses_content_spec.rb
@@ -19,7 +19,7 @@ feature 'Subscriber accesses content' do
     click_link video_product.name
 
     expect(page).to have_content I18n.t('products.show.free_to_subscribers')
-    expect(page).to_not have_content video_product.individual_price
+    expect(page).to_not have_content "$#{video_product.individual_price}"
     expect(page).to_not have_content I18n.t('products.show.purchase_for_company')
   end
 


### PR DESCRIPTION
- Test asserted that "15" wasn't present on the page
- The name sequence sometimes generates "name 15" for the product name
- Assert the "$15" isn't on the page instead
