### PR TITLE
Small changes to FakeOauthCLientApp

### DIFF
--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Api::V1::UsersController, '#show' do
   it 'returns a 401 when users are not authenticated' do
     get :show
-    response.code.should == '401'
+    response.code.should eq '401'
   end
 end

--- a/spec/support/fake_oauth_client_app.rb
+++ b/spec/support/fake_oauth_client_app.rb
@@ -5,7 +5,7 @@ class FakeOauthClientApp < Sinatra::Base
   include Rails.application.routes.url_helpers
 
   disable :dump_errors
-  enable :logging
+  disable :logging
 
   REDIRECT_PATH = '/fake_oauth_client_app/authorize'
 
@@ -38,8 +38,6 @@ class FakeOauthClientApp < Sinatra::Base
   end
 end
 
-FakeOauthClientRunner = Capybara::Discoball::Runner.new(FakeOauthClientApp) do |client|
+Capybara::Discoball.spin(FakeOauthClientApp) do |client|
   FakeOauthClientApp.client_url = client.url('')
 end
-
-FakeOauthClientRunner.boot


### PR DESCRIPTION
1. Silence logging noise during test runs
2. Use #spin convenience method to define and boot capybara_discoball
   server with one call.
3. (Unrelated style fix, prefer eq over ==).
