### PR TITLE
Add Google Webmaster Tools verification file

### DIFF
--- a/public/googlec0fa13aa63397a7d.html
+++ b/public/googlec0fa13aa63397a7d.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec0fa13aa63397a7d.html


### PR DESCRIPTION
This file is used as verification of our ownership of learn.thoughtbot.com.
I've tried the TXT and CNAME methods of verification from DNSimple but those
DNS records are not being recognized.

The purpose of setting up Google Webmaster Tools is to improve our Search
Engine Optimization data such as:
- External and internal links to the site.
- Search keywords and their impressions, clicks, CTR, and average
  position.
- Author stats.

https://www.apptrajectory.com/thoughtbot/learn/stories/15627125
