### PR TITLE
Send has_forum_access flag to determine Discourse access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '1.9.3'
 
 gem 'RedCloth', '4.2.9', require: 'redcloth'
+gem 'active_model_serializers', '~> 0.7.0'
 gem 'acts_as_list', '0.1.6'
 gem 'airbrake', '3.0.9'
 gem 'aws-s3', '0.6.2', :require => 'aws/s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
+    active_model_serializers (0.7.0)
+      activemodel (>= 3.0)
     activemodel (3.2.12)
       activesupport (= 3.2.12)
       builder (~> 3.0.0)
@@ -377,6 +379,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (= 4.2.9)
+  active_model_serializers (~> 0.7.0)
   acts_as_list (= 0.1.6)
   airbrake (= 3.0.9)
   aws-s3 (= 0.6.2)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,9 +4,7 @@ class Api::V1::UsersController < ApplicationController
   respond_to :json
 
   def show
-    respond_with current_resource_owner.to_json(
-      only: [:id, :first_name, :last_name, :email],
-      methods: :has_active_subscription?)
+    respond_with current_resource_owner
   end
 
   private

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,7 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :email, :first_name, :has_forum_access, :id, :last_name
+
+  def has_forum_access
+    object.has_active_subscription?
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Workshops
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
-    config.autoload_paths += ["#{config.root}/lib"]
+    config.autoload_paths += ["#{config.root}/lib", "#{config.root}/app/serializers"]
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/spec/requests/oauth_client_authenticates_spec.rb
+++ b/spec/requests/oauth_client_authenticates_spec.rb
@@ -42,6 +42,6 @@ feature 'An OAuth client authenticates', js: true do
     json = JSON.parse(page.find('#data').text)['user']
 
     json['email'].should eq User.last.email
-    json['has_active_subscription?'].should be_true
+    json['has_forum_access'].should be_true
   end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe UserSerializer do
+  it 'serializes simple attributes' do
+    user = build_stubbed(:user)
+
+    user_json = parse_serialized_json(user)
+
+    user_json['id'].should == user.id
+    user_json['first_name'].should == user.first_name
+    user_json['last_name'].should == user.last_name
+    user_json['email'].should == user.email
+  end
+
+  context 'when the user has an active subscription' do
+    it 'includes a key granting forum access' do
+      user = create(:user, :with_subscription)
+
+      user_json = parse_serialized_json(user)
+
+      user_json['has_forum_access'].should be_true
+    end
+  end
+
+  context 'when the user does not have an active subscription' do
+    it 'includes a key denying forum access' do
+      user = build_stubbed(:user)
+
+      user_json = parse_serialized_json(user)
+
+      user_json['has_forum_access'].should be_false
+    end
+  end
+
+  def parse_serialized_json(user)
+    JSON.parse(UserSerializer.new(user).to_json)['user']
+  end
+end


### PR DESCRIPTION
- Add activemodel_serializers. This feels like the right course, since we're likely to be sending additional/more complex attributes when we start using the OAuth endpoint in the iPad app.
