### PR TITLE
apply learn styles to oauth pages

### DIFF
--- a/app/assets/stylesheets/_doorkeeper.scss
+++ b/app/assets/stylesheets/_doorkeeper.scss
@@ -1,0 +1,29 @@
+.doorkeeper-auth {
+  padding: 1.75em 1.55em 3em;
+
+  .inline_block {
+    float: left;
+    margin-right: .5em;
+  }
+
+  table {
+    margin-top: 2em;
+    width: 100%;
+
+    th {
+      font-weight: bold;
+    }
+
+    td, th {
+      padding: .75em;
+      border-bottom: 1px solid  #ccc;
+    }
+  }
+
+  form {
+    input[type=submit], input[type=submit] + div {
+      display: inline-block;
+      margin-top: .5em;
+    }
+  }
+}

--- a/app/assets/stylesheets/_forms.css.scss
+++ b/app/assets/stylesheets/_forms.css.scss
@@ -108,6 +108,10 @@ form {
     }
 
     ol {
+      &.actions {
+        margin-top: 2em;
+      }
+
       li {
         font-size: 16px;
         margin: 0 0 0 0;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,3 +21,5 @@
 @import "users";
 @import "products";
 @import "design-for-developers";
+
+@import "doorkeeper";

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -1,0 +1,35 @@
+<section class="doorkeeper-auth">
+  <%= form_for([:oauth, application]) do |f| %>
+    <fieldset>
+      <% if application.errors.any? %>
+        <div class="alert-message error" data-alert><a class="close" href="#">×</a><p>Whoops! Check your form for possible errors</p></div>
+      <% end %>
+
+      <ol>
+        <li>
+          <%= f.label :name %>
+          <%= f.text_field :name %>
+          <%= errors_for application, :name %>
+        </li>
+      </ol>
+
+      <ol>
+        <li>
+          <%= f.label :redirect_uri %>
+          <%= f.text_field :redirect_uri %>
+          <%= errors_for application, :redirect_uri %>
+          <% if Doorkeeper.configuration.test_redirect_uri %>
+            <span class="help-inline">Use <%= Doorkeeper.configuration.test_redirect_uri %> for local tests</span>
+          <% end %>
+        </li>
+      </ol>
+
+      <ol class="actions">
+        <li>
+          <%= f.submit :Submit %>
+          <%= button_to 'Cancel', oauth_applications_path, :class => 'button cancel', :method => :get %>
+        </li>
+      </ol>
+    </fieldset>
+  <% end %>
+</section>

--- a/app/views/doorkeeper/applications/edit.html.erb
+++ b/app/views/doorkeeper/applications/edit.html.erb
@@ -1,0 +1,10 @@
+<section class="doorkeeper-auth">
+  <header class="page-header"><h2>Edit application</h2></header>
+  <div>
+    <%= render 'form', :application => @application %>
+  </div>
+  <div>
+    <h3>Actions</h3>
+    <p><%= link_to 'Back to application list', oauth_applications_path %></p>
+  </div>
+</section>

--- a/app/views/doorkeeper/applications/index.html.erb
+++ b/app/views/doorkeeper/applications/index.html.erb
@@ -1,0 +1,26 @@
+<section class="doorkeeper-auth">
+  <header class="page-header"><h2>Your applications</h2></header>
+
+  <p><%= link_to 'New Application', new_oauth_application_path %></p>
+
+  <table class="zebra-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Callback url</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @applications.each do |application| %>
+        <tr id="application_<%= application.id %>">
+          <td><%= link_to application.name, [:oauth, application] %></td>
+          <td><%= application.redirect_uri %></td>
+          <td><%= link_to 'Edit', edit_oauth_application_path(application) %></td>
+          <td><%= link_to 'Destroy', [:oauth, application], :data => { :confirm => 'Are you sure?' }, :method => :delete %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/doorkeeper/applications/new.html.erb
+++ b/app/views/doorkeeper/applications/new.html.erb
@@ -1,0 +1,12 @@
+<section class="doorkeeper-auth">
+  <header class="page-header"><h2>New application</h2></header>
+
+  <div>
+    <%= render 'form', :application => @application %>
+  </div>
+
+  <div>
+    <h3>Actions</h3>
+    <p><%= link_to 'Back to application list', oauth_applications_path %></p>
+  </div>
+</section>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -1,0 +1,24 @@
+<section class="doorkeeper-auth">
+  <header class="page-header"><h1>Application: <%= @application.name %></h1></header>
+
+  <div>
+    <h4>Callback url:</h4>
+    <p><code id="callback_url"><%= @application.redirect_uri %></code></p>
+
+    <h4>Application Id:</h4>
+    <p><code id="application_id"><%= @application.uid %></code></p>
+
+    <h4>Secret:</h4>
+    <p><code id="secret"><%= @application.secret %></code></p>
+
+    <h4>Link to authorization code:</h4>
+    <p><%= link_to 'Authorize', oauth_authorization_path(:client_id => @application.uid, :redirect_uri => @application.redirect_uri, :response_type => 'code' ) %></p>
+  </div>
+
+  <div>
+    <h3>Actions</h3>
+    <p><%= link_to 'List all', oauth_applications_path %></p>
+    <p><%= link_to 'Edit', edit_oauth_application_path(@application) %></p>
+    <p><%= link_to 'Remove', [:oauth, @application], :method => :delete, :data => { :confirm => "Are you sure?" } %></p>
+  </div>
+</section>

--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -1,0 +1,6 @@
+<section class="doorkeeper-auth">
+  <h2>An error has occurred</h2>
+  <p>
+    <pre><%= @pre_auth.error_response.body[:error_description] %></pre>
+  </p>
+</section>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -1,0 +1,36 @@
+<section class="doorkeeper-auth">
+  <h2>Authorize <%= @pre_auth.client.name %> to use your account?</h2>
+  <section>
+    <% if @pre_auth.scopes %>
+    <p>
+      This application will be able to:
+    </p>
+    <ul>
+      <% @pre_auth.scopes.each do |scope| %>
+        <li><%= t scope, :scope => [:doorkeeper, :scopes]  %></li>
+      <% end %>
+    </ul>
+    <% end %>
+
+    <div class="inline_block">
+      <%= form_tag oauth_authorization_path, :method => :post do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
+        <%= hidden_field_tag :state, @pre_auth.state %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+        <%= hidden_field_tag :scope, @pre_auth.scope %>
+        <%= submit_tag "Authorize", :class => "btn success" %>
+      <% end %>
+    </div>
+    <div class="inline_block">
+      <%= form_tag oauth_authorization_path, :method => :delete do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
+        <%= hidden_field_tag :state, @pre_auth.state %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+        <%= hidden_field_tag :scope, @pre_auth.scope %>
+        <%= submit_tag "Deny", :class => "btn" %>
+      <% end %>
+    </div>
+  </section>
+</section>

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,0 +1,4 @@
+<section class="doorkeeper-auth">
+  <h3>Authorization code:</h3>
+  <code id="authorization_code"><%= params[:code] %></code>
+</section>

--- a/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -1,0 +1,23 @@
+<section class="doorkeeper-auth">
+  <header class="page-header"><h2>Your authorized applications</h2></header>
+
+  <table class="zebra-striped">
+    <thead>
+      <tr>
+        <th>Application</th>
+        <th>Authorized at</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @applications.each do |application| %>
+        <tr>
+          <td><%= application.name %></td>
+          <td><%= application.created_at %></td>
+          <td><%= link_to 'Revoke', oauth_authorized_application_path(application), :data => { :confirm => 'Are you sure?' }, :method => :delete, :class => 'btn danger' %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Authorize <%= page_title(app_name: 'thoughtbot Learn') %></title>
+    <%= stylesheet_link_tag 'application' %>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <%= render 'shared/typekit' %>
+    <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <script type="text/javascript" src="https://js.stripe.com/v1/"></script>
+  </head>
+  <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
+
+    <section id="header-wrapper">
+      <div class="header-container">
+        <h1 class="small-logo">
+          <%= link_to image_tag('learn/learn-ralph-small.png'), root_path %>
+          <%= t 'shared.learn' %>
+        </h1>
+      </div>
+    </section>
+
+    <%= render 'shared/flashes' %>
+
+    <section class="content">
+      <%= yield %>
+    </section>
+
+    <%= render 'shared/javascript' %>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,10 @@ module Workshops
       generate.test_framework :rspec
     end
 
+    config.to_prepare do
+      Doorkeeper::ApplicationController.layout 'doorkeeper'
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
- use copied/simplified learn layout, regular layout had methods undefined for doorkeeper
- simplify default doorkeeper html, remove extra classes / elements
- style oauth tables
- style doorkeeper form

![Screen Shot 2013-04-26 at 2 51 23 PM](https://f.cloud.github.com/assets/654275/432386/ea0990be-aea2-11e2-969c-4f78a66e5a63.png)
![Screen Shot 2013-04-26 at 2 51 18 PM](https://f.cloud.github.com/assets/654275/432387/ea163120-aea2-11e2-8af6-c5f1fa216092.png)
![Screen Shot 2013-04-26 at 2 27 41 PM](https://f.cloud.github.com/assets/654275/432388/ea1b121c-aea2-11e2-929c-10987f3b2925.png)
![Screen Shot 2013-04-26 at 2 27 20 PM](https://f.cloud.github.com/assets/654275/432389/ea1ef986-aea2-11e2-967e-ecfb9c8411c8.png)
![Screen Shot 2013-04-26 at 2 53 23 PM](https://f.cloud.github.com/assets/654275/432390/eae33f1c-aea2-11e2-9c6b-fa1468180023.png)
