### PR TITLE
Automatically grant admin access to thoughtbot employees

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  THOUGHTBOT_ORGANIZATION = 'thoughtbot'
+
   include Clearance::User
 
   attr_accessible :email, :first_name, :github_username, :last_name, :password, :auth_provider, :auth_uid
@@ -31,13 +33,26 @@ class User < ActiveRecord::Base
         last_name: name.last,
         email: auth_hash['info']['email'],
         github_username: auth_hash['info']['nickname']
-      )
+      ).tap { |user| user.promote_admins_from_github_organization }
     rescue NoMethodError => e
       Airbrake.notify(
         :error_class   => "Auth hash error",
         :error_message => e.message,
         :parameters    => auth_hash
       )
+    end
+  end
+
+  def promote_admins_from_github_organization
+    organizations = Octokit.organizations(github_username)
+
+    organization_names = organizations.map do |organization|
+      organization['login']
+    end
+
+    if organization_names.include?(THOUGHTBOT_ORGANIZATION)
+      self.admin = true
+      save!
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,7 +88,16 @@ describe User do
       }
     end
 
+    def stub_organizations(names)
+      organizations = names.map do |name|
+        { 'login' => name }
+      end
+
+      Octokit.stubs(:organizations).with('thoughtbot').returns(organizations)
+    end
+
     it "creates a new user when no matching user" do
+      stub_organizations %w('alpha beta')
       user = User.find_or_create_from_auth_hash(auth_hash)
       user.should be_persisted
       user.first_name.should == 'Test'
@@ -97,6 +106,13 @@ describe User do
       user.github_username.should == 'thoughtbot'
       user.auth_provider.should == 'github'
       user.auth_uid.should == 1
+      user.should_not be_admin
+    end
+
+    it "creates a new admin when no matching user from our organization" do
+      stub_organizations %w(alpha beta thoughtbot)
+      user = User.find_or_create_from_auth_hash(auth_hash)
+      user.should be_admin
     end
 
     context "with an existing user" do


### PR DESCRIPTION
- Checks public organizations when signing in using GitHub
- thoughtbot organization members are granted admin access
