### PR TITLE
Associate Coupons with Purchases

### DIFF
--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -1,6 +1,8 @@
 class Coupon < ActiveRecord::Base
   DISCOUNT_TYPES = ["percentage", "dollars"]
 
+  has_many :purchases
+
   validates :code, presence: true
   validates :amount, presence: true
   validates :discount_type, inclusion: { in: DISCOUNT_TYPES }, presence: true

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Coupon do
+  it { should have_many(:purchases) }
+
   context "with a discount type of percentage" do
     subject { create(:coupon, amount: 10, discount_type: "percentage") }
     it "applies the coupon as a percentage" do


### PR DESCRIPTION
Purchases already belong_to :coupons. This sets up the reverse.
