### PR TITLE
Only mention support for workshops and prime members

### DIFF
--- a/app/views/books/_aside.html.erb
+++ b/app/views/books/_aside.html.erb
@@ -14,5 +14,5 @@
     </section>
   <% end %>
 
-  <%= render 'shared/sidebar_chat', purchaseable: purchaseable %>
+  <%= render 'shared/sidebar_forum', purchaseable: purchaseable %>
 </aside>

--- a/app/views/mailer/purchase_receipt.text.erb
+++ b/app/views/mailer/purchase_receipt.text.erb
@@ -13,8 +13,10 @@ You will also receive a notification from GitHub. Please contact us at
 learn@thoughtbot.com if you do not get access to this repository.
 <% end -%>
 
-Every <%= @purchase.purchaseable.product_type %> includes ongoing support for any questions you may have about the
-topic. Visit our live chat here: <%= CHAT_LINK %>
+<% if @purchase.subscription? -%>
+<%= @purchase.purchaseable_name %> includes support for any questions you may have
+Visit our forums here: <%= forum_url %>
+<% end -%>
 
 <% if @purchase.purchaseable.announcement.present? %>
 <%= @purchase.purchaseable.announcement.message %>

--- a/app/views/mailer/registration_confirmation.text.erb
+++ b/app/views/mailer/registration_confirmation.text.erb
@@ -22,9 +22,6 @@ Where
 
 We will be in touch before <%= @section.starts_on.to_s(:simple) %> with a reminder and any further instructions. However, please don't hesitate to get in touch with us at learn@thoughtbot.com should you have any questions or concerns.
 
-Every product and workshop includes ongoing support for any questions you may
-have about the topic, both before and after the workshop. Visit our live chat here: <%= CHAT_LINK %>
-
 <% if @section.workshop.announcement.present? %>
 <%= @section.workshop.announcement.message %>
 <% end %>

--- a/app/views/products/_terms.html.erb
+++ b/app/views/products/_terms.html.erb
@@ -1,6 +1,8 @@
 <section id="terms">
   <ul>
-    <dd><p>Every <%= product.product_type %> includes support for any questions you may have about the topic, direct from the thoughtbot team.</p></dd>
+    <% if product.subscription? %>
+      <dd><p>Your subscription includes support for any technical questions you have, direct from the thoughtbot team and the rest of the <%= subscription_product.name %> community in our forum and chat room.</p></dd>
+    <% end %>
     <% if !product.external? %>
       <dt><p>What if I'm not happy?</p></dt>
       <dd><p>If you&rsquo;re not happy, just let us know within 30 days and we&rsquo;ll refund your money. It&rsquo;s as simple as that.</p></dd>

--- a/app/views/shared/_sidebar_chat.html.erb
+++ b/app/views/shared/_sidebar_chat.html.erb
@@ -1,6 +1,6 @@
 <div class="text-chat">
   <h3>Text Chat</h3>
   <hr>
-  <p>Every <%= purchaseable.product_type %> includes support for any questions you may have about the topic. Visit our Campfire chat at any time.</p>
+  <p>Every <%= purchaseable.product_type %> includes support for any questions you may have about the topic. Visit our Campfire chat.</p>
   <%= link_to "Join Chat", CHAT_LINK, class: 'button' %>
 </div>

--- a/app/views/shared/_sidebar_forum.html.erb
+++ b/app/views/shared/_sidebar_forum.html.erb
@@ -1,0 +1,8 @@
+<% if current_user_has_active_subscription? %>
+  <div class="forum">
+    <h3>Forum</h3>
+    <hr>
+    <p>Your subscription includes support for any questions you may have about the topic.</p>
+    <%= link_to "Visit Forums", forum_url, class: 'button' %>
+  </div>
+<% end %>

--- a/app/views/subscriptions/_aside.html.erb
+++ b/app/views/subscriptions/_aside.html.erb
@@ -1,3 +1,3 @@
 <aside>
-  <%= render 'shared/sidebar_chat', purchaseable: purchaseable %>
+  <%= render 'shared/sidebar_forum', purchaseable: purchaseable %>
 </aside>

--- a/app/views/videos/_aside.html.erb
+++ b/app/views/videos/_aside.html.erb
@@ -1,4 +1,4 @@
 <aside>
   <%= render 'purchases/downloads_info', purchaseable: purchaseable %>
-  <%= render 'shared/sidebar_chat', purchaseable: purchaseable %>
+  <%= render 'shared/sidebar_forum', purchaseable: purchaseable %>
 </aside>

--- a/app/views/videos/_footer.html.erb
+++ b/app/views/videos/_footer.html.erb
@@ -1,2 +1,0 @@
-<div id="flash"></div>
-<p><em>Every product includes support for any questions you may have about the topic. Visit our <%= link_to "live chat", CHAT_LINK %>.</em></p>

--- a/app/views/workshops/_aside.html.erb
+++ b/app/views/workshops/_aside.html.erb
@@ -9,6 +9,7 @@
     </div>
   <% end %>
 
+  <%= render 'shared/sidebar_forum', purchaseable: purchaseable %>
   <%= render 'shared/sidebar_chat', purchaseable: purchaseable %>
 
   <% if purchaseable.events.any? %>

--- a/features/products/view_product.feature
+++ b/features/products/view_product.feature
@@ -1,4 +1,4 @@
-Feature: Products include support
+Feature: Products do not include support
 
   Scenario: Viewing products of different types
     Given the following products exist:
@@ -6,18 +6,21 @@ Feature: Products include support
       | Book     | book         | An awesome book   |
       | Video    | video        | An amazing video  |
       | Workshop | workshop     |                   |
+      | Prime    | subscription |                   |
     When I view the product "Book"
-    Then I should see "Every book includes support"
+    Then I should not see "includes support"
     Then the meta description should be "An awesome book"
     Then the page title should be "Book: a book by thoughtbot"
     When I view the product "Video"
-    Then I should see "Every video includes support"
+    Then I should not see "includes support"
     Then the meta description should be "An amazing video"
     Then the page title should be "Video: a video by thoughtbot"
     When I view the product "Workshop"
-    Then I should see "Every workshop includes support"
+    Then I should not see "includes support"
     Then the page should use the default meta description
     Then the page title should be "Workshop: a workshop by thoughtbot"
+    When I view the product "Prime"
+    Then I should see "includes support"
 
   Scenario: Viewing an inactive product
     Given the following product exists:

--- a/features/step_definitions/workshop_steps.rb
+++ b/features/step_definitions/workshop_steps.rb
@@ -79,11 +79,11 @@ Then /^I should see a link to the online workshop$/ do
 end
 
 Then /^I should see that the related workshop "([^"]+)" is in-person$/ do |workshop_name|
-  type_of_related_workshop_named(workshop_name).should == 'IN-PERSON WORKSHOP'
+  type_of_related_workshop_named(workshop_name).should == 'In-person workshop'
 end
 
 Then /^I should see that the related workshop "([^"]+)" is online$/ do |workshop_name|
-  type_of_related_workshop_named(workshop_name).should == 'ONLINE WORKSHOP'
+  type_of_related_workshop_named(workshop_name).should == 'Online workshop'
 end
 
 Then /^I should see a workshop alert for the in-person workshop$/ do

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -146,6 +146,13 @@ describe Mailer do
 
           expect_not_to_contain_receipt(purchase)
         end
+
+        it 'does not include support' do
+          user = create(:user, :with_subscription)
+          purchase = create(:book_purchase, user: user)
+
+          expect(email_for(purchase)).not_to have_body_text(/support/)
+        end
       end
 
       context 'for a subscription product' do
@@ -154,6 +161,13 @@ describe Mailer do
           purchase = create(:subscription_purchase, user: user)
 
           expect_to_contain_receipt(purchase)
+        end
+
+        it 'includes support' do
+          user = create(:user, :with_subscription)
+          purchase = create(:subscription_purchase, user: user)
+
+          expect(email_for(purchase)).to have_body_text(/support/)
         end
       end
     end

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -29,4 +29,25 @@ describe 'A Purchased book' do
       expect(page).not_to have_css("a[href='http://github.com/thoughtbot/book-repo/blob/master/release/book-title.pdf?raw=true']")
     end
   end
+
+  context 'GET /purchases/show for a book' do
+    it 'does not include support' do
+      book = create(:book_product, name: 'Book title')
+      purchase = create(:paid_purchase, purchaseable: book)
+
+      visit purchase_path(purchase)
+
+      expect(page).not_to have_content 'includes support'
+    end
+
+    it 'includes support with a subscription' do
+      book = create(:book_product, name: 'Book title')
+      purchase = create(:paid_purchase, purchaseable: book)
+
+      sign_in_as_user_with_subscription
+      visit purchase_path(purchase)
+
+      expect(page).to have_content 'includes support'
+    end
+  end
 end

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -42,6 +42,22 @@ describe 'Videos' do
       expect(page).not_to have_content("in this workshop")
     end
 
+    it "doesn't say it includes support with no subscription" do
+      purchase = create(:video_purchase)
+
+      visit purchase_path(purchase)
+      expect(page).not_to have_content("includes support")
+    end
+
+    it 'includes support with a subscription' do
+      sign_in_as_user_with_subscription
+
+      purchase = create(:video_purchase)
+
+      visit purchase_path(purchase)
+      expect(page).to have_content("includes support")
+    end
+
     def create_available_video(watchable, active_on_day, title)
       create(:video, watchable: watchable, active_on_day: active_on_day, title: title)
     end

--- a/spec/requests/workshops_spec.rb
+++ b/spec/requests/workshops_spec.rb
@@ -8,6 +8,7 @@ describe 'Workshops' do
     purchase = create(:paid_purchase, purchaseable: section)
 
     visit purchase_path(purchase)
+
     expect(page).to have_css('.resources li', text: 'Item 1')
     visit purchase_video_path(purchase, video)
     expect(page).to have_css('.resources li', text: 'Item 1')
@@ -22,10 +23,20 @@ describe 'Workshops' do
     event = create(:event, workshop: workshop, title: 'Office Hours', time: '1pm EST', occurs_on_day: 2)
 
     visit purchase_path(purchase)
+
     expect(page).to have_css('.video-chat a.button[href="http://example.com"]')
     expect(page).to have_css('.video-chat ol li', text: 'Office Hours')
     expect(page).to have_css('.video-chat ol li', text: 9.days.from_now.to_s(:simple))
     visit purchase_video_path(purchase, video)
     expect(page).to have_css('.video-chat a.button[href="http://example.com"]')
+  end
+
+  it 'includes support' do
+    section = create(:section)
+    purchase = create(:paid_purchase, purchaseable: section)
+
+    visit purchase_path(purchase)
+
+    expect(page).to have_content('includes support')
   end
 end


### PR DESCRIPTION
We'd like to continue to entice users to subscribe to Prime and not have to support individual purchasers on technical topics forever. We'd also like to move some support to the forums.

This pull request only mentions included support and forum to current subscribers. It mentions support and both the forum and chat room for workshops.
