### PR TITLE
send purchase receipt to billing email

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -144,7 +144,6 @@ FactoryGirl.define do
     name 'Test User'
     association :purchaseable, factory: :product
     variant 'individual'
-    billing_email 'billing@example.com'
 
     trait :free do
       paid_price 0

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -83,7 +83,7 @@ describe Mailer do
 
     context 'for a workshop purchase' do
       it 'does not contain text about downloading' do
-        purchase = create(:section_purchase)
+        purchase = create(:section_purchase, billing_email: 'billing@example.com')
         email = email_for(purchase)
 
         expect(email).not_to have_body_text(/download/)


### PR DESCRIPTION
Set purchase receipt recipient to purchase.billing_email
