### PR TITLE
Allow User to change attributes without setting the password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ActiveRecord::Base
   private
 
   def password_optional?
-    external_auth?
+    super || external_auth?
   end
 
   def associate_previous_purchases

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -144,4 +144,20 @@ describe User do
       expect(user.has_conflict?(create(:product))).to be_false
     end
   end
+
+  context 'password validations' do
+    it 'allows non-oauth users to update attributes without the password' do
+      user = create_user_without_cached_password(admin: false)
+
+      user.admin = true
+      user.save
+
+      user.reload.should be_admin
+    end
+
+    def create_user_without_cached_password(attributes)
+      user = create(:user, attributes)
+      User.find(user.id)
+    end
+  end
 end


### PR DESCRIPTION
- Extend instead of replace built-in behavior from clearance
- Password isn't required unless you're signing up or changing it
