### PR TITLE
Allow subscribers to view their monthly receipts

### DIFF
--- a/app/assets/stylesheets/_invoices.scss
+++ b/app/assets/stylesheets/_invoices.scss
@@ -1,0 +1,29 @@
+body.subscriber-invoices-index {
+  table {
+    width: 100%;
+  }
+}
+
+body.subscriber-invoices-show {
+  .address br {
+    display: block;
+  }
+
+  table {
+    width: 75%;
+
+    td {
+      text-align: right;
+    }
+
+    tr.subscription, tr.discount {
+      td:first-child {
+        text-align: left;
+      }
+    }
+  }
+
+  .note {
+    font-style: italic;
+  }
+}

--- a/app/assets/stylesheets/_users-edit.scss
+++ b/app/assets/stylesheets/_users-edit.scss
@@ -51,6 +51,20 @@ body.users-edit {
           font-size: 16px;
           font-style: normal;
         }
+
+        &.subscription {
+          a.invoices, a.cancel {
+            display: block;
+          }
+
+          a.invoices {
+            margin-top: 16px;
+          }
+
+          a.cancel {
+            text-align: right;
+          }
+        }
       }
 
       a {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -30,6 +30,7 @@
 @import "registrations";
 @import "design-for-developers";
 @import "articles-bytes";
+@import "invoices";
 
 @import "prettify";
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -29,7 +29,7 @@ class PurchasesController < ApplicationController
     end
 
     if use_existing_card?
-      @purchase.stripe_customer = current_user.stripe_customer
+      @purchase.stripe_customer_id = current_user.stripe_customer_id
     end
 
     if @purchase.save
@@ -84,8 +84,8 @@ class PurchasesController < ApplicationController
   end
 
   def retrieve_active_card
-    if current_user && current_user.stripe_customer
-      Stripe::Customer.retrieve(current_user.stripe_customer)['active_card']
+    if current_user && current_user.stripe_customer_id
+      Stripe::Customer.retrieve(current_user.stripe_customer_id)['active_card']
     end
   end
 

--- a/app/controllers/subscriber/invoices_controller.rb
+++ b/app/controllers/subscriber/invoices_controller.rb
@@ -1,0 +1,23 @@
+module Subscriber
+  class InvoicesController < ApplicationController
+    before_filter :authorize
+
+    def index
+      @invoices = SubscriptionInvoice.
+        find_all_by_stripe_customer_id(current_user.stripe_customer_id)
+    end
+
+    def show
+      @invoice = SubscriptionInvoice.new(params[:id])
+      ensure_invoice_belongs_to_user
+    end
+
+    private
+
+    def ensure_invoice_belongs_to_user
+      if @invoice.user != current_user
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/app/controllers/subscription_products_controller.rb
+++ b/app/controllers/subscription_products_controller.rb
@@ -1,4 +1,0 @@
-class SubscriptionProductsController < ApplicationController
-  def index
-  end
-end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -6,7 +6,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def update
-    customer = Stripe::Customer.retrieve(current_user.stripe_customer)
+    customer = Stripe::Customer.retrieve(current_user.stripe_customer_id)
     customer.card = params['stripe_token']
     begin
       customer.save

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 # This class represents a user's subscription to Learn content
 class Subscription < ActiveRecord::Base
   belongs_to :user
-  delegate :stripe_customer, to: :user
+  delegate :stripe_customer_id, to: :user
 
   def self.deliver_welcome_emails
     recent.each do |subscription|

--- a/app/models/subscription_invoice.rb
+++ b/app/models/subscription_invoice.rb
@@ -1,0 +1,147 @@
+class SubscriptionInvoice
+  attr_reader :stripe_invoice
+
+  def self.find_all_by_stripe_customer_id(stripe_customer_id)
+    if stripe_customer_id.present?
+      stripe_invoices_for_customer_id(stripe_customer_id).map do |invoice|
+        SubscriptionInvoice.new(invoice)
+      end
+    else
+      []
+    end
+  end
+
+  def initialize(invoice_id_or_invoice_object)
+    if invoice_id_or_invoice_object.is_a? String
+      @stripe_invoice = retrieve_stripe_invoice(invoice_id_or_invoice_object)
+    else
+      @stripe_invoice = invoice_id_or_invoice_object
+    end
+  end
+
+  def stripe_invoice_id
+    stripe_invoice.id
+  end
+
+  def number
+    date.to_s(:invoice)
+  end
+
+  def total
+    cents_to_dollars(stripe_invoice.total)
+  end
+
+  def subtotal
+    cents_to_dollars(stripe_invoice.subtotal)
+  end
+
+  def paid?
+    stripe_invoice.paid
+  end
+
+  def balance
+    if paid?
+      0.00
+    else
+      amount_due
+    end
+  end
+
+  def amount_due
+    cents_to_dollars(stripe_invoice.amount_due)
+  end
+
+  def amount_paid
+    if paid?
+      amount_due
+    else
+      0.00
+    end
+  end
+
+  def date
+    convert_stripe_time(stripe_invoice.date)
+  end
+
+  def subscription_item_name
+    "Subscription to #{subscription.plan.name}"
+  end
+
+  def subscription_item_amount
+    cents_to_dollars(subscription.amount)
+  end
+
+  def discounted?
+    stripe_invoice.discount.present?
+  end
+
+  def discount_name
+    stripe_invoice.discount.coupon.id
+  end
+
+  def discount_amount
+    cents_to_dollars(stripe_invoice.discount.coupon.amount_off)
+  end
+
+  def user_name
+    user.name
+  end
+
+  def user_organization
+    user.organization
+  end
+
+  def user_address1
+    user.address1
+  end
+
+  def user_address2
+    user.address2
+  end
+
+  def user_city
+    user.city
+  end
+
+  def user_state
+    user.state
+  end
+
+  def user_zip_code
+    user.zip_code
+  end
+
+  def user_country
+    user.country
+  end
+
+  def user
+    @user ||= User.find_by_stripe_customer_id(stripe_invoice.customer)
+  end
+
+  def to_partial_path
+    "subscriber/invoices/#{self.class.name.underscore}"
+  end
+
+  private
+
+  def self.stripe_invoices_for_customer_id(stripe_customer_id)
+    Stripe::Invoice.all(customer: stripe_customer_id, count: 100).data
+  end
+
+  def retrieve_stripe_invoice(stripe_invoice_id)
+    Stripe::Invoice.retrieve(stripe_invoice_id)
+  end
+
+  def cents_to_dollars(amount)
+    amount / 100.0
+  end
+
+  def convert_stripe_time(time)
+    Time.at(time)
+  end
+
+  def subscription
+    stripe_invoice.lines.subscriptions.first
+  end
+end

--- a/app/models/unsubscriber.rb
+++ b/app/models/unsubscriber.rb
@@ -6,7 +6,7 @@ class Unsubscriber
   def process
     Subscription.transaction do
       @subscription.deactivate
-      stripe_user = Stripe::Customer.retrieve(@subscription.stripe_customer)
+      stripe_user = Stripe::Customer.retrieve(@subscription.stripe_customer_id)
       stripe_user.cancel_subscription
       deliver_unsubscription_survey
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,10 +97,10 @@ class User < ActiveRecord::Base
     previous_purchases = Purchase.by_email(email)
     self.purchases << previous_purchases
 
-    existing_stripe_customer_id = previous_purchases.stripe.last.try(:stripe_customer)
+    existing_stripe_customer_id = previous_purchases.stripe.last.try(:stripe_customer_id)
 
     if existing_stripe_customer_id
-      self.update_column(:stripe_customer, existing_stripe_customer_id)
+      self.update_column(:stripe_customer_id, existing_stripe_customer_id)
     end
   end
 end

--- a/app/views/subscriber/invoices/_subscription_invoice.html.erb
+++ b/app/views/subscriber/invoices/_subscription_invoice.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td class="number">
+    <%= link_to subscription_invoice.number, subscriber_invoice_path(subscription_invoice.stripe_invoice_id) %>
+  </td>
+  <td class="date">
+    <%= subscription_invoice.date.to_s(:short_date) %>
+  </td>
+  <td class="total">
+    <%= number_to_currency subscription_invoice.total %>
+  </td>
+  <td class="balance">
+    <%= number_to_currency subscription_invoice.balance %>
+  </td>
+</tr>

--- a/app/views/subscriber/invoices/index.html.erb
+++ b/app/views/subscriber/invoices/index.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, "Invoices" %>
+<% content_for :subject, "Invoices" %>
+
+<div class="text-box-wrapper">
+  <div class="text-box">
+    <table>
+      <tr>
+        <th>Number</th>
+        <th>Date</th>
+        <th>Total</th>
+        <th>Balance</th>
+      </tr>
+      <%= render @invoices %>
+    </table>
+  </div>
+</div>

--- a/app/views/subscriber/invoices/show.html.erb
+++ b/app/views/subscriber/invoices/show.html.erb
@@ -1,0 +1,93 @@
+<% content_for :page_title, "Invoice" %>
+<% content_for :subject, "Invoice #{@invoice.number}" %>
+
+<div class="text-box-wrapper">
+  <div class="text-box">
+    <p>Date <%= @invoice.date.to_s(:short_date) %></p>
+
+    <p class="address">
+      <strong>Sold by</strong><br>
+      thoughtbot, inc.<br>
+      228 Park Ave S #19298<br>
+      New York NY  10003<br>
+      United States<br>
+      Phone: 1 (877) 976-2687 (US toll-free)<br>
+      +46 81 211 11 52 (Europe)
+    </p>
+
+    <p class="address">
+      <strong>Billed to</strong><br>
+      <% if @invoice.user_name.present? %><%= @invoice.user_name %><br><% end %>
+      <% if @invoice.user_organization.present? %><%= @invoice.user_organization %><br><% end %>
+      <% if @invoice.user_address1.present? %><%= @invoice.user_address1 %><br><% end %>
+      <% if @invoice.user_address2.present? %><%= @invoice.user_address2 %><br><% end %>
+      <%= @invoice.user_city %><% if @invoice.user_state.present? %>, <%= @invoice.user_state %><% end %> <%= @invoice.user_zip_code %>
+      <%= @invoice.user_country %>
+    </p>
+
+    <table>
+      <tr class="subscription">
+        <td>
+          <%= @invoice.subscription_item_name %>
+        </td>
+        <td>
+          <%= number_to_currency @invoice.subscription_item_amount, precision: 2 %> USD
+        </td>
+      </tr>
+      <tr class="subtotal">
+        <td>
+          Subtotal
+        </td>
+        <td>
+          <%= number_to_currency @invoice.subtotal, precision: 2 %> USD
+        </td>
+      </tr>
+      <% if @invoice.discounted? %>
+        <tr class="discount">
+          <td>
+            Discount: <%= @invoice.discount_name %>
+          </td>
+          <td>
+            - <%= number_to_currency @invoice.discount_amount, precision: 2 %> USD
+          </td>
+        </tr>
+      <% end %>
+      <tr class="tax">
+        <td>
+          Tax
+        </td>
+        <td>
+          $0.00 USD
+        </td>
+      </tr>
+      <tr class="total">
+        <td>
+          Total
+        </td>
+        <td>
+          <%= number_to_currency @invoice.total, precision: 2 %> USD
+        </td>
+      </tr>
+      <tr class="paid">
+        <td>
+          Amount paid
+        </td>
+        <td>
+          <%= number_to_currency @invoice.amount_paid, precision: 2 %> USD
+        </td>
+      </tr>
+      <tr class="balance">
+        <td>
+          Balance due
+        </td>
+        <td>
+          <%= number_to_currency @invoice.balance, precision: 2 %> USD
+        </td>
+      </tr>
+    </table>
+
+    <p class="note">EU customers, please note: prices exclude VAT</p>
+
+    <p>Invoice lookup: <%= @invoice.stripe_invoice_id %></p>
+  </div>
+</div>

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -1,8 +1,16 @@
-<li>
-  Active since <%= subscription.created_at.to_s(:simple) %><br>
-  (<%= link_to t('subscriptions.cancel'), subscription,
+<li class="subscription">
+  <% if subscription.active? %>
+    Active since <%= subscription.created_at.to_s(:simple) %><br>
+  <% else %>
+    Canceled on <%= subscription.deactivated_on.to_s(:simple) %>
+  <% end %>
+
+  <%= link_to 'View all invoices', subscriber_invoices_path, class: 'invoices' %>
+  <% if subscription.active? %>
+    <%= link_to t('subscriptions.cancel'), subscription,
       method: :delete,
       confirm: 'Are you sure you want to cancel your Prime subscription?',
       class: 'cancel'
-  %>)
+    %>
+  <% end %>
 </li>

--- a/app/views/users/_credit_card_form.html.erb
+++ b/app/views/users/_credit_card_form.html.erb
@@ -1,6 +1,6 @@
 <div class='text-box'>
   <%= semantic_form_for current_user.subscription, url: subscription_path(current_user.subscription) do |form| %>
-    <%= form.inputs "Your Subscription Billing Info", id: 'billing-information' do %>
+    <%= form.inputs "Your Billing Info", id: 'billing-information' do %>
       <li class="subscription-errors"></li>
       <li id="purchase_cc_input" class="stripe">
         <label for='card-number'>Card Number</label>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,12 +19,19 @@
     <% end %>
   </div>
 
-  <% if current_user.subscription && current_user.stripe_customer %>
+  <% if current_user.subscription && current_user.stripe_customer_id %>
     <%= render 'credit_card_form' %>
   <% end %>
 </div>
 
 <aside id="account-sidebar">
+  <% if current_user.subscription %>
+    <h3>Your Subscription</h3>
+    <ol class="purchases">
+      <%= render current_user.subscription %>
+    </ol>
+  <% end %>
+
   <% if current_user.has_purchased? %>
     <h3>Your purchases</h3>
     <ol class="purchases">
@@ -32,13 +39,6 @@
     </ol>
 
     <p class="chat">Every product includes support for any questions you may have about the topic. Visit our <%= link_to "live chat", CHAT_LINK %>.</p>
-  <% end %>
-
-  <% if current_user.has_active_subscription? %>
-    <h3>Your Subscription</h3>
-    <ol class="purchases">
-      <%= render current_user.subscription %>
-    </ol>
   <% end %>
 </aside>
 

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -5,7 +5,8 @@
   short_date: '%x',
   simple: '%B %d, %Y',
   rfc822: '%a, %d %b %Y %H:%M:%S %z',
-  month: '%B'
+  month: '%B',
+  invoice: '%y%m%d'
 }.each do |k, v|
   Date::DATE_FORMATS[k] = v
   Time::DATE_FORMATS[k] = v

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Workshops::Application.routes.draw do
 
   namespace :subscriber do
     resources :purchases, only: :create
+    resources :invoices, only: [:index, :show]
   end
 
   resources :subscriptions, only: [:destroy, :update]

--- a/db/migrate/20130530010021_add_address_fields_to_users.rb
+++ b/db/migrate/20130530010021_add_address_fields_to_users.rb
@@ -1,0 +1,11 @@
+class AddAddressFieldsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :organization, :string
+    add_column :users, :address1, :string
+    add_column :users, :address2, :string
+    add_column :users, :city, :string
+    add_column :users, :state, :string
+    add_column :users, :zip_code, :string
+    add_column :users, :country, :string
+  end
+end

--- a/db/migrate/20130530203918_rename_users_stripe_customer_to_stripe_customer_id.rb
+++ b/db/migrate/20130530203918_rename_users_stripe_customer_to_stripe_customer_id.rb
@@ -1,0 +1,11 @@
+class RenameUsersStripeCustomerToStripeCustomerId < ActiveRecord::Migration
+  def up
+    rename_column :users, :stripe_customer, :stripe_customer_id
+    rename_column :purchases, :stripe_customer, :stripe_customer_id
+  end
+
+  def down
+    rename_column :users, :stripe_customer_id, :stripe_customer
+    rename_column :purchases, :stripe_customer_id, :stripe_customer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130521152542) do
+ActiveRecord::Schema.define(:version => 20130530203918) do
 
   create_table "announcements", :force => true do |t|
     t.datetime "created_at",        :null => false
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(:version => 20130521152542) do
   end
 
   create_table "purchases", :force => true do |t|
-    t.string   "stripe_customer"
+    t.string   "stripe_customer_id"
     t.string   "variant"
     t.string   "name"
     t.string   "email"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(:version => 20130521152542) do
   end
 
   add_index "purchases", ["lookup"], :name => "index_purchases_on_lookup"
-  add_index "purchases", ["stripe_customer"], :name => "index_purchases_on_stripe_customer"
+  add_index "purchases", ["stripe_customer_id"], :name => "index_purchases_on_stripe_customer"
 
   create_table "questions", :force => true do |t|
     t.integer  "workshop_id"
@@ -317,10 +317,17 @@ ActiveRecord::Schema.define(:version => 20130521152542) do
     t.string   "last_name"
     t.string   "reference"
     t.boolean  "admin",                             :default => false, :null => false
-    t.string   "stripe_customer"
+    t.string   "stripe_customer_id"
     t.string   "github_username"
     t.string   "auth_provider"
     t.integer  "auth_uid"
+    t.string   "organization"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zip_code"
+    t.string   "country"
   end
 
   add_index "users", ["admin"], :name => "index_users_on_admin"

--- a/features/step_definitions/stripe_steps.rb
+++ b/features/step_definitions/stripe_steps.rb
@@ -3,7 +3,7 @@ Given 'stripe is stubbed with a failure' do
 end
 
 Given 'I have an existing credit card' do
-  User.all.each { |user| user.update_column(:stripe_customer, "test") }
+  User.all.each { |user| user.update_column(:stripe_customer_id, "test") }
   Stripe::Customer.stubs(:retrieve).returns({"active_card" => {"last4" => "1234", "type" => "Visa"}})
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -257,7 +257,7 @@ FactoryGirl.define do
 
     trait :with_subscription do
       github_username 'github_user_1'
-      stripe_customer 'cus12345'
+      stripe_customer_id 'cus12345'
 
       after :create do |instance|
         create(:subscription, user: instance)

--- a/spec/models/subscription_invoice_spec.rb
+++ b/spec/models/subscription_invoice_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+describe SubscriptionInvoice do
+  it 'retrieves all invoices for a customer' do
+    invoices = SubscriptionInvoice.
+      find_all_by_stripe_customer_id('cus_1KjDojUy0RiwFH')
+
+    invoices.length.should eq 1
+    invoices.first.stripe_invoice_id.should eq 'in_1s4JSgbcUaElzU'
+  end
+
+  it 'does not find invoices with a blank customer' do
+    SubscriptionInvoice.find_all_by_stripe_customer_id(' ').length.should eq 0
+    SubscriptionInvoice.find_all_by_stripe_customer_id('').length.should eq 0
+    SubscriptionInvoice.find_all_by_stripe_customer_id(nil).length.should eq 0
+  end
+
+  describe 'invoice fields' do
+    let(:invoice) { SubscriptionInvoice.new('in_1s4JSgbcUaElzU') }
+
+    it 'has a number equal to its subscription id and date' do
+      date = Time.at(1369159688)
+      invoice.number.should == date.to_s(:invoice)
+    end
+
+    it 'returns the invoice total from stripe' do
+      invoice.total.should == 79
+    end
+
+    it 'returns the invoice subtotal from stripe' do
+      invoice.subtotal.should == 99
+    end
+
+    it 'returns the amount_due from stripe' do
+      invoice.amount_due.should == 79
+    end
+
+    it 'returns the invoice paid status from stripe' do
+      invoice.should be_paid
+    end
+
+    it 'returns the invoice date from stripe' do
+      invoice.date.should eq Time.at(1369159688)
+    end
+
+    it 'returns the subscription name from stripe' do
+      invoice.subscription_item_name.should eq "Subscription to Prime"
+    end
+
+    it 'returns the subscription billed amount from stripe' do
+      invoice.subscription_item_amount.should eq 99
+    end
+
+    it 'returns true if there is a discount on the invoice' do
+      invoice.should be_discounted
+    end
+
+    it 'returns the name of the discount from stripe' do
+      invoice.discount_name.should eq 'railsconf'
+    end
+
+    it 'returns the amount of the discount from stripe' do
+      invoice.discount_amount.should eq 20
+    end
+
+    it 'returns the user who matches the stripe customer' do
+      user = create(:user, stripe_customer_id: "cus_1KjDojUy0RiwFH")
+
+      invoice.user.should eq user
+    end
+
+    it 'returns a zero balance when paid' do
+      invoice.balance.should eq 0.00
+    end
+
+    it 'returns a balance equal to the amount_due when not paid' do
+      stripe_invoice = SubscriptionInvoice.new('in_1s4JSgbcUaElzU')
+      stub_invoice = stub(paid: false, amount_due: 500)
+      Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
+
+      invoice.balance.should eq 5.00
+    end
+
+    describe 'amount_paid' do
+      it 'returns zero when not paid' do
+        stripe_invoice = SubscriptionInvoice.new('in_1s4JSgbcUaElzU')
+        stub_invoice = stub(paid: false)
+        Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
+
+        invoice.amount_paid.should eq 0.00
+      end
+
+      it 'returns the amount_due when paid' do
+        stripe_invoice = SubscriptionInvoice.new('in_1s4JSgbcUaElzU')
+        stub_invoice = stub(paid: true, amount_due: 500)
+        Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
+
+        invoice.amount_paid.should eq 5.00
+      end
+    end
+
+    it 'returns the user info for the user' do
+      user = create(
+        :user,
+        stripe_customer_id: "cus_1KjDojUy0RiwFH",
+        organization: 'thoughtbot',
+        address1: '41 Winter St.',
+        address2: 'Floor 7',
+        city: 'Boston',
+        state: 'MA',
+        zip_code: '02108',
+        country: 'USA'
+      )
+
+      invoice.user_name.should == user.name
+      invoice.user_organization.should eq user.organization
+      invoice.user_address1.should eq user.address1
+      invoice.user_address2.should eq user.address2
+      invoice.user_city.should eq user.city
+      invoice.user_state.should eq user.state
+      invoice.user_zip_code.should eq user.zip_code
+      invoice.user_country.should eq user.country
+    end
+
+    it 'returns the proper partial path' do
+      invoice.to_partial_path.should eq 'subscriber/invoices/subscription_invoice'
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Subscription do
-  it { should delegate(:stripe_customer).to(:user) }
+  it { should delegate(:stripe_customer_id).to(:user) }
 
   describe '.deliver_welcome_emails' do
     it 'sends emails for each new subscriber in the last 24 hours' do

--- a/spec/models/unsubscriber_spec.rb
+++ b/spec/models/unsubscriber_spec.rb
@@ -5,7 +5,7 @@ describe Unsubscriber do
     subscription = create(:subscription)
     unsubscriber = Unsubscriber.new(subscription)
 
-    subscription.stubs(:stripe_customer).returns('cus_1CXxPJDpw1VLvJ')
+    subscription.stubs(:stripe_customer_id).returns('cus_1CXxPJDpw1VLvJ')
     unsubscriber.process
 
     subscription.deactivated_on.should == Date.today
@@ -26,7 +26,7 @@ describe Unsubscriber do
     subscription = create(:subscription)
     unsubscriber = Unsubscriber.new(subscription)
 
-    subscription.stubs(:stripe_customer).returns('cus_1CXxPJDpw1VLvJ')
+    subscription.stubs(:stripe_customer_id).returns('cus_1CXxPJDpw1VLvJ')
     stripe_customer = stub('Stripe::Customer', cancel_subscription: nil)
     Stripe::Customer.stubs(:retrieve).returns(stripe_customer)
     unsubscriber.process

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,8 +75,8 @@ describe User do
     let(:email) { "newuser@example.com" }
 
     before do
-      @prev_purchases = [create(:purchase, email: email, stripe_customer: "stripecustomer"),
-                         create(:purchase, email: email, stripe_customer: nil, payment_method: "paypal")]
+      @prev_purchases = [create(:purchase, email: email, stripe_customer_id: "stripecustomer"),
+                         create(:purchase, email: email, stripe_customer_id: nil, payment_method: "paypal")]
       @other_purchase = create(:purchase)
     end
 
@@ -88,7 +88,7 @@ describe User do
 
     it "retrieves the stripe customer id from previous purchases" do
       user = create(:user, email: email)
-      user.reload.stripe_customer.should == "stripecustomer"
+      user.reload.stripe_customer_id.should == "stripecustomer"
     end
   end
 
@@ -96,7 +96,7 @@ describe User do
     it "doesn't associate a created user with any purchases" do
       user = create(:user)
       user.purchases.should be_empty
-      user.stripe_customer.should be_blank
+      user.stripe_customer_id.should be_blank
     end
   end
 

--- a/spec/requests/subscriber_views_monthly_receipt_spec.rb
+++ b/spec/requests/subscriber_views_monthly_receipt_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+feature 'Subscriber views subscription invoices' do
+  scenario 'Subscriber views a listing of all invoices' do
+    sign_in_as_user_with_subscription
+    @current_user.stripe_customer_id = "cus_1KjDojUy0RiwFH"
+    @current_user.save!
+
+    visit my_account_path
+    click_link 'View all invoices'
+
+    expect(page).to have_css('.number', text: '130521')
+    expect(page).to have_css('.date', text: '05/21/13')
+    expect(page).to have_css('.total', text: '$79.00')
+    expect(page).to have_css('.balance', text: '$0.00')
+
+    click_link '130521'
+
+    expect(page).to have_content('Invoice 130521')
+  end
+
+  scenario 'Subscriber can view a subscription invoice' do
+    sign_in_as_user_with_subscription
+    subscription_purchase = create(:subscription_purchase, user: @current_user)
+    @current_user.stripe_customer_id = "cus_1KjDojUy0RiwFH"
+    @current_user.organization = 'Sprockets, LLC'
+    @current_user.address1 = '1 Street Way'
+    @current_user.address2 = 'Suite 3'
+    @current_user.city = 'Austin'
+    @current_user.state = 'TX'
+    @current_user.zip_code = '00000'
+    @current_user.country = 'USA'
+    @current_user.save!
+
+    visit subscriber_invoice_path("in_1s4JSgbcUaElzU")
+
+    expect(page).to have_content('Invoice 130521')
+    expect(page).to have_content('Date 05/21/13')
+    expect(page).to have_css('.subscription', text: 'Subscription to Prime')
+    expect(page).to have_css('.subscription', text: '$99.00 USD')
+    expect(page).to have_css('.subtotal', text: '$99.00 USD')
+    expect(page).to have_css('.discount', text: 'Discount: railsconf')
+    expect(page).to have_css('.discount', text: '- $20.00 USD')
+    expect(page).to have_css('.total', text: '$79.00 USD')
+    expect(page).to have_content('Invoice lookup: in_1s4JSgbcUaElzU')
+
+    expect(page).to have_content(@current_user.organization)
+    expect(page).to have_content(@current_user.address1)
+    expect(page).to have_content(@current_user.address2)
+    expect(page).to have_content(@current_user.city)
+    expect(page).to have_content(@current_user.state)
+    expect(page).to have_content(@current_user.zip_code)
+    expect(page).to have_content(@current_user.country)
+  end
+
+  scenario "a subscriber can't view another user's invoice" do
+    sign_in_as_user_with_subscription
+    subscription_purchase = create(:subscription_purchase, user: @current_user)
+    @current_user.stripe_customer_id = "cus_NOMATCH"
+    @current_user.save!
+
+    expect do
+      visit subscriber_invoice_path("in_1s4JSgbcUaElzU")
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/requests/user_cancels_subscription_spec.rb
+++ b/spec/requests/user_cancels_subscription_spec.rb
@@ -33,5 +33,9 @@ feature 'User cancels a subscription', js: true do
     click_link 'Subscribe to Prime'
     expect(page).to have_content('Thank you for purchasing Prime')
     expect(page).to have_content('You stopped subscribing to Prime')
+
+    visit my_account_path
+
+    expect(page).to have_content "Canceled on #{Date.today.to_s(:simple)}"
   end
 end

--- a/spec/requests/user_manages_subscription_spec.rb
+++ b/spec/requests/user_manages_subscription_spec.rb
@@ -101,7 +101,7 @@ feature 'User creates a subscription' do
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
     expect(current_path).to eq products_path
-    expect(Purchase.last.stripe_customer).to be_present
+    expect(Purchase.last.stripe_customer_id).to be_present
   end
 
   scenario 'creates a Stripe subscription with an invalid coupon', :js => true do
@@ -120,7 +120,7 @@ feature 'User creates a subscription' do
     sign_in_as_subscriber
     visit my_account_path
 
-    expect(page).to have_content('Your Subscription Billing Info')
+    expect(page).to have_content('Your Billing Info')
   end
 
   scenario 'updates Stripe subscription', js: true do
@@ -146,7 +146,7 @@ feature 'User creates a subscription' do
   scenario 'does not see option to update billing if not subscribing' do
     visit my_account_path
 
-    expect(page).not_to have_content('Your Subscription Billing Info')
+    expect(page).not_to have_content('Your Billing Info')
   end
 
   def submit_new_credit_card_info

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -224,6 +224,23 @@ class FakeStripe < Sinatra::Base
     end
   end
 
+  get '/invoices' do
+    content_type :json
+    {
+      object: "list",
+      count: 1,
+      url: "/v1/invoices",
+      data: [
+        customer_invoice
+      ]
+    }.to_json
+  end
+
+  get '/invoices/:id' do
+    content_type :json
+    customer_invoice.to_json
+  end
+
   get "/events/#{EVENT_ID_FOR_SUCCESSFUL_INVOICE_PAYMENT}" do
     content_type :json
     {
@@ -264,6 +281,68 @@ class FakeStripe < Sinatra::Base
       max_redemptions: params[:max_redemptions],
       times_redeemed: 0,
       duration_in_months: params[:duration_in_months]
+    }
+  end
+
+  def customer_invoice
+    {
+      date: 1369159688,
+      id: "in_1s4JSgbcUaElzU",
+      period_start: 1366567645,
+      period_end: 1369159645,
+      lines: {
+        invoiceitems: [],
+        prorations: [],
+        subscriptions: [
+          {
+            id: "su_1ri03Utwow0Sue",
+            object: "line_item",
+            type: "subscription",
+            livemode: true,
+            amount: 9900,
+            currency: "usd",
+            proration: false,
+            period: {
+              start: 1371755084,
+              end: 1374347084
+            },
+            quantity: 1,
+            plan: {
+              interval: "month",
+              name: "Prime",
+              amount: 9900,
+              currency: "usd",
+              id: "prime",
+              object: "plan",
+              livemode: false,
+              interval_count: 1,
+              trial_period_days: nil
+            },
+            description: nil
+          }
+        ]
+      },
+      discount: {
+        id: "di_1m6sZ5I9P0fk8d",
+        coupon: {
+          id: "railsconf",
+          percent_off: nil,
+          amount_off: 2000,
+          currency: "usd",
+          object: "coupon",
+          livemode: true,
+          duration: "once",
+          redeem_by: 1367971199,
+          max_redemptions: nil,
+          times_redeemed: 1,
+          duration_in_months:nil
+        }
+      },
+      paid: true,
+      total: 7900,
+      subtotal: 9900,
+      amount_due: 7900,
+      customer: "cus_1KjDojUy0RiwFH"
     }
   end
 end


### PR DESCRIPTION
This PR fulfills this story
https://www.apptrajectory.com/thoughtbot/learn/stories/15628597

The ability for a subscriber to view their receipts online. It includes protection to ensure that the only user who can view the invoice is the subscriber.

It introduces saved organization, and address fields on user, which are not exposed as editable in the UI yet. We get these when the user purchases something, we save a copy onto their user, just like we currently do for github_username. New purchases are also automatically populated with the user's info as well.

I'd like to expose these fields on the user edit screen. Also the invoice listing is not yet linked from anywhere. I'm going to add that, but wanted to submit the overall PR for review now.

There is still some styling work needed on the invoice listing, but I've already done a bunch so it could, in theory, ship like it is now.
