### PR TITLE
Send subscription receipt to users

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -128,6 +128,18 @@ class Mailer < ActionMailer::Base
     )
   end
 
+  def subscription_receipt(email, plan_name, amount, stripe_invoice_id)
+    @plan_name = plan_name
+    @amount = amount
+    @stripe_invoice_id = stripe_invoice_id
+
+    mail(
+      to: email,
+      subject: "[Learn] Your #{plan_name} receipt and some tips",
+      from: Clearance.configuration.mailer_sender
+    )
+  end
+
   private
 
   def section_item_name(item)

--- a/app/views/mailer/subscription_receipt.text.erb
+++ b/app/views/mailer/subscription_receipt.text.erb
@@ -1,0 +1,26 @@
+Hi!
+
+You were just charged <%= number_to_currency @amount %> for Learn <%= @plan_name %>.
+
+You can view an invoice for this month, as well as all past ones at
+<%= subscriber_invoice_url(@stripe_invoice_id) %>
+
+If you'd like to chat with a thoughtbot person about your current skill level,
+and next steps you might take to be a better developer, just hit 'Reply' and
+send us an email. We'll schedule a phone or Skype call with you, or if you'd
+rather just talk via email, thats fine too.
+
+Also!
+
+* Have a technical question about something you're working on in your personal
+  project, a workshop, or any of our books?  Post it to the forum at 
+  http://forum.thoughtbot.com
+
+* Each week we deliver a new Byte to your email. You can access the archive of
+  all previous Bytes at https://learn.thoughtbot.com/bytes
+
+* As a <%= @plan_name %> subscriber, you get access to all our books, workshops,
+  and screencasts. View everything at <%= products_url %>
+
+Thanks for subscribing to thoughtbot's Learn <%= @plan_name %>!
+thoughtbot

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -478,4 +478,28 @@ describe Mailer do
       expect(email).to have_body_text(/just unsubscribed/)
     end
   end
+
+  describe '.subscription_receipt' do
+    include Rails.application.routes.url_helpers
+
+    it 'is sent to the given email' do
+      expect(subscription_receipt_email.to).to eq(%w(email@example.com))
+    end
+
+    it 'includes the billed amount as currency' do
+      expect(subscription_receipt_email).to have_body_text(/\$99.00/)
+    end
+
+    it 'includes a link to the invoice' do
+      expect(subscription_receipt_email).to have_body_text(subscriber_invoice_url('invoice_id'))
+    end
+
+    it 'is sent from learn' do
+      expect(subscription_receipt_email.from).to eq(%w(learn@thoughtbot.com))
+    end
+
+    def subscription_receipt_email
+      Mailer.subscription_receipt('email@example.com', 'Prime', 99, 'invoice_id')
+    end
+  end
 end

--- a/spec/models/subscription_invoice_spec.rb
+++ b/spec/models/subscription_invoice_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SubscriptionInvoice do
   it 'retrieves all invoices for a customer' do
     invoices = SubscriptionInvoice.
-      find_all_by_stripe_customer_id('cus_1KjDojUy0RiwFH')
+      find_all_by_stripe_customer_id(FakeStripe::CUSTOMER_ID)
 
     invoices.length.should eq 1
     invoices.first.stripe_invoice_id.should eq 'in_1s4JSgbcUaElzU'
@@ -64,7 +64,7 @@ describe SubscriptionInvoice do
     end
 
     it 'returns the user who matches the stripe customer' do
-      user = create(:user, stripe_customer_id: "cus_1KjDojUy0RiwFH")
+      user = create(:user, stripe_customer_id: FakeStripe::CUSTOMER_ID)
 
       invoice.user.should eq user
     end
@@ -102,7 +102,7 @@ describe SubscriptionInvoice do
     it 'returns the user info for the user' do
       user = create(
         :user,
-        stripe_customer_id: "cus_1KjDojUy0RiwFH",
+        stripe_customer_id: FakeStripe::CUSTOMER_ID,
         organization: 'thoughtbot',
         address1: '41 Winter St.',
         address2: 'Floor 7',

--- a/spec/requests/stripe_webook_spec.rb
+++ b/spec/requests/stripe_webook_spec.rb
@@ -2,18 +2,44 @@ require 'spec_helper'
 
 describe 'successful charges reported by Stripe webhook' do
   it 'sends the event to Kissmetrics' do
+    ActionMailer::Base.deliveries.clear
+    user = create(
+      :user,
+      :with_subscription,
+      stripe_customer_id: FakeStripe::CUSTOMER_ID
+    )
     create(:subscribeable_product, sku: 'prime')
 
     simulate_stripe_webhook_firing
 
-    kissmetrics_should_receive_succesful_charge_event
+    kissmetrics_should_receive_succesful_charge_event(user)
+  end
+
+  it 'sends the customer a receipt' do
+    ActionMailer::Base.deliveries.clear
+    user = create(
+      :user,
+      :with_subscription,
+      stripe_customer_id: FakeStripe::CUSTOMER_ID
+    )
+    create(:subscribeable_product, sku: 'prime')
+
+    simulate_stripe_webhook_firing
+
+    customer_should_receive_receipt_email(user)
   end
 
   def simulate_stripe_webhook_firing
     post '/stripe-webhook', 'id' => FakeStripe::EVENT_ID_FOR_SUCCESSFUL_INVOICE_PAYMENT
   end
 
-  def kissmetrics_should_receive_succesful_charge_event
-    expect(FakeKissmetrics.events_for(FakeStripe::CUSTOMER_EMAIL)).to be_present
+  def kissmetrics_should_receive_succesful_charge_event(user)
+    expect(FakeKissmetrics.events_for(user.email)).to be_present
+  end
+
+  def customer_should_receive_receipt_email(user)
+    email = ActionMailer::Base.deliveries.first
+    email.subject.should include('receipt')
+    email.to.should eq [user.email]
   end
 end

--- a/spec/requests/subscriber_views_monthly_receipt_spec.rb
+++ b/spec/requests/subscriber_views_monthly_receipt_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Subscriber views subscription invoices' do
   scenario 'Subscriber views a listing of all invoices' do
     sign_in_as_user_with_subscription
-    @current_user.stripe_customer_id = "cus_1KjDojUy0RiwFH"
+    @current_user.stripe_customer_id = FakeStripe::CUSTOMER_ID
     @current_user.save!
 
     visit my_account_path
@@ -22,7 +22,7 @@ feature 'Subscriber views subscription invoices' do
   scenario 'Subscriber can view a subscription invoice' do
     sign_in_as_user_with_subscription
     subscription_purchase = create(:subscription_purchase, user: @current_user)
-    @current_user.stripe_customer_id = "cus_1KjDojUy0RiwFH"
+    @current_user.stripe_customer_id = FakeStripe::CUSTOMER_ID
     @current_user.organization = 'Sprockets, LLC'
     @current_user.address1 = '1 Street Way'
     @current_user.address2 = 'Suite 3'

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -247,23 +247,7 @@ class FakeStripe < Sinatra::Base
       id: "evt_1X6Z2OXmhBVcm9",
       type: "invoice.payment_succeeded",
       data: {
-        object: {
-          customer: CUSTOMER_ID,
-          lines: {
-            subscriptions: [
-              {
-                plan: {
-                  interval: "month",
-                  name: "Prime",
-                  amount: 9900,
-                  currency: "usd",
-                  id: "prime",
-                  object: "plan",
-                }
-              }
-            ]
-          }
-        }
+        object: customer_invoice
       }
     }.to_json
   end
@@ -342,7 +326,7 @@ class FakeStripe < Sinatra::Base
       total: 7900,
       subtotal: 9900,
       amount_due: 7900,
-      customer: "cus_1KjDojUy0RiwFH"
+      customer: CUSTOMER_ID
     }
   end
 end


### PR DESCRIPTION
This addresses this story: https://www.apptrajectory.com/thoughtbot/learn/stories/15622776

We decided to include text and pointers about Prime content in the body of the email instead of an actual receipt. In the future, this could be expanded to automatically include info about new workshops, book updates, etc.
