### PR TITLE
Send workshop students a survey

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -108,6 +108,17 @@ class Mailer < ActionMailer::Base
     )
   end
 
+  def workshop_survey(section, email)
+    @section = section
+
+    mail(
+      to: email,
+      from: 'learn@thoughtbot.com',
+      reply_to: 'learn@thoughtbot.com',
+      subject: "[Learn] #{section.name}: Please tell us how we did"
+    )
+  end
+
   def byte_notification(email, article)
     @article = article
 

--- a/app/views/mailer/workshop_survey.text.erb
+++ b/app/views/mailer/workshop_survey.text.erb
@@ -1,0 +1,10 @@
+Hello!
+
+Thanks for taking the <%= @section.name %> workshop. I'd love to get your honest feedback on the workshop, it's what helps us make the workshop better for future students.
+
+<%= page_url('feedback') %>
+
+If you answer the short survey, we'll give you a coupon code that gives you 20% off any future Learn purchase (for non-Prime members). You'll see the coupon code on the confirmation page.
+
+Thank you again,
+thoughtbot

--- a/app/views/pages/feedback.html.erb
+++ b/app/views/pages/feedback.html.erb
@@ -16,5 +16,5 @@
 </div>
 
 <aside>
-  <p>Thank you for your thoughts. After completing the survey you'll be given a coupon of 20% everything at Learn</p>
+  <p>Thank you for your thoughts. After completing the survey you'll be given a coupon for 20% of everything at Learn, good for non-Prime members.</p>
 </aside>

--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,10 +1,15 @@
 namespace :notifications do
   desc 'Send notifications for current sections'
   task section: :environment do
-    Section.send_notifications
+    Section.send_video_notifications
     if Date.today.friday?
       Section.send_office_hours_reminders
     end
+  end
+
+  desc 'Send workshop surveys for current sections that are ending'
+  task surveys: :environment do
+    Section.send_surveys
   end
 
   desc 'Send welcome emails to those who subscribed to prime in the last 24 hours'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -141,7 +141,7 @@ FactoryGirl.define do
   end
 
   factory :purchase, aliases: [:individual_purchase] do
-    email 'joe@example.com'
+    email
     name 'Test User'
     association :purchaseable, factory: :product
     variant 'individual'

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -502,4 +502,23 @@ describe Mailer do
       Mailer.subscription_receipt('email@example.com', 'Prime', 99, 'invoice_id')
     end
   end
+
+  describe '.workshop_survey' do
+    it 'is sent to the given email' do
+      expect(workshop_survey_email.to).to eq(%w(email@example.com))
+    end
+
+    it 'is sent from learn' do
+      expect(workshop_survey_email.from).to eq(%w(learn@thoughtbot.com))
+    end
+
+    it 'includes a link to the survey' do
+      expect(workshop_survey_email).to have_body_text(page_url('feedback'))
+    end
+
+    def workshop_survey_email
+      section = create(:section)
+      Mailer.workshop_survey(section, 'email@example.com')
+    end
+  end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Teacher do
-  context ".by_name" do
+  describe ".by_name" do
     let!(:bob) { create(:teacher, name: "Bob Doe") }
     let!(:albert) { create(:teacher, name: "Albert Doe") }
     subject { Teacher.by_name }


### PR DESCRIPTION
This PR covers this story:
https://www.apptrajectory.com/thoughtbot/learn/stories/15629457

It introduces new functionality on Section to email students whose workshop ends today, and a rake task that triggers this.

This rake task will be set up with Heroku Scheduler to run at 6pm eastern time so that its sent out right after in-person workshops end.
