### PR TITLE
decouple dateless workshops from online

### DIFF
--- a/app/helpers/workshops_helper.rb
+++ b/app/helpers/workshops_helper.rb
@@ -26,12 +26,13 @@ module WorkshopsHelper
   end
 
   def workshop_frequency_note(workshop)
-    if workshop.online?
-      'This online workshop starts as soon as you register.'
+    if workshop.starts_immediately?
+      "This #{workshop_delivery_method(workshop)} workshop
+       starts as soon as you register."
     else
-      "This in-person workshop is held about every six weeks.
-      #{link_to 'Get notified', '#new_follow_up'} when
-      the next one is scheduled.".html_safe
+      "This #{workshop_delivery_method(workshop)} workshop is held about every
+      six weeks. #{link_to 'Get notified', '#new_follow_up'} when the next one
+      is scheduled.".html_safe
     end
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -171,7 +171,7 @@ class Section < ActiveRecord::Base
   end
 
   def starts_on(purchase_date = nil)
-    if purchase_date && self[:ends_on].blank?
+    if purchase_date && starts_immediately?
       purchase_date
     else
       self[:starts_on]
@@ -179,11 +179,15 @@ class Section < ActiveRecord::Base
   end
 
   def ends_on(purchase_date = nil)
-    if purchase_date && self[:ends_on].blank?
+    if purchase_date && starts_immediately?
       purchase_date + length_in_days.days
     else
       self[:ends_on]
     end
+  end
+
+  def starts_immediately?
+    self[:ends_on].blank?
   end
 
   private

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -122,6 +122,10 @@ class Workshop < ActiveRecord::Base
     github_team.present?
   end
 
+  def starts_immediately?
+    active_section.try(:starts_immediately?)
+  end
+
   private
 
   def alternate_workshop

--- a/app/views/sections/_online_section.html.erb
+++ b/app/views/sections/_online_section.html.erb
@@ -1,3 +1,12 @@
+<% unless online_section.starts_immediately? %>
+  <section class="section-location">
+    <div class="when">
+      <h3>When</h3>
+     <p><%= online_section.date_range %><br><%= online_section.time_range %></p>
+    </div>
+  </section>
+<% end %>
+
 <section id="license">
   <% if online_section.full? %>
     <h2>

--- a/spec/helpers/workshops_helper_spec.rb
+++ b/spec/helpers/workshops_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe WorkshopsHelper, '#workshop_frequency_note' do
-  context 'an online workshop' do
+  context 'an workshop that starts immediately' do
     it 'says how often it is offered' do
-      workshop = build(:online_workshop)
+      workshop = stub(online?: true, starts_immediately?: true)
 
       note = workshop_frequency_note(workshop)
 
@@ -11,13 +11,13 @@ describe WorkshopsHelper, '#workshop_frequency_note' do
     end
   end
 
-  context 'an in person workshop' do
+  context 'a workshop that does not start immediately' do
     it 'says how often it is offered' do
-      workshop = build(:workshop)
+      workshop = stub(online?: true, starts_immediately?: false)
 
       note = workshop_frequency_note(workshop)
 
-      expect(note).to include 'about every six weeks'
+      expect(note).to include 'six weeks'
     end
   end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -448,4 +448,26 @@ describe Section do
       expect(section.ends_on(Date.today)).to eq ends_on
     end
   end
+
+  describe '#starts_immediately?' do
+    it 'does not start immediately when the section has an end date' do
+      section = create(
+        :section,
+        starts_on: Date.today,
+        ends_on: Date.tomorrow
+      )
+
+      expect(section.starts_immediately?).to be false
+    end
+
+    it 'starts immediately when the section does not have an end date' do
+      section = create(
+        :section,
+        starts_on: Date.today,
+        ends_on: nil
+      )
+
+      expect(section.starts_immediately?).to be true
+    end
+  end
 end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -218,4 +218,34 @@ describe Workshop do
       purchase.should_not be_fulfilled_with_github
     end
   end
+
+  describe '#starts_immediately?' do
+    it 'does not start immediately when the active section has an end date' do
+      section = create(
+        :section,
+        starts_on: Date.today,
+        ends_on: Date.tomorrow
+      )
+      workshop = section.workshop
+
+      expect(workshop.starts_immediately?).to be false
+    end
+
+    it 'starts immediately when the active section does not have an end date' do
+      section = create(
+        :section,
+        starts_on: Date.today,
+        ends_on: nil
+      )
+      workshop = section.workshop
+
+      expect(workshop.starts_immediately?).to be_true
+    end
+
+    it 'does not start immediately when there is no active section' do
+      workshop = create(:workshop)
+
+      expect(workshop.starts_immediately?).to be_false
+    end
+  end
 end


### PR DESCRIPTION
Finishes https://www.apptrajectory.com/thoughtbot/learn/stories/15629669

Currently we're doing some things based on whether a workshop is online
or not, but this is not what actually determines this behavior. These
changes decouple the last places where we were assuming that online
workshops start immediately and actually chedck the data to determine
that.
