### PR TITLE
show active state on a workshop if it has been purchased

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -112,7 +112,7 @@
     background: $workshop-online-color;
   }
 
-  &.workshop-inperson h4 {
+  &.workshop-in-person h4 {
     background: $workshop-inperson-color;
   }
 
@@ -171,7 +171,7 @@
   }
 
   .actions {
-    background: rgba(0, 0, 0, .6);
+    background: rgba(0, 0, 0, .5);
     border-radius: 3px;
     opacity: 0;
     padding: 3.3rem 1.5rem;
@@ -180,6 +180,7 @@
 
     a {
       @include product-card-button(#7ebe69);
+      -webkit-font-smoothing: antialiased;
     }
 
     a.main {

--- a/app/helpers/workshops_helper.rb
+++ b/app/helpers/workshops_helper.rb
@@ -17,22 +17,30 @@ module WorkshopsHelper
     end
   end
 
-  def workshop_delivery_method(workshop)
-    if workshop.online?
-      'online'
+  def workshop_frequency_note(workshop)
+    if workshop.starts_immediately?
+      "This #{workshop.fulfillment_method} workshop
+       starts as soon as you register."
     else
-      'in-person'
+      "This #{workshop.fulfillment_method} workshop is held about every
+      six weeks. #{link_to 'Get notified', '#new_follow_up'} when the next one
+      is scheduled.".html_safe
     end
   end
 
-  def workshop_frequency_note(workshop)
-    if workshop.starts_immediately?
-      "This #{workshop_delivery_method(workshop)} workshop
-       starts as soon as you register."
+  def workshop_card_classes(workshop)
+    classes = ["workshop-#{workshop.fulfillment_method}", 'product-card']
+    if workshop.purchase_for(current_user)
+      classes << 'active'
+    end
+    classes.join(' ')
+  end
+
+  def workshop_dashboard_text(workshop)
+    if workshop.purchase_for(current_user)
+      'View Workshop Materials'
     else
-      "This #{workshop_delivery_method(workshop)} workshop is held about every
-      six weeks. #{link_to 'Get notified', '#new_follow_up'} when the next one
-      is scheduled.".html_safe
+      'Learn More'
     end
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -15,7 +15,7 @@ class Section < ActiveRecord::Base
   delegate :name, :description, :individual_price, :company_price, :terms,
     :videos, :resources, :video_chat_url, :office_hours, :in_person?, :online?,
     :github_team, :fulfilled_with_github?, :length_in_days, :sku,
-    to: :workshop, allow_nil: true
+    :fulfillment_method, to: :workshop, allow_nil: true
 
   # Nested Attributes
   accepts_nested_attributes_for :section_teachers
@@ -84,14 +84,6 @@ class Section < ActiveRecord::Base
 
   def announcement
     @announcement ||= announcements.current
-  end
-
-  def fulfillment_method
-    if in_person?
-      'in-person'
-    else
-      'online'
-    end
   end
 
   def product_type

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -117,6 +117,14 @@ class Workshop < ActiveRecord::Base
     end
   end
 
+  def fulfillment_method
+    if in_person?
+      'in-person'
+    else
+      'online'
+    end
+  end
+
   def fulfilled_with_github?
     github_team.present?
   end

--- a/app/views/pages/prime.html.erb
+++ b/app/views/pages/prime.html.erb
@@ -88,7 +88,7 @@
       <div>
         <h3>In-Person Workshops</h3>
         <div class="figuregroup">
-          <figure class="workshop-inperson product-card">
+          <figure class="workshop-in-person product-card">
             <%= link_to '/workshops/2-design-for-developers', title: 'The Design for Developers in-person workshop details' do %>
               <h4>Design for Developers</h4>
               <%= image_tag('workshop_thumbs/design-for-developers.png') %>
@@ -97,7 +97,7 @@
               <p class="note">Also offered online</p>
             <% end %>
           </figure>
-          <figure class="workshop-inperson product-card">
+          <figure class="workshop-in-person product-card">
             <%= link_to '/workshops/12-intermediate-ruby-on-rails', title: 'The Intermediate Ruby on Rails in-person workshop details' do %>
               <h4>Intermediate Ruby on Rails</h4>
               <%= image_tag('workshop_thumbs/intermediate-ruby-on-rails.png') %>
@@ -106,7 +106,7 @@
               <p class="note">Also offered online</p>
             <% end %>
           </figure>
-          <figure class="workshop-inperson product-card">
+          <figure class="workshop-in-person product-card">
             <%= link_to '/workshops/1-test-driven-rails', title: 'The Test Driven Rails in-person workshop details' do %>
               <h4>Test-Driven Rails</h4>
               <%= image_tag('workshop_thumbs/test-driven-rails.png') %>

--- a/app/views/products/_workshop.html.erb
+++ b/app/views/products/_workshop.html.erb
@@ -1,8 +1,4 @@
-<% if workshop.online? %>
-  <figure class="workshop-online product-card">
-<% else %>
-  <figure class="workshop-inperson product-card">
-<% end %>
+<%= content_tag :figure, class: workshop_card_classes(workshop) do %>
   <h4><%= workshop.name %></h4>
   <% if workshop.online? %>
     <%= image_tag(workshop.thumbnail_path) %>
@@ -27,9 +23,9 @@
   <% end %>
   <p><%= workshop.short_description %></p>
   <section class="actions">
-    <%= link_to 'Learn More', workshop, 'data-role' => workshop_data_role(workshop), class: 'main' %>
+    <%= link_to workshop_dashboard_text(workshop), workshop, 'data-role' => workshop_data_role(workshop), class: 'main' %>
     <% if signed_in? %>
       <%= render partial: 'products/forum_link', locals: { current_user: current_user } %>
     <% end %>
   </section>
-</figure>
+<% end %>

--- a/app/views/workshops/_terms.html.erb
+++ b/app/views/workshops/_terms.html.erb
@@ -1,6 +1,6 @@
 <section id="terms">
   <dl>
-    <dt><p>How often is this <%= workshop_delivery_method(workshop) %> workshop offered?</p></dt>
+    <dt><p>How often is this <%= workshop.fulfillment_method %> workshop offered?</p></dt>
     <dd><p><%= workshop_frequency_note(workshop) %></p></dd>
     <dt><p>What if I'm not happy?</p></dt>
     <dd><p>If you&rsquo;re not happy, just let us know within 30 days and we&rsquo;ll refund your money. It&rsquo;s as simple as that.</p></dd>

--- a/spec/helpers/workshops_helper_spec.rb
+++ b/spec/helpers/workshops_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe WorkshopsHelper, '#workshop_frequency_note' do
   context 'an workshop that starts immediately' do
     it 'says how often it is offered' do
-      workshop = stub(online?: true, starts_immediately?: true)
+      workshop = stub(fulfillment_method: 'online', starts_immediately?: true)
 
       note = workshop_frequency_note(workshop)
 
@@ -13,7 +13,7 @@ describe WorkshopsHelper, '#workshop_frequency_note' do
 
   context 'a workshop that does not start immediately' do
     it 'says how often it is offered' do
-      workshop = stub(online?: true, starts_immediately?: false)
+      workshop = stub(fulfillment_method: 'online', starts_immediately?: false)
 
       note = workshop_frequency_note(workshop)
 

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -155,22 +155,6 @@ describe Section do
       expect(last_week).not_to be_upcoming
     end
   end
-
-  describe '#fulfillment_method' do
-    it 'returns in-person if the workshop is an in-person one' do
-      in_person_workshop = create(:workshop, online: false)
-      section = create(:section, workshop: in_person_workshop)
-
-      expect(section.fulfillment_method).to eq('in-person')
-    end
-
-    it 'returns online if the workshop is an online one' do
-      online_workshop = create(:workshop, online: true)
-      section = create(:section, workshop: online_workshop)
-
-      expect(section.fulfillment_method).to eq('online')
-    end
-  end
 end
 
 describe Section do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -255,4 +255,18 @@ describe Workshop do
       expect(workshop.thumbnail_path).to eq "workshop_thumbs/#{workshop.name.parameterize}.png"
     end
   end
+
+  describe '#fulfillment_method' do
+    it 'returns in-person if the workshop is an in-person one' do
+      workshop = create(:in_person_workshop, online: false)
+
+      expect(workshop.fulfillment_method).to eq('in-person')
+    end
+
+    it 'returns online if the workshop is an online one' do
+      workshop = create(:online_workshop, online: true)
+
+      expect(workshop.fulfillment_method).to eq('online')
+    end
+  end
 end

--- a/spec/requests/subscriber_accesses_content_via_dashboard_spec.rb
+++ b/spec/requests/subscriber_accesses_content_via_dashboard_spec.rb
@@ -17,6 +17,8 @@ feature 'Subscriber accesses content' do
 
     expect(page).to have_content I18n.t('subscriber_purchase.flashes.success')
     expect(page).not_to have_content('Receipt')
+
+    expect_dashboard_to_show_workshop_active(online_section.workshop)
   end
 
   scenario 'gets access to a book product' do
@@ -71,7 +73,7 @@ feature 'Subscriber accesses content' do
 
     visit products_path
 
-    click_online_workshop_detail_link
+    click_active_online_workshop_detail_link
     expect(page).to_not have_content I18n.t('workshops.show.register')
   end
 
@@ -92,6 +94,8 @@ feature 'Subscriber accesses content' do
 
     expect(page).to have_content I18n.t('subscriber_purchase.flashes.success')
     expect(page).not_to have_content 'Receipt'
+
+    expect_dashboard_to_show_workshop_active(in_person_section.workshop)
   end
 
   def stub_github_fulfillment_job
@@ -104,8 +108,14 @@ feature 'Subscriber accesses content' do
     end
   end
 
+  def click_active_online_workshop_detail_link
+    within('.workshop-online') do
+      click_link 'View Workshop Materials'
+    end
+  end
+
   def click_in_person_workshop_detail_link
-    within('.workshop-inperson') do
+    within('.workshop-in-person') do
       click_link 'Learn More'
     end
   end
@@ -120,5 +130,10 @@ feature 'Subscriber accesses content' do
     within('section.books') do
       click_link 'Learn More'
     end
+  end
+
+  def expect_dashboard_to_show_workshop_active(workshop)
+    visit products_url
+    expect(page).to have_css(".product-card.active h4", text: workshop.name)
   end
 end


### PR DESCRIPTION
The playbook workshop in this example is "finished" i.e. all videos are available. The Design for Developers workshop is in-progress i.e. in the first week. I'm not sure how to differentiate between the two, but I think this language suits both states.

I also think that the in progress workshops should be at the far left of the list, and once we have "updates", they should be right after in-progress workshops.

![screen shot 2013-06-19 at 4 28 45 pm](https://f.cloud.github.com/assets/654275/677564/de2d51d0-d91e-11e2-8461-1dad5c85ab52.png)
