### PR TITLE
Redirecting workshops#index to products#index

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -1,6 +1,11 @@
 class WorkshopsController < ApplicationController
   def index
-    @workshops = Workshop.only_active.by_position
+    respond_to do |format|
+      format.html { redirect_to products_path}
+      format.json do
+        @workshops = Workshop.only_active.by_position
+      end
+    end
   end
 
   def show

--- a/spec/controllers/workshops_controller_spec.rb
+++ b/spec/controllers/workshops_controller_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe WorkshopsController do
+  context 'index' do
+    it 'redirects to products page if request is HTML' do
+      get :index
+
+      expect(response).to redirect_to products_path
+    end
+
+    it 'returns json data if request is JSON' do
+      get :index, format: :json
+
+      expect(response).to render_template 'index'
+    end
+  end
+
   context "show" do
     it "redirects to a user's purchase if the user has one" do
       user = create(:user)


### PR DESCRIPTION
We are having workshops#index calls from blog
So instead of having as an error we want to 
redirect to our products page.

Right now products page is auth required but later
it will be open.
