### PR TITLE
remove buttons on hover for all product cards

### DIFF
--- a/app/helpers/workshops_helper.rb
+++ b/app/helpers/workshops_helper.rb
@@ -41,12 +41,4 @@ module WorkshopsHelper
       workshop.purchase_for(current_user).status
     end
   end
-
-  def workshop_dashboard_text(workshop)
-    if workshop.purchase_for(current_user) && signed_in?
-      'View Workshop Materials'
-    else
-      'Learn More'
-    end
-  end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -55,6 +55,29 @@ describe Purchase do
     end
   end
 
+  context '#status' do
+    it 'returns in-progress when it can purchaseable online and ends in future' do
+      section = create(:online_section, ends_on: 2.days.from_now)
+      purchase = create(:purchase, purchaseable: section)
+
+      expect(purchase.status).to eq 'in-progress'
+    end
+
+    it 'returns registered when it ends in future' do
+      section = create(:section, ends_on: 5.days.since)
+      purchase = create(:purchase, purchaseable: section)
+
+      expect(purchase.status).to eq 'registered'
+    end
+
+    it 'returns complete when already end' do
+       section = create(:section, ends_on: 5.days.ago)
+      purchase = create(:purchase, purchaseable: section)
+
+      expect(purchase.status).to eq 'complete'
+    end
+  end
+
   context '#set_as_paid' do
     it 'sets paid properties' do
       purchase = build(:unpaid_purchase)

--- a/spec/requests/subscriber_accesses_content_via_dashboard_spec.rb
+++ b/spec/requests/subscriber_accesses_content_via_dashboard_spec.rb
@@ -73,7 +73,7 @@ feature 'Subscriber accesses content' do
 
     visit products_path
 
-    click_active_online_workshop_detail_link
+    click_online_workshop_detail_link
     expect(page).to_not have_content I18n.t('workshops.show.register')
   end
 
@@ -96,17 +96,49 @@ feature 'Subscriber accesses content' do
     expect_dashboard_to_show_workshop_active(in_person_section.workshop)
   end
 
+  scenario 'show in-progress status for future online workshop' do
+    online_section = create(:online_section, :ends_on => 2.days.from_now)
+
+    sign_in_as_user_with_subscription
+    click_online_workshop_detail_link
+    click_link I18n.t('workshops.show.register_free')
+    click_button 'Get Access'
+
+    visit products_url
+    expect(page).to have_css(".product-card.in-progress", text: online_section.name)
+  end
+
+  scenario 'show complete status for future online past workshop' do
+    online_section = create(:in_person_section, :ends_on => 2.days.ago)
+
+    get_access_to_in_person_workshop
+
+    visit products_url
+    expect(page).to have_css(".product-card.complete", text: online_section.name)
+  end
+
+  scenario 'show registered status for future in-person workshop' do
+    online_section = create(:in_person_section, :ends_on => 2.days.from_now)
+
+    get_access_to_in_person_workshop
+
+    visit products_url
+    expect(page).to have_css(".product-card.registered", text: online_section.name)
+  end
+
+  def get_access_to_in_person_workshop
+    sign_in_as_user_with_subscription
+    click_in_person_workshop_detail_link
+    click_link I18n.t('workshops.show.register_free_inperson')
+    fill_in 'subscriber_purchase_comments', with: 'Vegetarian'
+    click_button 'Get Access'
+  end
+
   def stub_github_fulfillment_job
     GithubFulfillmentJob.stubs(:enqueue)
   end
 
   def click_online_workshop_detail_link
-    within('.workshop-online') do
-      click_link 'View Details'
-    end
-  end
-
-  def click_active_online_workshop_detail_link
     within('.workshop-online') do
       click_link 'View Details'
     end


### PR DESCRIPTION
Changes to note: 
- Added back the white background to separate out screencasts
- Added an "in progress or complete" status to "purchased" workshops and a "registered" status to in person workshops
- Removed the hover buttons and made the items link directly to their detail pages
- Removed the link over books and just placed the covers in the container, linking directly to their detail pages.

![screen shot 2013-07-25 at 3 36 47 pm](https://f.cloud.github.com/assets/654275/858245/1f1118bc-f562-11e2-8259-b0923210177b.png)
![screen shot 2013-07-25 at 3 37 01 pm](https://f.cloud.github.com/assets/654275/858244/1f064cfc-f562-11e2-8d21-3df88e0cb72b.png)

https://www.apptrajectory.com/thoughtbot/learn/stories/15632472
