### PR TITLE
make videos accessible immediately

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -1,12 +1,4 @@
 module VideosHelper
-  def video_availability_class(video, purchase)
-    if video.available?(purchase.starts_on)
-      'available'
-    else
-      'unavailable'
-    end
-  end
-
   def single_video?(purchaseable)
     purchaseable.videos.size == 1
   end

--- a/app/views/videos/_thumbnail.html.erb
+++ b/app/views/videos/_thumbnail.html.erb
@@ -4,9 +4,6 @@
   <p class="videoinfo">
     <em>
       <%= distance_of_time_in_words video.wistia_running_time %>
-      <% unless video.available?(purchase.starts_on) %>
-        &mdash; Starts on <%= video.available_on(purchase.starts_on).to_s(:simple) %>
-      <% end %>
     </em>
   </p>
 </div>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -1,12 +1,5 @@
-<%= content_tag_for :div,
-  video,
-  class: video_availability_class(video, purchase) do %>
-
-  <% if video.available?(purchase.starts_on) %>
-    <%= link_to purchase_video_path(purchase, video) do %>
-      <%= render 'videos/thumbnail', video: video, purchase: purchase %>
-    <% end %>
-  <% else %>
+<%= content_tag_for :div, video do %>
+  <%= link_to purchase_video_path(purchase, video) do %>
     <%= render 'videos/thumbnail', video: video, purchase: purchase %>
   <% end %>
 <% end %>

--- a/app/views/videos/_watch_video.html.erb
+++ b/app/views/videos/_watch_video.html.erb
@@ -1,20 +1,16 @@
-<% if video.available?(purchase.starts_on) %>
-  <p class="videowrapper"><%= render 'videos/code', video_hash_id: video.video_hash_id %></p>
+<p class="videowrapper"><%= render 'videos/code', video_hash_id: video.video_hash_id %></p>
 
-  <section class="assets-wrapper">
-    <div class="assets">
-      <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", video: video %>
-      <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", video: video %>
-      <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", video: video %>
-    </div>
+<section class="assets-wrapper">
+  <div class="assets">
+    <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", video: video %>
+    <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", video: video %>
+    <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", video: video %>
+  </div>
+</section>
+
+<% if video.has_notes? %>
+  <section class='video-notes'>
+    <h3>Notes</h3>
+    <%= raw(video.notes_html) %>
   </section>
-
-  <% if video.has_notes? %>
-    <section class='video-notes'>
-      <h3>Notes</h3>
-      <%= raw(video.notes_html) %>
-    </section>
-  <% end %>
-<% else %>
-  <p>This video is not yet available. It will be released on <%= video.available_on(purchase.starts_on).to_s(:simple) %></p>
 <% end %>

--- a/app/views/workshop_mailer/video_notification.text.erb
+++ b/app/views/workshop_mailer/video_notification.text.erb
@@ -1,6 +1,6 @@
 Hello,
 
-<%= @video.watchable_name %> video lesson <%= @video.position %>, <%= @video.title %>, is now available.
+It's time to start <%= @video.watchable_name %> video lesson <%= @video.position %>, <%= @video.title %>, if you haven't already. If you have questions about this, or the previous lesson, please don't hesitate to post to the forum or attend the weekly office hours.
 
 <% if @video.has_notes? %>
 <%= @video.notes %>
@@ -9,7 +9,7 @@ Hello,
 You can get to the lesson in two ways:
 
 * By following the link in your receipt email
-* By going to the "My Account" page on http://learn.thoughtbot.com, and clicking on "<%= @video.watchable.name %>" in the right hand sidebar. If you do not have a user account at Learn yet, create one with the same email address you used to register for the workshop and the purchase of the workshop should be linked to your account. Or create it with a different email or github account and let us know and we'll manually associate it.
+* By going to the Settings page at http://learn.thoughtbot.com/my_account, and clicking on "<%= @video.watchable.name %>" in the right hand sidebar. If you do not have a user account at Learn yet, create one with the same email address you used to register for the workshop and the purchase of the workshop should be linked to your account. Or create it with a different email or github account and let us know and we'll manually associate it.
 
 thank you very much,
 thoughtbot

--- a/app/views/workshops/_dates.html.erb
+++ b/app/views/workshops/_dates.html.erb
@@ -1,5 +1,6 @@
 <% if purchaseable.starts_immediately? %>
-  <p>Your <%= purchaseable.fulfillment_method %> workshop runs from <%= purchase_date_range(purchase) %>.</p>
+  <p><strong>Your <%= purchaseable.fulfillment_method %> workshop runs from <%= purchase_date_range(purchase) %>.</strong> The recommended pace for this workshop is one lesson per week. Feel free to progress faster if you are able.</p>
+  <p>You will know you have learned the material when you are able to rebuild the application yourself, without the help of the video lessons, or apply the concepts in the lessons to your own work.</p>
 <% elsif purchaseable.upcoming? %>
   <p>Please don't hesitate to get in touch with us at <%= mail_to 'learn@thoughtbot.com' %> should you have any questions or concerns.</p>
 <% end %>

--- a/spec/helpers/videos_helper_spec.rb
+++ b/spec/helpers/videos_helper_spec.rb
@@ -1,19 +1,5 @@
 require 'spec_helper'
 
-describe VideosHelper, '#video_availability_class' do
-  it 'returns available for videos available to a section' do
-    section = stub(starts_on: Time.zone.today)
-    video = stub(:available? => true)
-    expect(helper.video_availability_class(video, section)).to eq 'available'
-  end
-
-  it 'returns unavailable for videos available to a section' do
-    section = stub(starts_on: Time.zone.today)
-    video = stub(:available? => false)
-    expect(helper.video_availability_class(video, section)).to eq 'unavailable'
-  end
-end
-
 describe VideosHelper, '#single_video?' do
   it 'returns true for purchaseables with only one video' do
     videos = stub(size: 1)

--- a/spec/mailers/workshop_mailer_spec.rb
+++ b/spec/mailers/workshop_mailer_spec.rb
@@ -134,7 +134,7 @@ describe WorkshopMailer do
 
       expect(email.from).to eq(%w(learn@thoughtbot.com))
       expect(email).to have_subject('[Learn] Workshop name: Title')
-      expect(email).to have_body_text(/Workshop name video lesson 2, Title, is now available/)
+      expect(email).to have_body_text(/Workshop name video lesson 2, Title/)
     end
   end
 

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Videos' do
   context 'GET /' do
-    it 'indicates available videos for a workshop' do
+    it 'lists the videos for a workshop' do
       workshop = create(:workshop)
       section = create(:section, starts_on: Date.yesterday, ends_on: 1.month.from_now, workshop: workshop)
       video_one = create_available_video(workshop, 0, 'Video One')
@@ -14,15 +14,12 @@ describe 'Videos' do
       expect(page).to have_content(video_one.title)
       expect(page).to have_content(video_two.title)
       expect(page.body.index(video_one.title) < page.body.index(video_two.title)).to be
-      expect(page).to have_css('.available > a', text: video_one.title)
-      expect(page).to have_css('.unavailable > div', text: video_two.title)
-      expect(page).to have_css('.unavailable > div', text: "Starts on #{1.day.from_now.to_s(:simple)}")
 
       visit purchase_video_path(purchase, video_two)
-      expect(page).to_not have_css('iframe')
+      expect(page).to have_css('iframe')
     end
 
-    it 'indicates available videos for a product' do
+    it 'lists the videos for a product' do
       purchase = create(:video_purchase)
       video_one = create_available_video(purchase.purchaseable, 0, 'Video One')
       video_two = create_available_video(purchase.purchaseable, 0, 'Video Two')


### PR DESCRIPTION
https://www.apptrajectory.com/thoughtbot/learn/stories/15633629
The functionality that tracks the video schedule is still in place so
that we'll still email people about the videos on a schedule. We may
decide to remove that in the future based on user feedback.
