### PR TITLE
Allow mentors to see their mentees' timelines

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -18,11 +18,10 @@ class SubscriptionsController < ApplicationController
   private
 
   def assign_mentor
+    @mentor = User.find_or_sample_mentor(cookies[:mentor_id])
+
     if cookies[:mentor_id].blank?
-      @mentor = User.mentors.sample
       cookies[:mentor_id] ||= @mentor.id
-    else
-      @mentor = User.find(cookies[:mentor_id])
     end
   end
 end

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -3,6 +3,20 @@ class TimelinesController < ApplicationController
   layout 'header-only'
 
   def show
-    @timeline = Timeline.new(current_user)
+    authorize_user_viewing_timeline
+    @timeline = Timeline.new(timeline_user)
+  end
+
+  private
+
+  def authorize_user_viewing_timeline
+    if params[:user_id].present? && !current_user_is_admin?
+      flash[:error] = 'You do not have permission to view that timeline.'
+      redirect_to timeline_path
+    end
+  end
+
+  def timeline_user
+    @timeline_user = User.where(id: params[:user_id]).first || current_user
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,14 +4,11 @@ class Subscription < ActiveRecord::Base
   DOWNGRADED_PLAN = 'prime-basic'
 
   belongs_to :user
-  belongs_to :mentor, class_name: User
   belongs_to :plan
 
   delegate :includes_mentor?, to: :plan
   delegate :includes_workshops?, to: :plan
   delegate :stripe_customer_id, to: :user
-
-  validates :mentor_id, presence: true
 
   after_create :add_user_to_mailing_list
 

--- a/app/models/subscription_fulfillment.rb
+++ b/app/models/subscription_fulfillment.rb
@@ -5,9 +5,9 @@ class SubscriptionFulfillment
 
   def fulfill
     if @purchase.subscription?
+      @purchase.user.assign_mentor(mentor)
       @purchase.user.create_subscription(
         plan: @purchase.purchaseable,
-        mentor: mentor
       )
     end
   end
@@ -15,10 +15,6 @@ class SubscriptionFulfillment
   private
 
   def mentor
-    if @purchase.mentor_id.present?
-      User.find(@purchase.mentor_id)
-    else
-      User.mentors.sample
-    end
+    User.find_or_sample_mentor(@purchase.mentor_id)
   end
 end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -1,7 +1,11 @@
 class Timeline
+  attr_reader :user
+
   def initialize(user)
     @user = user
   end
+
+  delegate :name, :bio, to: :user, prefix: true
 
   def has_items?
     timeline_items.values.present?
@@ -20,8 +24,6 @@ class Timeline
   end
 
   private
-
-  attr_reader :user
 
   def null_week
     { Time.now.beginning_of_week => {} }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,8 @@ class User < ActiveRecord::Base
   has_many :completions
   has_many :notes, order: 'created_at DESC'
   has_one :subscription
-
-  delegate :mentor, to: :subscription, allow_nil: true
+  belongs_to :mentor, class_name: 'User'
+  has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
 
   validates :name, presence: true
 
@@ -48,7 +48,11 @@ class User < ActiveRecord::Base
   end
 
   def self.mentors
-    where(mentor: true)
+    where(available_to_mentor: true)
+  end
+
+  def self.find_or_sample_mentor(user_id)
+    where(id: user_id).first || mentors.sample
   end
 
   def subscription_purchases
@@ -108,6 +112,10 @@ class User < ActiveRecord::Base
     if stripe_customer
       stripe_customer['active_card']
     end
+  end
+
+  def assign_mentor(user)
+    update_attribute(:mentor_id, user.id)
   end
 
   private

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,10 +1,10 @@
 <section class="timeline">
   <section class="profile">
-    <%= image_tag gravatar_url(current_user, size: '200'), class: 'user-image' %>
+    <%= image_tag gravatar_url(@timeline.user, size: '200'), class: 'user-image' %>
     <div class="user-info">
       <p data-role="user-bio">
-        <strong><%= current_user.name %>:</strong>
-        <%= current_user.bio || 'Tell us about yourself' %>
+        <strong><%= @timeline.user_name %>:</strong>
+        <%= @timeline.user_bio || 'Tell us about yourself' %>
         &mdash;
         <%= link_to 'edit bio', my_account_path, 'data-role' => 'edit-bio' %>
       </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,7 +114,9 @@ Workshops::Application.routes.draw do
   get '/my_account' => 'users#edit', as: 'my_account'
   get '/sign_up' => 'users#new', as: 'sign_up'
   get '/sign_in' => 'sessions#new', as: 'sign_in'
-  resources :users, controller: 'users'
+  resources :users, controller: 'users' do
+    resource :timeline, only: :show
+  end
   resources :passwords, controller: 'passwords'
 
   mount Split::Dashboard, at: 'split'

--- a/db/migrate/20130822220121_move_mentor_to_users.rb
+++ b/db/migrate/20130822220121_move_mentor_to_users.rb
@@ -1,0 +1,28 @@
+class MoveMentorToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :mentor_id, :integer
+    execute <<-SQL
+      UPDATE users u
+      SET mentor_id = s.mentor_id
+      FROM subscriptions s
+      WHERE u.id = s.user_id
+    SQL
+    add_index :users, :mentor_id
+
+    remove_column :subscriptions, :mentor_id
+  end
+
+  def down
+    add_column :subscriptions, :mentor_id, :integer
+    execute <<-SQL
+      UPDATE subscriptions s
+      SET mentor_id = u.mentor_id
+      FROM users u
+      WHERE s.user_id = u.id
+    SQL
+    change_column_null :subscriptions, :mentor_id, false
+    add_index :subscriptions, :mentor_id
+
+    remove_column :users, :mentor_id
+  end
+end

--- a/db/migrate/20130826172010_rename_mentor_to_available_to_mentor.rb
+++ b/db/migrate/20130826172010_rename_mentor_to_available_to_mentor.rb
@@ -1,0 +1,5 @@
+class RenameMentorToAvailableToMentor < ActiveRecord::Migration
+  def change
+    rename_column :users, :mentor, :available_to_mentor
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130822152026) do
+ActiveRecord::Schema.define(:version => 20130826172010) do
 
   create_table "announcements", :force => true do |t|
     t.datetime "created_at",        :null => false
@@ -332,11 +332,8 @@ ActiveRecord::Schema.define(:version => 20130822152026) do
     t.date     "deactivated_on"
     t.date     "scheduled_for_cancellation_on"
     t.boolean  "paid",                          :default => true, :null => false
-    t.integer  "mentor_id",                                       :null => false
     t.integer  "plan_id",                                         :null => false
   end
-
-  add_index "subscriptions", ["mentor_id"], :name => "index_subscriptions_on_mentor_id"
 
   create_table "teachers", :force => true do |t|
     t.string   "name"
@@ -372,16 +369,16 @@ ActiveRecord::Schema.define(:version => 20130822152026) do
 
   create_table "users", :force => true do |t|
     t.string   "email"
-    t.string   "encrypted_password", :limit => 128
-    t.string   "salt",               :limit => 128
-    t.string   "confirmation_token", :limit => 128
-    t.string   "remember_token",     :limit => 128
-    t.boolean  "email_confirmed",                   :default => true,  :null => false
-    t.datetime "created_at",                                           :null => false
-    t.datetime "updated_at",                                           :null => false
-    t.string   "customer_id",                       :default => ""
-    t.string   "reference",                         :default => ""
-    t.boolean  "admin",                             :default => false, :null => false
+    t.string   "encrypted_password",  :limit => 128
+    t.string   "salt",                :limit => 128
+    t.string   "confirmation_token",  :limit => 128
+    t.string   "remember_token",      :limit => 128
+    t.boolean  "email_confirmed",                    :default => true,  :null => false
+    t.datetime "created_at",                                            :null => false
+    t.datetime "updated_at",                                            :null => false
+    t.string   "customer_id",                        :default => ""
+    t.string   "reference",                          :default => ""
+    t.boolean  "admin",                              :default => false, :null => false
     t.string   "stripe_customer_id"
     t.string   "github_username"
     t.string   "auth_provider"
@@ -394,13 +391,15 @@ ActiveRecord::Schema.define(:version => 20130822152026) do
     t.string   "zip_code"
     t.string   "country"
     t.string   "name"
-    t.boolean  "mentor",                            :default => false
+    t.boolean  "available_to_mentor",                :default => false
     t.text     "bio"
+    t.integer  "mentor_id"
   end
 
   add_index "users", ["admin"], :name => "index_users_on_admin"
   add_index "users", ["email"], :name => "index_users_on_email"
   add_index "users", ["id", "confirmation_token"], :name => "index_users_on_id_and_confirmation_token"
+  add_index "users", ["mentor_id"], :name => "index_users_on_mentor_id"
   add_index "users", ["remember_token"], :name => "index_users_on_remember_token"
 
   create_table "videos", :force => true do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -95,7 +95,7 @@ namespace :dev do
   def create_mentors
     header "Mentors"
 
-    mentor = FactoryGirl.create(:user, email: 'mentor@example.com', mentor: true)
+    mentor = FactoryGirl.create(:user, email: 'mentor@example.com', available_to_mentor: true)
     puts_user mentor, 'mentor'
 
     puts "\n"

--- a/spec/controllers/bytes_controller_spec.rb
+++ b/spec/controllers/bytes_controller_spec.rb
@@ -18,7 +18,7 @@ describe BytesController do
 
     context 'for a non-admin user' do
       before do
-        user = create(:user, subscription: Subscription.new)
+        user = create(:user, :with_subscription)
         sign_in_as user
       end
 

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -9,5 +9,24 @@ describe TimelinesController do
 
       expect(response).to redirect_to sign_in_path
     end
+
+    it 'allows an admin to view the timeline of a mentee' do
+      admin = create(:user, admin: true)
+      mentee = create(:user)
+      sign_in_as(admin)
+
+      get :show, user_id: mentee
+
+      expect(response).to be_success
+    end
+
+    it 'shows the timeline for the current user if no user id is available' do
+      user = create(:user)
+      sign_in_as(user)
+
+      get :show
+
+      expect(response).to be_success
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -304,6 +304,7 @@ FactoryGirl.define do
     end
 
     trait :with_subscription do
+      with_mentor
       with_github
       stripe_customer_id 'cus12345'
 
@@ -311,12 +312,15 @@ FactoryGirl.define do
         create(:subscription, user: instance)
       end
     end
+
+    trait :with_mentor do
+      association :mentor, factory: :user
+    end
   end
 
   factory :subscription, aliases: [:active_subscription] do
-    association :mentor, factory: :user
     association :plan
-    association :user, :with_github, :with_stripe
+    association :user, :with_github, :with_stripe, :with_mentor
     factory :inactive_subscription do
       deactivated_on Time.zone.today
     end

--- a/spec/models/subscription_fulfillment_spec.rb
+++ b/spec/models/subscription_fulfillment_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe SubscriptionFulfillment do
   describe 'fulfill' do
     it 'adds a subscription to the user for a subscription purchase' do
+      create_mentors
       user = create(:user)
       purchase = build(:plan_purchase, user: user)
 
@@ -27,14 +28,15 @@ describe SubscriptionFulfillment do
 
     it 'assigns a mentor on creation' do
       create_mentors
+      mentor = User.mentors.first
       user = create(:user)
-      purchase = build(:plan_purchase, user: user)
+      purchase = build(:plan_purchase, user: user, mentor_id: mentor.id)
 
       expect(user.subscription).to be_nil
 
       SubscriptionFulfillment.new(purchase).fulfill
 
-      expect(user.subscription.mentor).not_to be_nil
+      expect(user.mentor).not_to be_nil
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Subscription do
   it { should delegate(:stripe_customer_id).to(:user) }
-  it { should belong_to(:mentor) }
 
   it 'defaults paid to true' do
     Subscription.new.should be_paid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,8 @@ describe User do
     it { should have_many(:purchases) }
     it { should have_many(:completions) }
     it { should have_many(:notes).order('created_at DESC') }
+    it { should belong_to(:mentor).class_name('User') }
+    it { should have_many(:mentees).class_name('User') }
   end
 
   context "validations" do
@@ -269,27 +271,38 @@ describe User do
     end
   end
 
-  describe '#mentor' do
-    it "returns the subscription's mentor" do
-      user = create(:user, :with_subscription)
-
-      expect(user.mentor).to eq user.subscription.mentor
-    end
-
-    it 'is nil if the user does not have a subscription' do
-      user = create(:user)
-
-      expect(user.mentor).to be_nil
-    end
-  end
-
-  describe 'self.mentors' do
+  describe '.mentors' do
     it 'includes only mentors' do
       user = create(:user)
-      mentor = create(:user, mentor: true)
+      mentor = create(:user, available_to_mentor: true)
 
       expect(User.mentors).to include mentor
       expect(User.mentors).not_to include user
+    end
+  end
+
+  describe '#assign_mentor' do
+    it 'sets the given user as the mentor' do
+      mentee = create(:user)
+      mentor = create(:user, available_to_mentor: true)
+
+      mentee.assign_mentor(mentor)
+
+      expect(mentee.mentor).not_to be_nil
+    end
+  end
+
+  describe '.find_or_sample_mentor' do
+    it 'returns a mentor for the given id' do
+      mentor = create(:user)
+
+      expect(User.find_or_sample_mentor(mentor.id)).to eq mentor
+    end
+
+    it 'returns a random mentor if one cannot be found with the given id' do
+      mentor = create(:user, available_to_mentor: true)
+
+      expect(User.find_or_sample_mentor(nil)).to eq mentor
     end
   end
 end

--- a/spec/requests/visitor_creates_subscription_spec.rb
+++ b/spec/requests/visitor_creates_subscription_spec.rb
@@ -11,8 +11,8 @@ feature 'Visitor is asked to create a user before subscription' do
   end
 
   scenario 'visitor subscribes and is assigned a mentor' do
-    create(:user, name: 'Chad Pytel', mentor: true)
-    create(:user, name: 'Ben Orenstein', mentor: true)
+    create(:user, name: 'Chad Pytel', available_to_mentor: true)
+    create(:user, name: 'Ben Orenstein', available_to_mentor: true)
 
     visit prime_path
     click_landing_page_call_to_action

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -13,6 +13,6 @@ module Subscriptions
   end
 
   def create_mentors
-    create(:user, mentor: true)
+    create(:user, available_to_mentor: true)
   end
 end


### PR DESCRIPTION
- A mentor may now view their mentees' timelines by visiting
  `/users/:user_id/timeline` where `:user_id` is their mentee's id
- The mentor/mentee relationship is now represented as associations on the User
  model instead of having to rely on Subscription. This also means that the
  `mentor` attribute on User has to be renamed to `available_to_mentor` to avoid
  conflicts with the association.
- Finding, sampling, or assigning mentors are all done via User methods.
