### PR TITLE
Redirect users to dashboard after signin

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,7 +1,7 @@
 class PurchasesController < ApplicationController
   def new
     if current_user_purchase_is_free?
-      redirect_to subscriber_purchase_url
+      redirect_to products_or_subscriber_purchase_url
     else
       @purchase = build_purchase_with_defaults
     end
@@ -45,13 +45,21 @@ class PurchasesController < ApplicationController
 
   private
 
+  def products_or_subscriber_purchase_url
+    if plan_purchase?
+      products_path
+    else
+      subscriber_purchase_url
+    end
+  end
+
   def current_user_purchase_is_free?
-    current_user_has_active_subscription? && included_in_subscription?
+    current_user_has_active_subscription? &&
+      (plan_purchase? || included_in_subscription?)
   end
 
   def included_in_subscription?
-    !plan_purchase? &&
-      (!workshop_purchase? || (workshop_purchase? && subscription_includes_workshops?))
+    !workshop_purchase? || (workshop_purchase? && subscription_includes_workshops?)
   end
 
   def plan_purchase?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < Clearance::SessionsController
     if current_user.admin?
       admin_path
     else
-      my_account_path
+      products_path
     end
   end
 end

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -8,7 +8,7 @@ Feature: Signing in
     And I fill in the session email with "ralph@example.com"
     And I fill in the session password with "ralph_was_here"
     And I press the button to sign in
-    Then I should be on my account page
+    Then I should be on my dashboard
 
   Scenario: Admin Signing in
     Given the following admin exists:

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -7,6 +7,8 @@ module NavigationHelpers
       "/?#{$2}=#{$1}"
     when 'my account page'
       my_account_path
+    when 'my dashboard'
+      products_path
     when 'the workshops json page'
       workshops_path(format: :json)
     when /the workshops json page with the callback "([^"]+)"/

--- a/features/user/view_account.feature
+++ b/features/user/view_account.feature
@@ -4,6 +4,7 @@ Feature: Viewing my own account information
     Given I have signed up with "user@example.com"
     And I have 3 paid purchases
     When I sign in with "user@example.com"
+    And I visit my profile
     Then I should see the edit account form
     And I should see "Your purchases"
     And I should see my 3 purchases
@@ -45,6 +46,7 @@ Feature: Viewing my own account information
   Scenario: Edit my account information
     Given I have signed up with "user@example.com"
     And I sign in with "user@example.com"
+    And I visit my profile
     When I fill in "Github username" with "dhh"
     And I press "Update account"
     Then "Github username" should be filled in with "dhh"

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -17,14 +17,14 @@ describe PurchasesController do
     end
   end
 
-  describe '#new when purchasing a plan as a user with and active subscription' do
+  describe '#new when purchasing a plan as a user with an active subscription' do
     it 'renders a subscriber-specific layout' do
       user = create(:user, :with_subscription)
       stub_current_user_with(user)
 
       get :new, plan_id: user.subscription.plan
 
-      expect(response).to render_template 'new'
+      expect(response).to redirect_to products_path
     end
   end
 


### PR DESCRIPTION
- If the user is purchasing a plan but already has a subscription, he/she will
  be redirected to the dashboard.
- If the user is purchasing a product other than a plan, he/she will be
  redirected back to the purchase form after login.
- If the user is just signing in, they'll be redirected to the dashboard.
