### PR TITLE
Change existing purchases from Plan to Individual Plan

### DIFF
--- a/db/migrate/20130906183616_change_plan_to_individual_plan_in_purchases.rb
+++ b/db/migrate/20130906183616_change_plan_to_individual_plan_in_purchases.rb
@@ -1,0 +1,17 @@
+class ChangePlanToIndividualPlanInPurchases < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      UPDATE purchases
+      SET purchaseable_type = 'IndividualPlan'
+      WHERE purchaseable_type = 'Plan'
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE purchases
+      SET purchaseable_type = 'Plan'
+      WHERE purchaseable_type = 'IndividualPlan'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130904175521) do
+ActiveRecord::Schema.define(:version => 20130906183616) do
 
   create_table "announcements", :force => true do |t|
     t.datetime "created_at",        :null => false
@@ -327,14 +327,14 @@ ActiveRecord::Schema.define(:version => 20130904175521) do
 
   create_table "subscriptions", :force => true do |t|
     t.integer  "user_id"
-    t.datetime "created_at",                                      :null => false
-    t.datetime "updated_at",                                      :null => false
+    t.datetime "created_at",                                                  :null => false
+    t.datetime "updated_at",                                                  :null => false
     t.date     "deactivated_on"
     t.date     "scheduled_for_cancellation_on"
-    t.boolean  "paid",                          :default => true, :null => false
-    t.integer  "plan_id",                                         :null => false
+    t.boolean  "paid",                          :default => true,             :null => false
+    t.integer  "plan_id",                                                     :null => false
     t.integer  "team_id"
-    t.string   "plan_type",                                       :null => false
+    t.string   "plan_type",                     :default => "IndividualPlan", :null => false
   end
 
   create_table "teachers", :force => true do |t|


### PR DESCRIPTION
For https://www.apptrajectory.com/thoughtbot/learn/stories/15634155.

Settings/My Account page errors out (on staging) for any users who have subscribed to the individual plan for Prime. This is because we did not change `purchaseable_type` to 'IndividualPlan' from 'Plan'.
