### PR TITLE
Exclude subscriptions from your purchases

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,10 @@ class User < ActiveRecord::Base
     paid_purchases.where(payment_method: 'subscription')
   end
 
+  def paid_products
+    paid_purchases.where("purchaseable_type != 'IndividualPlan'")
+  end
+
   def promote_thoughtbot_employee_to_admin
     client = Octokit::Client.new(login: GITHUB_USER, password: GITHUB_PASSWORD)
     if client.team_member?(THOUGHTBOT_TEAM_ID, github_username)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -27,7 +27,7 @@
 <aside id="account-sidebar">
   <% if current_user.subscription %>
     <h3>Your subscription</h3>
-    <ol class="purchases">
+    <ol class="subscription">
       <%= render current_user.subscription %>
     </ol>
   <% end %>
@@ -35,7 +35,7 @@
   <% if current_user.has_purchased? %>
     <h3>Your purchases</h3>
     <ol class="purchases">
-      <%= render current_user.paid_purchases %>
+      <%= render current_user.paid_products %>
     </ol>
   <% end %>
 </aside>

--- a/features/step_definitions/github_steps.rb
+++ b/features/step_definitions/github_steps.rb
@@ -1,5 +1,5 @@
 Given /^github is stubbed$/ do
-  stub_request(:put, 'https://api.github.com/teams/9999/members/cpytel').
+  stub_request(:put, 'https://api.github.com/teams/516450/members/thoughtbot').
     to_return(:status => 200, :body => '', :headers => {})
   stub_request(:get, 'https://api.github.com/teams/3675/members/thoughtbot').
     to_return(:status => 404, :body => '', :headers => {})

--- a/features/step_definitions/stripe_steps.rb
+++ b/features/step_definitions/stripe_steps.rb
@@ -7,6 +7,10 @@ Given 'I have an existing credit card' do
   Stripe::Customer.stubs(:retrieve).returns({"active_card" => {"last4" => "1234", "type" => "Visa"}})
 end
 
+When 'I remove my credit card' do
+  Stripe::Customer.unstub(:retrieve)
+end
+
 When 'I pay using Stripe' do
   page.execute_script <<-JS
     var form$ = $("#new_purchase");

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -6,11 +6,21 @@ Given /^I have (\d+) paid purchases$/ do |count|
   end
 end
 
+Given /^I have a prime subscription$/ do
+  step 'github is stubbed'
+
+  user = User.last
+  user.update_attributes(github_username: 'thoughtbot')
+  mentor = create(:user)
+
+  create(:plan_purchase, user: user, mentor_id: mentor.id)
+end
+
 Then /^I should see the edit account form$/ do
   page.should have_selector('form.formtastic.user')
 end
 
-Then /^I should see my (\d+) (workshops|purchases)$/ do |count, type|
+Then /^I should see my (\d+) (workshops|purchases|subscription)$/ do |count, type|
   page.should have_css("ol.#{type} li", count: count.to_i)
 end
 

--- a/features/user/purchase_product.feature
+++ b/features/user/purchase_product.feature
@@ -41,3 +41,4 @@ Feature: Purchase a Product
     Then I should see a purchase price of "$15"
     When I pay with existing credit card
     Then I should see "Thank you"
+    And I remove my credit card

--- a/features/user/view_account.feature
+++ b/features/user/view_account.feature
@@ -3,11 +3,14 @@ Feature: Viewing my own account information
   Scenario: View my account information
     Given I have signed up with "user@example.com"
     And I have 3 paid purchases
+    And I have a prime subscription
     When I sign in with "user@example.com"
     And I visit my profile
     Then I should see the edit account form
     And I should see "Your purchases"
     And I should see my 3 purchases
+    And I should see "Your subscription"
+    And I should see my 1 subscription
 
   Scenario: View my account information with no purchases or workshops
     Given I have signed up with "user@example.com"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -219,6 +219,12 @@ FactoryGirl.define do
     factory :plan_purchase do
       association :purchaseable, factory: :plan
       association :user, :with_stripe, :with_mentor, :with_github
+
+      before(:create) do |purchase|
+        if purchase.user.mentor
+          purchase.mentor_id = purchase.user.mentor.id
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -256,6 +256,16 @@ describe User do
     end
   end
 
+  describe '#paid_products' do
+    it 'includes purchased products with no subscription plans' do
+      user = create(:user, :with_mentor, :with_github)
+      book_purchase = create(:book_purchase, user: user)
+      prime_plan = create(:plan_purchase, user: user)
+
+      expect(user.paid_products).to eq [book_purchase]
+    end
+  end
+
   describe '#credit_card' do
     it 'returns nil if there is no stripe_customer_id' do
       user = create(:user, stripe_customer_id: nil)


### PR DESCRIPTION
https://www.apptrajectory.com/thoughtbot/learn/stories/15635095

Subscriptions should not be included among "Your Purchases" as they are
already called out above under "Your subscription".
- In SubscriptionFulfillment it attempts to assign a mentor from the
  purchase's mentor_id. The factory for plan_purchase has been updated
  to set that mentor_id up for future use by User#assign_mentor
- The app was attempting to PUT to `/teams/:team_id/members` in
  FakeGithub but was failing - this adds that route to the fake
  service and stubs the same request in cucumber
- Rm stub on Stripe::Customer @ end of scenario
  This stub was leaking over into subsequent features that was looking to
  send messages to an instance of Stripe::Customer, not a hash (which is what
  is being returned here).
