### PR TITLE
Update location of AdWords conversion tracker

### DIFF
--- a/app/helpers/adwords_helper.rb
+++ b/app/helpers/adwords_helper.rb
@@ -16,7 +16,7 @@ module AdwordsHelper
         </script>
         <noscript>
         <div style="display:inline;">
-        <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/983769411/?value=#{flash[:purchase_paid_price]}&amp;label=h6fpCI3R6QkQw8KM1QM&amp;guid=ON&amp;script=0"/>
+        <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/983769411/?value=#{flash[:purchase_paid_price]}&label=h6fpCI3R6QkQw8KM1QM&guid=ON&script=0"/>
         </div>
         </noscript>
       JS

--- a/app/views/books/book_purchase_show.html.erb
+++ b/app/views/books/book_purchase_show.html.erb
@@ -1,7 +1,6 @@
 <% content_for :subject_block do %>
   <h1><%= @purchaseable.name %></h1>
 <% end %>
-<%= adwords_conversion_tracker(flash[:purchase_paid_price]) %>
 
 <div class="text-box-wrapper">
   <div class="text-box">

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -5,5 +5,9 @@
         <%= flash[key] %>
       </div>
     <% end -%>
+
+   <% if flash[:purchase_paid_price] %>
+     <%= adwords_conversion_tracker(flash[:purchase_paid_price]) %>
+   <% end %>
   </div>
 <% end %>

--- a/app/views/subscriptions/subscription_purchase_show.html.erb
+++ b/app/views/subscriptions/subscription_purchase_show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :subject, @purchaseable.name %>
-<%= adwords_conversion_tracker(flash[:purchase_paid_price]) %>
 
 <div class="text-box-wrapper">
   <div class="text-box">

--- a/app/views/videos/video_purchase_show.html.erb
+++ b/app/views/videos/video_purchase_show.html.erb
@@ -9,7 +9,6 @@
     <% end %>
   </h2>
 <% end %>
-<%= adwords_conversion_tracker(flash[:purchase_paid_price]) %>
 
 <div class="text-box-wrapper">
   <div class="text-box">

--- a/app/views/workshops/workshop_purchase_show.html.erb
+++ b/app/views/workshops/workshop_purchase_show.html.erb
@@ -6,7 +6,6 @@
     <h2 class="tagline">Watch or download video lessons, <%= pluralize @purchaseable.videos.size, 'lesson' %> in this workshop.</h2>
   <% end %>
 <% end %>
-<%= adwords_conversion_tracker(flash[:purchase_paid_price]) %>
 
 <div class="text-box-wrapper">
   <section class="text-box" id="videos">


### PR DESCRIPTION
What I most want to track is when someone subscribes to Prime. That was not
being tracked before.

This new implementation placing the tracker next to the flashes allows more
flexibility where as long as flash[:paid_purchase_price] is set, the flash
will show on the next redirection.

https://www.apptrajectory.com/thoughtbot/learn/stories/15636628
