### PR TITLE
Enable asset and controller response compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'unicorn'
 gem 'sass-rails', '4.0.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'uglifier', '1.3.0'
+gem 'heroku-deflater'
 
 group :development do
   gem 'hirb', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     haml (4.0.3)
       tilt
     hashie (2.0.5)
+    heroku-deflater (0.5.2)
+      rack (>= 1.4.5)
     hike (1.2.3)
     hirb (0.6.2)
     httparty (0.8.1)
@@ -455,6 +457,7 @@ DEPENDENCIES
   formtastic (= 2.2.0)
   gibbon (= 0.4.6)
   gravatarify (~> 3.1.0)
+  heroku-deflater
   high_voltage!
   hirb (= 0.6.2)
   httparty (= 0.8.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,15 @@ Workshops::Application.configure do
   config.assets.digest = true
   config.assets.js_compressor = :uglifier
   config.assets.precompile += %w( print.css prefilled_input.js )
-  config.serve_static_assets = false
+
+  # Serve static assets, which allows us to populate the CDN with compressed
+  # assets if a client supports them
+  config.serve_static_assets = true
+
+  # Fiddling with expires values is kind of pointless as we use hashing to bust
+  # caches during redeploys, but it should bump up our google pagespeed
+  # ranking.
+  config.static_cache_control = 'public, max-age=31536000'
 
   config.eager_load = true
   config.cache_store = :dalli_store

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,7 +10,15 @@ Workshops::Application.configure do
   config.assets.digest = true
   config.assets.js_compressor = :uglifier
   config.assets.precompile += %w( print.css prefilled_input.js )
-  config.serve_static_assets = false
+
+  # Serve static assets, which allows us to populate the CDN with compressed
+  # assets if a client supports them via Heroku::Deflater
+  config.serve_static_assets = true
+
+  # Fiddling with expires values is kind of pointless as we use hashing to bust
+  # caches during redeploys, but it should bump up our google pagespeed
+  # ranking.
+  config.static_cache_control = 'public, max-age=31536000'
 
   config.eager_load = true
   config.cache_store = :dalli_store

--- a/spec/requests/content_compression_spec.rb
+++ b/spec/requests/content_compression_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+feature "A visitor visits the home page" do
+
+  scenario "a visitor has a browser that supports compression" do
+    ['deflate','gzip', 'deflate,gzip','gzip,deflate'].each do|compression_method|
+      get root_path, {}, {'HTTP_ACCEPT_ENCODING' => compression_method }
+      response.headers['Content-Encoding'].should be
+    end
+  end
+
+  scenario "a visitor's browser does not support compression" do
+    get root_path
+    response.headers['Content-Encoding'].should_not be
+  end
+
+end


### PR DESCRIPTION
Use heroku_deflater to compress controller-generated responses and assets,
which allows us populate the cloudfront origin servers correctly with
compressed assets.

Preliminary results show around a 20% increase in pagespeed rank for desktop
clients.
