### PR TITLE
Bring back the old section URLs.

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,0 +1,6 @@
+class SectionsController < ApplicationController
+  def show
+    section = Section.find(params[:id])
+    redirect_to section.workshop
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Workshops::Application.routes.draw do
 
   resource :session, controller: 'sessions'
 
-  resources :sections, only: [] do
+  resources :sections, only: [:show] do
     resources :purchases, only: [:new, :create]
     resources :redemptions, only: [:new]
   end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe SectionsController do
+  context 'show' do
+    it 'redirects to the workshop associated with the section' do
+      workshop = create(:workshop, name: 'Learn to fly')
+      section = create(:section, workshop: workshop)
+
+      get :show, id: section
+
+      expect(response).to redirect_to workshop_path(workshop)
+    end
+  end
+end


### PR DESCRIPTION
Redirects /sections/:id to the section's associated workshop.

There are various links around to /sections/:id (e.g. in many of our blog posts about workshops), and cool URIs don't change.
