### PR TITLE
Increase capybara wait time

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ Capybara.javascript_driver = :webkit
 Capybara.configure do |config|
   config.match = :prefer_exact
   config.ignore_hidden_elements = false
+  config.default_wait_time = 4
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
I'm hoping this will fix the intermittent failure described here: https://www.apptrajectory.com/thoughtbot/learn/stories/15637153

My suspicion is that the javascript call to Stripe hasn't finished, leading to the js error we see. I hope that increasing the time that capybara waits (from 2 seconds (default), to 4) will allow that call to finish.

This won't impact test-run speeds since Capybara only waits the full time period when the expected elements never appear.
