### PR TITLE
Move widget into controller

### DIFF
--- a/app/controllers/widgets/total_cancellations_controller.rb
+++ b/app/controllers/widgets/total_cancellations_controller.rb
@@ -1,0 +1,12 @@
+class Widgets::TotalCancellationsController < WidgetController
+  def show
+    respond_with number_widget(total_cancellations)
+  end
+
+  private
+
+  def total_cancellations
+    Metrics.new.canceled_subscriptions_since(30.days.ago)
+  end
+
+end

--- a/app/widgets/total_cancellations_last_30_days.rb
+++ b/app/widgets/total_cancellations_last_30_days.rb
@@ -1,7 +1,0 @@
-widget :total_cancellations_last_30_days do
-  key ENV['WIDGETS_API_KEY']
-  type "number_and_secondary"
-  data do
-    { value: Metrics.new.canceled_subscriptions_since(30.days.ago.to_date).count }
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Workshops::Application.routes.draw do
       route.resource :plan_ltv
       route.resource :plan_subscriber_count
       route.resource :projected_monthly_revenue
+      route.resource :total_cancellations
       route.resource :total_churn
       route.resource :total_new_subscriber_count
       route.resource :total_subscriber_count

--- a/spec/controllers/widgets/total_cancellations_controller_spec.rb
+++ b/spec/controllers/widgets/total_cancellations_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Widgets::TotalCancellationsController do
+  it 'returns the total number of cancellations' do
+    metrics_instance = stub(canceled_subscriptions_since: 10)
+    Metrics.stubs(new: metrics_instance)
+
+    get :show, format: :json
+
+    expect(number_widget_first_value).to eq 10
+  end
+
+end


### PR DESCRIPTION
- This widget was trying to use the chameleon gem, which was removed in
  an earlier commit. No tests failed, because no integration tests actually hit the endpoint. I've added controller tests to cover this.
