### PR TITLE
Add instructions for configuring Stripe

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -8,8 +8,11 @@ PAYPAL_SIGNATURE=signature
 AIRBRAKE_API_KEY=api_key
 KISSMETRICS_API_KEY=api_key
 SPIT_DASHBOARD_PASSWORD=password
-STRIPE_API_KEY=api_key
-STRIPE_PUBLIC_KEY=public_key
 WISTIA_API_KEY=api_key
 WIDGETS_API_KEY=api_key
 COVERAGE=true
+
+# Visit https://manage.stripe.com/account/apikeys
+# Fill in the Test Secret Key and Test Publishable key below
+STRIPE_API_KEY=api_key
+STRIPE_PUBLIC_KEY=public_key

--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ All new code should follow these rules. If you make changes in a pre-existing fi
 
         $ bin/setup
 
-6. Start your Redis server.
+6. Follow instructions in .env to configure Stripe.
+
+        $ vim .env
+
+7. Start your Redis server.
 
         $ redis-server
 
-7. Start Foreman.
+8. Start Foreman.
 
         $ foreman start
 
-8. Verify that the app is up and running.
+9. Verify that the app is up and running.
 
         $ open http://localhost:5000
 


### PR DESCRIPTION
- The default setup results in an error when purchasing in dev
- STRIPE_API_KEY and STRIPE_PUBLIC_KEY require valid test values
