### PR TITLE
Add a route for learn live

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,7 +143,7 @@ Workshops::Application.routes.draw do
   get '/geocodingonrails' => redirect('/products/22-geocoding-on-rails')
   get '/5by5' => redirect('/workshops/19-design-for-developers?utm_source=5by5')
   get '/rubyist-booster-shot' => "pages#show", as: :rubyist_booster_shot, id: "rubyist-booster-shot"
-  get '/live' => redirect('https://thoughtbot.campfirenow.com/7fd76')
+  get '/live' => redirect(ENV['CHAT_LINK'])
 
   patch '/my_account' => 'users#update', as: 'edit_my_account'
   get '/my_account' => 'users#edit', as: 'my_account'


### PR DESCRIPTION
New route redirects to the campfire room because https://learn.thoughtbot.com/live is easier to remember than https://thoughtbot.campfirenow.com/7fd76
