### PR TITLE
Fix screencast order regression from recent refactoring

### DIFF
--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -14,6 +14,6 @@ class Catalog
   end
 
   def screencasts
-    Screencast.active.ordered
+    Screencast.active.newest_first
   end
 end

--- a/spec/models/catalog_spec.rb
+++ b/spec/models/catalog_spec.rb
@@ -27,7 +27,8 @@ describe Catalog do
   describe '#screencasts' do
     it 'returns active screencasts with the most recent first' do
       catalog = Catalog.new
-      expect(catalog.screencasts).to find_relation(Screencast.active.ordered)
+      expect(catalog.screencasts).
+        to find_relation(Screencast.active.newest_first)
     end
   end
 


### PR DESCRIPTION
- Extraction changed order from newest first to alphabetical
- Fix to use newest first order

Regression caused by:

```
commit 54d50fda9b86798bc57a29f23c7e41c96ca6accd
```

   Author: Joe Ferris jferris@thoughtbot.com
   Date:   Wed Dec 18 13:41:14 2013 -0500

```
Extract Catalog class from ApplicationController methods
```
