### PR TITLE
Use memory cache store in tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,6 +53,9 @@ Workshops::Application.configure do
   config.serve_static_assets  = true
   config.static_cache_control = "public, max-age=3600"
 
+  # Use memory cache to avoid errors when running tests in parallel
+  config.cache_store = :memory_store
+
   HOST = 'www.example.com'
   config.action_mailer.default_url_options = { host: HOST }
 


### PR DESCRIPTION
- File store causes errors with parallel tests
- Tests run in parallel on TDDium
