### PR TITLE
Fix error on subscribe/unsubscribe mailing list

### DIFF
--- a/app/jobs/mailchimp_fulfillment_job.rb
+++ b/app/jobs/mailchimp_fulfillment_job.rb
@@ -3,15 +3,32 @@ class MailchimpFulfillmentJob < MailchimpJob
 
   def perform
     lists = client.lists(filters: { list_name: list_name })
-    subscribe(lists['data'].first['id'], email)
-    subscribe(MASTER_LIST_ID, email)
+
+    if lists['total'] > 0
+      subscribe(lists['data'].first['id'])
+    else
+      notify_about_missing_list
+    end
+
+    subscribe(MASTER_LIST_ID)
   end
 
   private
 
-  def subscribe(list_id, email)
+  def subscribe(list_id)
     rescue_email_errors do
       client.list_subscribe(id: list_id, email_address: email, double_optin: false)
     end
+  end
+
+  def notify_about_missing_list
+    Airbrake.notify_or_ignore({
+      error_message: "Missing Mailchimp mailing list: #{list_name}",
+      error_class: 'MailchimpError',
+      parameters: {
+        list_name: list_name,
+        subscriber_email: email
+      }
+    })
   end
 end

--- a/app/jobs/mailchimp_removal_job.rb
+++ b/app/jobs/mailchimp_removal_job.rb
@@ -2,7 +2,10 @@ class MailchimpRemovalJob < MailchimpJob
   def perform
     rescue_email_errors do
       lists = client.lists(filters: { list_name: list_name })
-      client.list_unsubscribe(id: lists['data'].first['id'], email_address: email)
+
+      if lists['total'] > 0
+        client.list_unsubscribe(id: lists['data'].first['id'], email_address: email)
+      end
     end
   end
 end

--- a/spec/jobs/mailchimp_fulfillment_job_spec.rb
+++ b/spec/jobs/mailchimp_fulfillment_job_spec.rb
@@ -13,4 +13,13 @@ describe MailchimpFulfillmentJob do
     expect(master_list).to include 'user@example.com'
     expect(FakeMailchimp.lists['product']).to include 'user@example.com'
   end
+
+  it 'notifies Airbrake if the mailing list is missing' do
+    Gibbon.stubs new: stub(lists: {"total"=>0, "data"=>[]}, list_subscribe: true)
+    Airbrake.stubs(:notify_or_ignore)
+
+    MailchimpFulfillmentJob.new('product', 'user@example.com').perform
+
+    expect(Airbrake).to have_received(:notify_or_ignore)
+  end
 end

--- a/spec/jobs/mailchimp_removal_job_spec.rb
+++ b/spec/jobs/mailchimp_removal_job_spec.rb
@@ -9,4 +9,10 @@ describe MailchimpRemovalJob do
 
     expect(FakeMailchimp.lists['product']).not_to include 'user@example.com'
   end
+
+  it 'silently fail if the mailing list is missing' do
+    Gibbon.stubs new: stub(lists: {"total"=>0, "data"=>[]})
+
+    expect { MailchimpRemovalJob.new('product', 'user@example.com').perform }.not_to raise_error
+  end
 end


### PR DESCRIPTION
- Notify Airbrake if user subscribes to a non-existence list.
- Silently ignore if user unsubscribes from a non-existence list.

https://www.apptrajectory.com/thoughtbot/learn/stories/15638060
