### PR TITLE
We need to be able to make mentors unavailable

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -7,11 +7,11 @@ class Mentor < ActiveRecord::Base
   delegate :name, :first_name, :email, :github_username, :bio, to: :user
 
   def self.featured
-    all.sample(NUMBER_OF_MENTORS_TO_FEATURE)
+    accepting_new_mentees.sample(NUMBER_OF_MENTORS_TO_FEATURE)
   end
 
   def self.find_or_sample(mentor_id)
-    where(id: mentor_id).first || all.sample
+    where(id: mentor_id).first || accepting_new_mentees.sample
   end
 
   def active_mentees
@@ -22,5 +22,11 @@ class Mentor < ActiveRecord::Base
 
   def active_mentee_count
     active_mentees.count
+  end
+
+  private
+
+  def self.accepting_new_mentees
+    where(accepting_new_mentees: true)
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -41,6 +41,7 @@ RailsAdmin.config do |config|
   config.model Mentor do
     list do
       field :name
+      field :available
       field :active_mentee_count do
         label 'Mentees'
       end
@@ -49,6 +50,7 @@ RailsAdmin.config do |config|
 
     show do
       field :user
+      field :available
       field :availability
       field :active_mentees do
         pretty_value do
@@ -65,6 +67,7 @@ RailsAdmin.config do |config|
 
     edit do
       field :user
+      field :available
       field :availability
     end
   end

--- a/db/migrate/20131227145412_add_available_flag_to_mentors.rb
+++ b/db/migrate/20131227145412_add_available_flag_to_mentors.rb
@@ -1,0 +1,5 @@
+class AddAvailableFlagToMentors < ActiveRecord::Migration
+  def change
+    add_column :mentors, :accepting_new_mentees, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131226142103) do
+ActiveRecord::Schema.define(version: 20131227145412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,9 @@ ActiveRecord::Schema.define(version: 20131226142103) do
   end
 
   create_table "mentors", force: true do |t|
-    t.integer "user_id",                                         null: false
-    t.string  "availability", default: "11am to 5pm on Fridays", null: false
+    t.integer "user_id",                                                  null: false
+    t.string  "availability",          default: "11am to 5pm on Fridays", null: false
+    t.boolean "accepting_new_mentees", default: true,                     null: false
   end
 
   add_index "mentors", ["user_id"], name: "index_mentors_on_user_id", using: :btree

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -6,7 +6,7 @@ describe Mentor do
   describe '.featured' do
     it 'executes queries on the relation' do
       mentors = stub('mentors', :sample)
-      Mentor.stubs(all: mentors)
+      Mentor.stubs(accepting_new_mentees: mentors)
 
       Mentor.featured
 
@@ -25,6 +25,12 @@ describe Mentor do
       mentor = create(:mentor)
 
       expect(Mentor.find_or_sample(nil)).to eq mentor
+    end
+
+    it 'does not return unavailable mentors when sampling' do
+      create(:mentor, accepting_new_mentees: false)
+
+      expect(Mentor.find_or_sample(nil)).to be_nil
     end
   end
 


### PR DESCRIPTION
I realized this morning that Ben and Myself had been set to
`available_to_mentor: false`, and we were not carried over to the new Mentor
records because of that.

However, there are still paying customers who have us as their mentor, and
someone who has us would not get an error because we had no mentor record.

So this add a boolean to to indicate whether a Mentor is available for new
mentees and uses it in the right places.
