### PR TITLE
Don't call the basic plan "downgraded"

### DIFF
--- a/app/controllers/subscriber/cancellations_controller.rb
+++ b/app/controllers/subscriber/cancellations_controller.rb
@@ -2,12 +2,21 @@ class Subscriber::CancellationsController < ApplicationController
   before_filter :authorize
 
   def new
+    @cancellation = build_cancellation
   end
 
   def create
-    cancellation = Cancellation.new(current_user.subscription)
+    cancellation = build_cancellation
     cancellation.schedule
-    redirect_to my_account_path,
+    redirect_to(
+      my_account_path,
       notice: t('subscriptions.flashes.cancel.success')
+    )
+  end
+
+  private
+
+  def build_cancellation
+    Cancellation.new(current_user.subscription)
   end
 end

--- a/app/controllers/subscriber/downgrades_controller.rb
+++ b/app/controllers/subscriber/downgrades_controller.rb
@@ -1,6 +1,6 @@
 class Subscriber::DowngradesController < ApplicationController
   def create
-    current_user.subscription.change_plan(IndividualPlan.downgraded)
+    Cancellation.new(current_user.subscription).downgrade
     redirect_to my_account_path,
       notice: t('subscriptions.flashes.downgrade.success')
   end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -16,6 +16,22 @@ class Cancellation
     deliver_unsubscription_survey
   end
 
+  def can_downgrade_instead?
+    !downgraded?
+  end
+
+  def downgrade_plan
+    IndividualPlan.basic
+  end
+
+  def subscribed_plan
+    @subscription.plan
+  end
+
+  def downgrade
+    @subscription.change_plan(IndividualPlan.basic)
+  end
+
   private
 
   def deliver_unsubscription_survey
@@ -27,5 +43,9 @@ class Cancellation
       :scheduled_for_cancellation_on,
       Time.zone.at(stripe_customer.subscription.current_period_end)
     )
+  end
+
+  def downgraded?
+    @subscription.plan == downgrade_plan
   end
 end

--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -22,7 +22,7 @@ class IndividualPlan < ActiveRecord::Base
     active.featured.ordered.first
   end
 
-  def self.downgraded
+  def self.basic
     where(sku: PRIME_BASIC_SKU).first
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -54,10 +54,6 @@ class Subscription < ActiveRecord::Base
     save!
   end
 
-  def downgraded?
-    plan == IndividualPlan.downgraded
-  end
-
   def deliver_welcome_email
     if includes_mentor?
       SubscriptionMailer.welcome_to_prime_from_mentor(user).deliver

--- a/app/views/subscriber/cancellations/new.html.erb
+++ b/app/views/subscriber/cancellations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="text-box-wrapper solo cancellation-discount">
   <article>
-    <% if !current_user.subscription.downgraded? %>
+    <% if @cancellation.can_downgrade_instead? %>
       <p>
         We're sorry to hear you want to cancel. Before we remove the
         subscription from your account, we want to make sure you know about the
@@ -8,8 +8,8 @@
         <%= t('shared.subscription.name') %> except for a mentor and workshops.
         You still get books, screencasts, office hours, the forum, and you'll
         also continue to have access to the workshops you've already taken, for
-        <%= individual_price_per_month(IndividualPlan.downgraded) %> instead of
-        <%= individual_price_per_month(current_user.subscription.plan) %>.
+        <%= individual_price_per_month(@cancellation.downgrade_plan) %> instead of
+        <%= individual_price_per_month(@cancellation.subscribed_plan) %>.
       </p>
       <p>
         Any remaining balance you have on your account will be applied to your
@@ -17,7 +17,7 @@
       </p>
       <p>
         <%= link_to(
-          "Change to #{individual_price_per_month(IndividualPlan.downgraded)} &rarr;".html_safe,
+          "Change to #{individual_price_per_month(@cancellation.downgrade_plan)} &rarr;".html_safe,
           [:subscriber, :downgrade],
           method: :create
         ) %>
@@ -33,13 +33,13 @@
   </article>
   <%= form_for(
     :cancellation, 
-    url: [:subscriber, :cancellation], 
+    url: [:subscriber, :cancellation],
     html: { class: 'cancellation-feedback' }
   ) do |form| %>
-    <% if current_user.subscription.downgraded? %>
-      <%= form.submit t('subscriptions.confirm_cancel') %>
-    <% else %>
+    <% if @cancellation.can_downgrade_instead? %>
       <%= form.submit t('subscriptions.confirm_cancel_reject_deal') %>
+    <% else %>
+      <%= form.submit t('subscriptions.confirm_cancel') %>
     <% end %>
   <% end %>
 </div>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -141,7 +141,7 @@ FactoryGirl.define do
     short_description 'A great Subscription'
     description 'A long description'
 
-    factory :downgraded_plan do
+    factory :basic_plan do
       sku IndividualPlan::PRIME_BASIC_SKU
       includes_mentor false
       includes_workshops false
@@ -345,13 +345,13 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_downgraded_subscription do
+    trait :with_basic_subscription do
       with_github
       stripe_customer_id 'cus12345'
 
       after :create do |instance|
-        downgrade = create(:downgraded_plan)
-        create(:subscription, plan: downgrade, user: instance)
+        plan = create(:basic_plan)
+        create(:subscription, plan: plan, user: instance)
       end
     end
 

--- a/spec/features/user_cancels_subscription_spec.rb
+++ b/spec/features/user_cancels_subscription_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'User cancels a subscription', js: true do
   scenario 'successfully unsubscribes' do
     prime = create(:plan, sku: 'prime', name: 'Prime')
-    downgraded_plan = create(:downgraded_plan)
+    basic_plan = create(:basic_plan)
     create(:online_section,
       workshop: create(:workshop, name: 'A Cool Workshop')
     )

--- a/spec/features/user_downgrades_subscription_spec.rb
+++ b/spec/features/user_downgrades_subscription_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'User downgrades subscription', js: true do
   scenario 'successfully downgrades and then cancels' do
     prime = create(:plan, sku: 'prime', name: 'Prime')
-    downgraded_plan = create(:downgraded_plan)
+    basic_plan = create(:basic_plan)
     section = create(:online_section)
 
     sign_in_as_user_with_subscription
@@ -21,7 +21,7 @@ feature 'User downgrades subscription', js: true do
     expect(page).to have_link I18n.t('subscriptions.cancel')
     expect(page).to have_no_content "Scheduled for cancellation"
     @current_user.reload
-    expect(@current_user.subscription.plan).to eq downgraded_plan
+    expect(@current_user.subscription.plan).to eq basic_plan
 
     visit workshop_path(section.workshop)
 

--- a/spec/mailers/purchase_mailer_spec.rb
+++ b/spec/mailers/purchase_mailer_spec.rb
@@ -182,7 +182,7 @@ describe PurchaseMailer do
           purchase = create(
             :plan_purchase,
             user: user,
-            purchaseable: create(:downgraded_plan)
+            purchaseable: create(:basic_plan)
           )
 
           expect(email_for(purchase)).not_to have_body_text(/mentor/)

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -70,4 +70,61 @@ describe Cancellation do
       subscription.should have_received(:cancel_subscription).never
     end
   end
+
+  describe '#can_downgrade_instead?' do
+    it 'returns false if the subscribed plan is the downgrade plan' do
+      stub_downgrade_plan
+      subscribed_plan = build_stubbed(:plan)
+      subscription = build_stubbed(:subscription, plan: subscribed_plan)
+      cancellation = Cancellation.new(subscription)
+
+      expect(cancellation.can_downgrade_instead?).to be_true
+    end
+
+    it 'returns true if the subscribed plan is not the downgrade plan' do
+      downgrade_plan = stub_downgrade_plan
+      subscription = build_stubbed(:subscription, plan: downgrade_plan)
+      cancellation = Cancellation.new(subscription)
+
+      expect(cancellation.can_downgrade_instead?).to be_false
+    end
+  end
+
+  describe '#downgrade_plan' do
+    it 'returns the basic plan' do
+      downgrade_plan = stub_downgrade_plan
+      subscription = build_stubbed(:subscription)
+      cancellation = Cancellation.new(subscription)
+
+      expect(cancellation.downgrade_plan).to eq(downgrade_plan)
+    end
+  end
+
+  describe '#subscribed_plan' do
+    it 'returns the plan from the subscription' do
+      subscription = build_stubbed(:subscription)
+      cancellation = Cancellation.new(subscription)
+
+      expect(cancellation.subscribed_plan).to eq(subscription.plan)
+    end
+  end
+
+  describe '#downgrade' do
+    it 'switches to the downgrade plan' do
+      downgrade_plan = stub_downgrade_plan
+      subscription = build_stubbed(:subscription)
+      subscription.stubs(:change_plan)
+      cancellation = Cancellation.new(subscription)
+
+      cancellation.downgrade
+
+      expect(subscription).to have_received(:change_plan).with(downgrade_plan)
+    end
+  end
+
+  def stub_downgrade_plan
+    build_stubbed(:plan).tap do |plan|
+      IndividualPlan.stubs(:basic).returns(plan)
+    end
+  end
 end

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -41,12 +41,12 @@ describe IndividualPlan do
     end
   end
 
-  describe '.downgraded' do
-    it 'returns the downgraded plan' do
-      downgraded_plan = create(:downgraded_plan)
+  describe '.basic' do
+    it 'returns the basic plan' do
+      basic_plan = create(:basic_plan)
       create(:plan)
 
-      expect(IndividualPlan.downgraded).to eq downgraded_plan
+      expect(IndividualPlan.basic).to eq basic_plan
     end
   end
 

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -47,7 +47,7 @@ describe Mentor do
       mentor = create(:mentor)
       active = create(:subscriber)
       inactive = create(:user, :with_inactive_subscription)
-      without_mentoring = create(:user, :with_downgraded_subscription)
+      without_mentoring = create(:user, :with_basic_subscription)
       mentor.mentees = [active, inactive, without_mentoring]
 
       expect(mentor.active_mentees).to eq [active]

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -141,17 +141,6 @@ describe Subscription do
     end
   end
 
-  describe "#downgraded?" do
-    it 'is downgraded if it has the downgraded plan' do
-      downgraded_plan = create(:downgraded_plan)
-      subscription = create(:active_subscription)
-
-      subscription.change_plan(downgraded_plan)
-
-      expect(subscription).to be_downgraded
-    end
-  end
-
   describe '.canceled_in_last_30_days' do
     it 'returns nothing when none have been canceled within 30 days' do
       create(:subscription, deactivated_on: 60.days.ago)

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -9,7 +9,7 @@ module Subscriptions
 
   def sign_in_as_user_with_downgraded_subscription
     sign_in_as_user_with_subscription
-    @current_user.subscription.change_plan(create(:downgraded_plan))
+    @current_user.subscription.change_plan(create(:basic_plan))
   end
 
   def click_landing_page_call_to_action


### PR DESCRIPTION
https://www.apptrajectory.com/thoughtbot/learn/stories/15638428

I started with a `Downgrade` class, but ended up merging it into
`Cancellation`, as it was largely used on the cancellation form.

Changes:
- Rename `IndividualPlan.downgraded` to `IndividualPlan.basic`
- Rename `downgraded_plan` factory to `basic_plan`
- Move data fields used in cancellation form into `Cancellation`
- Encapsulate downgrade logic into `Cancellation`

I think the changes to `Subscription` and the cancellation form are
pretty obvious improvements, but I think this reduced overall cohesion
in `Cancellation`. I had a couple ideas to improve that:
- Extract a `Downgrade` class again.
- Create a facade for the cancellation form that composes `Cancellation`
  and `Downgrade` and just use `Cancellation` and `Downgrade` directly
  from `cancellations#create` and `downgrades#create`.

That would create one or two extra classes, though. I'm interested in
feedback as to whether it's worth it.
