### PR TITLE
Hide scrollbar from flash message

### DIFF
--- a/app/assets/stylesheets/layout/_flashes.scss
+++ b/app/assets/stylesheets/layout/_flashes.scss
@@ -10,6 +10,7 @@
     border-width: 0;
     display: inline-block;
     margin-bottom: 0;
+    overflow-y: auto;
     padding: 1rem 2rem;
 
     &.failure {


### PR DESCRIPTION
Currently flash message element inherits `overflow-y` attribute from `%main-content-box`. However, we don't want that for flash message box, so let's override that.

**Before**:
![before](https://f.cloud.github.com/assets/4912/1826434/7d61d9e6-71fa-11e3-87f0-b8e669d6280b.png)

**After**:
![after](https://f.cloud.github.com/assets/4912/1826435/82c18f4e-71fa-11e3-9aee-c5bfee9264e2.png)

Note: You can currently see the scrollbar in flash message by connecting a mouse or go to `Settings.app -> General -> Show scroll bars: Always`. 
