### PR TITLE
Users get a subscription from their team

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -185,7 +185,10 @@ class Purchase < ActiveRecord::Base
     if fulfilled_with_github?
       GithubFulfillment.new(self).fulfill
     end
-    SubscriptionFulfillment.new(self).fulfill
+
+    if subscription?
+      SubscriptionFulfillment.new(self, user).fulfill
+    end
   end
 
   def generate_lookup

--- a/app/models/subscription_fulfillment.rb
+++ b/app/models/subscription_fulfillment.rb
@@ -1,18 +1,51 @@
 class SubscriptionFulfillment
-  def initialize(purchase)
+  GITHUB_TEAM = 516450
+
+  def initialize(purchase, user)
     @purchase = purchase
+    @user = user
   end
 
   def fulfill
-    if @purchase.subscription?
-      @purchase.user.assign_mentor(mentor)
-      @purchase.user.create_subscription(
-        plan: @purchase.purchaseable,
-      )
-    end
+    assign_mentor
+    create_subscription
+    add_user_to_github_team
+  end
+
+  def remove
+    remove_user_from_github_team
+    deactivate_subscription_purchases
   end
 
   private
+
+  def assign_mentor
+    @user.assign_mentor(mentor)
+  end
+
+  def create_subscription
+    if purchaser?
+      @user.create_purchased_subscription(plan: @purchase.purchaseable)
+    end
+  end
+
+  def purchaser?
+    @purchase.user == @user
+  end
+
+  def add_user_to_github_team
+    GithubFulfillmentJob.enqueue(GITHUB_TEAM, [@user.github_username])
+  end
+
+  def remove_user_from_github_team
+    GithubRemovalJob.enqueue(GITHUB_TEAM, [@user.github_username])
+  end
+
+  def deactivate_subscription_purchases
+    @user.subscription_purchases.each do |purchase|
+      PurchaseRefunder.new(purchase).refund
+    end
+  end
 
   def mentor
     Mentor.find_or_sample(@purchase.mentor_id)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,10 +3,22 @@
 # Because purchases of TeamPlans happens rarely, Teams are created manually,
 # and not through the UI.
 class Team < ActiveRecord::Base
+  belongs_to :subscription
   belongs_to :team_plan
 
-  has_many :subscriptions
-  has_many :users, through: :subscriptions
+  has_many :users, dependent: :nullify
 
   validates :name, presence: true
+
+  def add_user(user)
+    SubscriptionFulfillment.new(subscription.purchase, user).fulfill
+    user.team = self
+    user.save!
+  end
+
+  def remove_user(user)
+    SubscriptionFulfillment.new(subscription.purchase, user).remove
+    user.team = nil
+    user.save!
+  end
 end

--- a/app/views/purchase_mailer/_receipt_subscription_intro.text.erb
+++ b/app/views/purchase_mailer/_receipt_subscription_intro.text.erb
@@ -1,11 +1,11 @@
 Thank you for subscribing to <%= purchase.purchaseable_name %>!
 
-<%- if purchase.user.subscription.includes_mentor? -%>
+<%- if purchase.purchaseable.includes_mentor? -%>
 You will receive an email from your mentor soon.
 <%- end -%>
 
 In the meantime, one of the first things you might do is visit our Trail Maps
-<%- if purchase.user.subscription.includes_workshops? -%>
+<%- if purchase.purchaseable.includes_workshops? -%>
 and check off your skills to determine which workshops are right for you:
 <%- else -%>
 and check off your skills to identify new things to learn:

--- a/db/migrate/20131230192546_add_team_id_to_users.rb
+++ b/db/migrate/20131230192546_add_team_id_to_users.rb
@@ -1,0 +1,27 @@
+class AddTeamIdToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :team_id, :integer
+
+    say_with_time 'Setting user team IDs' do
+      connection.update(<<-SQL)
+        WITH team_subscriptions AS (
+          SELECT
+            user_id,
+            MIN(team_id) AS team_id
+          FROM subscriptions
+          GROUP BY user_id
+        )
+        UPDATE users
+        SET team_id = team_subscriptions.team_id
+        FROM team_subscriptions
+        WHERE team_subscriptions.user_id = users.id
+      SQL
+    end
+
+    add_index :users, :team_id
+  end
+
+  def down
+    remove_column :users, :team_id
+  end
+end

--- a/db/migrate/20131230193510_add_subscription_id_to_teams.rb
+++ b/db/migrate/20131230193510_add_subscription_id_to_teams.rb
@@ -1,0 +1,28 @@
+class AddSubscriptionIdToTeams < ActiveRecord::Migration
+  def up
+    add_column :teams, :subscription_id, :integer
+
+    say_with_time 'Setting team subscriptions' do
+      connection.update(<<-SQL)
+        WITH teams_with_first_subscription AS (
+          SELECT
+            team_id AS team_id,
+            MIN(id) AS subscription_id
+          FROM subscriptions
+          WHERE team_id IS NOT NULL
+          GROUP BY team_id
+        )
+        UPDATE teams
+        SET subscription_id = teams_with_first_subscription.subscription_id
+        FROM teams_with_first_subscription
+        WHERE teams.id = teams_with_first_subscription.team_id
+      SQL
+    end
+
+    change_column_null :teams, :subscription_id, false
+  end
+
+  def down
+    remove_column :teams, :subscription_id
+  end
+end

--- a/db/migrate/20131230195418_remove_team_id_from_subscriptions.rb
+++ b/db/migrate/20131230195418_remove_team_id_from_subscriptions.rb
@@ -1,0 +1,45 @@
+class RemoveTeamIdFromSubscriptions < ActiveRecord::Migration
+  def up
+    say_with_time 'Deleting subscriptions for team members' do
+      connection.delete(<<-SQL)
+        DELETE FROM subscriptions
+        WHERE team_id IS NOT NULL
+          AND id NOT IN (SELECT subscription_id FROM teams)
+      SQL
+    end
+
+    remove_column :subscriptions, :team_id
+  end
+
+  def down
+    add_column :subscriptions, :team_id, :integer
+    add_index :subscriptions, :team_id
+
+    say_with_time 'Create subscriptions for team members' do
+      connection.insert(<<-SQL)
+        INSERT INTO subscriptions
+          (user_id, created_at, updated_at, plan_id, team_id, plan_type)
+        SELECT
+          users.id AS user_id,
+          teams.created_at,
+          teams.updated_at,
+          teams.team_plan_id AS plan_id,
+          teams.id AS team_id,
+          'TeamPlan' As plan_type
+        FROM teams
+        INNER JOIN users ON users.team_id = teams.id
+        LEFT JOIN subscriptions ON subscriptions.user_id = users.id
+        WHERE subscriptions.id IS NULL
+      SQL
+    end
+
+    say_with_time 'Setting subscription teams' do
+      connection.update(<<-SQL)
+        UPDATE subscriptions
+        SET team_id = teams.id
+        FROM teams
+        WHERE teams.subscription_id = subscriptions.id
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131230094755) do
+ActiveRecord::Schema.define(version: 20131230195418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,14 +283,12 @@ ActiveRecord::Schema.define(version: 20131230094755) do
     t.date     "scheduled_for_cancellation_on"
     t.boolean  "paid",                          default: true,             null: false
     t.integer  "plan_id",                                                  null: false
-    t.integer  "team_id"
     t.string   "plan_type",                     default: "IndividualPlan", null: false
     t.decimal  "next_payment_amount",           default: 0.0,              null: false
     t.date     "next_payment_on"
   end
 
   add_index "subscriptions", ["plan_id", "plan_type"], name: "index_subscriptions_on_plan_id_and_plan_type", using: :btree
-  add_index "subscriptions", ["team_id"], name: "index_subscriptions_on_team_id", using: :btree
   add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
 
   create_table "teachers", force: true do |t|
@@ -316,10 +314,11 @@ ActiveRecord::Schema.define(version: 20131230094755) do
   end
 
   create_table "teams", force: true do |t|
-    t.string   "name",         null: false
+    t.string   "name",            null: false
     t.integer  "team_plan_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.integer  "subscription_id", null: false
   end
 
   create_table "topics", force: true do |t|
@@ -370,6 +369,7 @@ ActiveRecord::Schema.define(version: 20131230094755) do
     t.string   "name"
     t.text     "bio"
     t.integer  "mentor_id"
+    t.integer  "team_id"
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree
@@ -377,6 +377,7 @@ ActiveRecord::Schema.define(version: 20131230094755) do
   add_index "users", ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token", using: :btree
   add_index "users", ["mentor_id"], name: "index_users_on_mentor_id", using: :btree
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
+  add_index "users", ["team_id"], name: "index_users_on_team_id", using: :btree
 
   create_table "videos", force: true do |t|
     t.integer  "watchable_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -167,6 +167,7 @@ FactoryGirl.define do
 
   factory :team do
     name 'Google'
+    subscription
   end
 
   factory :purchase, aliases: [:individual_purchase] do
@@ -312,6 +313,11 @@ FactoryGirl.define do
     email
     name 'Dan Deacon'
     password 'password'
+    purchased_subscription { subscription }
+
+    ignore do
+      subscription nil
+    end
 
     factory :admin do
       admin true
@@ -341,7 +347,7 @@ FactoryGirl.define do
       stripe_customer_id 'cus12345'
 
       after :create do |instance|
-        create(:subscription, user: instance)
+        instance.purchased_subscription = create(:subscription, user: instance)
       end
     end
 

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -9,9 +9,9 @@ feature 'User creates a subscription' do
 
   scenario 'creates a Stripe subscription with a valid credit card' do
     subscribe_with_valid_credit_card
-    expect(current_user).to have_active_subscription
     expect(current_path).to eq dashboard_path
     expect(page).to have_content(I18n.t('purchase.flashes.success', name: plan.name))
+    expect(settings_page).to have_subscription_to(plan.name)
   end
 
   scenario 'does not create a Stripe subscription with an invalid credit card' do

--- a/spec/features/user_manages_team_subscription_spec.rb
+++ b/spec/features/user_manages_team_subscription_spec.rb
@@ -10,10 +10,10 @@ feature 'User creates a team subscription' do
   scenario 'creates a team subscription with a valid credit card' do
     subscribe_with_valid_credit_card
 
-    expect(current_user).to have_active_subscription
     expect(current_path).to eq dashboard_path
     expect(page).
       to have_content(I18n.t('purchase.flashes.success', name: plan.name))
+    expect(settings_page).to have_subscription_to(plan.name)
     expect(FakeStripe.customer_plan_quantity).to eq plan.minimum_quantity.to_s
   end
 

--- a/spec/models/subscription_count_report_spec.rb
+++ b/spec/models/subscription_count_report_spec.rb
@@ -28,7 +28,12 @@ describe SubscriptionCountReport do
 
   def create_user_with_subscription(subscription_date)
     subscription = create(:subscription, created_at: subscription_date)
-    user = create(:user, subscription: subscription, created_at: subscription_date)
+    user = create(
+      :user,
+      :with_mentor,
+      subscription: subscription,
+      created_at: subscription_date
+    )
     user
   end
 

--- a/spec/models/subscription_fulfillment_spec.rb
+++ b/spec/models/subscription_fulfillment_spec.rb
@@ -1,27 +1,25 @@
 require 'spec_helper'
 
 describe SubscriptionFulfillment do
-  describe 'fulfill' do
-    it 'adds a subscription to the user for a subscription purchase' do
+  describe '#fulfill' do
+    it 'adds a subscription to the user that created the purchase' do
       create_mentors
       user = create(:user, :with_github)
       purchase = build(:plan_purchase, user: user)
 
       expect(user.subscription).to be_nil
 
-      SubscriptionFulfillment.new(purchase).fulfill
+      SubscriptionFulfillment.new(purchase, user).fulfill
 
       expect(user.subscription).not_to be_nil
       expect(user.subscription.plan).to eq purchase.purchaseable
     end
 
-    it 'does not add subscription for a regular purchase' do
+    it "doesn't add a subscription to a user that didn't create the purchase" do
       user = create(:user, :with_github)
-      purchase = build(:book_purchase)
+      purchase = build(:plan_purchase)
 
-      expect(user.subscription).to be_nil
-
-      SubscriptionFulfillment.new(purchase).fulfill
+      SubscriptionFulfillment.new(purchase, user).fulfill
 
       expect(user.subscription).to be_nil
     end
@@ -30,13 +28,68 @@ describe SubscriptionFulfillment do
       create_mentors
       mentor = Mentor.first
       user = create(:user, :with_github)
-      purchase = build(:plan_purchase, user: user, mentor_id: mentor.id)
+      purchase = build(:plan_purchase, mentor_id: mentor.id)
 
       expect(user.subscription).to be_nil
 
-      SubscriptionFulfillment.new(purchase).fulfill
+      SubscriptionFulfillment.new(purchase, user).fulfill
 
       expect(user.mentor).not_to be_nil
+    end
+
+    it 'adds the user to the subscriber github team' do
+      GithubFulfillmentJob.stubs(:enqueue)
+      user = create(:user, :with_github)
+      purchase = build(:plan_purchase)
+
+      SubscriptionFulfillment.new(purchase, user).fulfill
+
+      GithubFulfillmentJob.should have_received(:enqueue).
+        with(SubscriptionFulfillment::GITHUB_TEAM, [user.github_username])
+    end
+  end
+
+  describe '#remove' do
+    it 'removes the user from the subscriber github team' do
+      GithubRemovalJob.stubs(:enqueue)
+      user = create(:user, :with_github)
+      purchase = build(:plan_purchase)
+
+      SubscriptionFulfillment.new(purchase, user).remove
+
+      GithubRemovalJob.should have_received(:enqueue).
+        with(SubscriptionFulfillment::GITHUB_TEAM, [user.github_username])
+    end
+
+    it 'removes all subscription purchases' do
+      user = create(:user, :with_github)
+      create_subscription_purchase(user)
+      book_purchase = create_paid_purchase(user)
+      github_fulfillment = stub_github_fulfillment
+      plan_purchase = build(:plan_purchase)
+
+      SubscriptionFulfillment.new(plan_purchase, user).remove
+
+      user.paid_purchases.count.should eq 1
+      user.paid_purchases.should eq [book_purchase]
+      user.subscription_purchases.count.should eq 0
+      github_fulfillment.should have_received(:remove)
+    end
+
+    def create_subscription_purchase(user)
+      product = create(:book, :github)
+      subscription_purchase = SubscriberPurchase.new(product, user)
+      subscription_purchase.create
+    end
+
+    def create_paid_purchase(user)
+      create(:book_purchase, user: user)
+    end
+
+    def stub_github_fulfillment
+      github_fulfillment = stub(remove: nil)
+      GithubFulfillment.stubs(:new).returns(github_fulfillment)
+      github_fulfillment
     end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,8 +1,45 @@
 require 'spec_helper'
 
 describe Team do
+  it { should belong_to(:subscription) }
   it { should belong_to(:team_plan) }
-  it { should have_many(:subscriptions) }
-  it { should have_many(:users).through(:subscriptions) }
+  it { should have_many(:users).dependent(:nullify) }
   it { should validate_presence_of(:name) }
+
+  describe '#add_user' do
+    it "fulfils that user's subscription" do
+      team = create(:team)
+      user = create(:user, :with_mentor)
+      fulfillment = stub_subscription_fulfillment(team.subscription, user)
+
+      team.add_user(user)
+
+      expect(user.reload.team).to eq(team)
+      fulfillment.should have_received(:fulfill)
+    end
+  end
+
+  describe '#remove_user' do
+    it "removes that user's subscription" do
+      team = create(:team)
+      user = create(:user, :with_mentor, team: team)
+      fulfillment = stub_subscription_fulfillment(team.subscription, user)
+
+      team.remove_user(user)
+
+      expect(user.reload.team).to be_nil
+      fulfillment.should have_received(:remove)
+    end
+  end
+
+  def stub_subscription_fulfillment(subscription, user)
+    purchase = build_stubbed(:purchase)
+    subscription.stubs(:purchase).returns(purchase)
+    stub('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
+      SubscriptionFulfillment.
+        stubs(:new).
+        with(purchase, user).
+        returns(fulfillment)
+    end
+  end
 end

--- a/spec/requests/stripe_webook_spec.rb
+++ b/spec/requests/stripe_webook_spec.rb
@@ -22,7 +22,7 @@ describe 'subscription cancellations reported by Stripe webhook' do
 
     simulate_stripe_webhook_firing
 
-    expect(user).not_to have_active_subscription
+    expect(user.reload).not_to have_active_subscription
   end
 
   def simulate_stripe_webhook_firing

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -20,6 +20,15 @@ module Subscriptions
     click_link 'Prime Membership'
   end
 
+  def settings_page
+    click_on 'Settings'
+    page
+  end
+
+  def have_subscription_to(plan_name)
+    have_css('.subscription', text: plan_name)
+  end
+
   def create_mentors
     create(:mentor)
   end


### PR DESCRIPTION
- Add users directly to teams (users table has a team_id)
- `User.subscription` returns its team's subscription when present
- Adding users to a Team will affect that user's access
- Deactivating a team subscription will affect team member's access
- Ensure users have a mentor when their plan allows it
- Model methdos for managing team users

https://www.apptrajectory.com/thoughtbot/learn/stories/15638524
