### PR TITLE
Simplify GitHub fulfillment

### DIFF
--- a/app/models/github_fulfillment.rb
+++ b/app/models/github_fulfillment.rb
@@ -4,15 +4,11 @@ class GithubFulfillment
   end
 
   def fulfill
-    if usernames.present?
-      GithubFulfillmentJob.enqueue(team, usernames, @purchase.id)
-    end
+    GithubFulfillmentJob.enqueue(team, usernames, @purchase.id)
   end
 
   def remove
-    if usernames.present?
-      GithubRemovalJob.enqueue(team, usernames)
-    end
+    GithubRemovalJob.enqueue(team, usernames)
   end
 
   private
@@ -26,7 +22,6 @@ class GithubFulfillment
   end
 
   def usernames
-    users = @purchase.github_usernames || []
-    users.map(&:strip).reject(&:blank?).compact
+    @purchase.github_usernames
   end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -137,6 +137,10 @@ class Purchase < ActiveRecord::Base
     @payment ||= Payments::Factory.new(payment_method).new(self)
   end
 
+  def github_usernames
+    Array(super).compact.map(&:strip).reject(&:blank?)
+  end
+
   private
 
   def password_required?

--- a/spec/jobs/github_fullfillment_job_spec.rb
+++ b/spec/jobs/github_fullfillment_job_spec.rb
@@ -3,14 +3,13 @@ require 'spec_helper'
 describe GithubFulfillmentJob do
   it_behaves_like 'a Delayed Job that notifies Airbrake about errors'
 
-  it 'adds given usernames to a github team' do
+  it 'adds the given username to a github team' do
     client = stub_octokit
     client.stubs(:add_team_member => nil)
 
-    GithubFulfillmentJob.new(3, ['gabebw', 'cpytel']).perform
+    GithubFulfillmentJob.new(3, 'gabebw').perform
 
     client.should have_received(:add_team_member).with(3, 'gabebw')
-    client.should have_received(:add_team_member).with(3, 'cpytel')
   end
 
   [Octokit::NotFound, Net::HTTPBadResponse].each do |error_class|
@@ -20,7 +19,8 @@ describe GithubFulfillmentJob do
       client.stubs(:add_team_member).raises(error_class)
       PurchaseMailer.stubs(:fulfillment_error => stub("deliver", :deliver => true))
 
-      GithubFulfillmentJob.new(3, ['gabebw'], purchase_id).perform
+      expect { GithubFulfillmentJob.new(3, 'gabebw', purchase_id).perform }.
+        to raise_error(error_class)
 
       PurchaseMailer.should have_received(:fulfillment_error).
         with(instance_of(Purchase), 'gabebw')
@@ -31,24 +31,14 @@ describe GithubFulfillmentJob do
       client.stubs(:add_team_member).raises(error_class)
       PurchaseMailer.stubs(fulfillment_error: stub("deliver", deliver: true))
 
-      GithubFulfillmentJob.new(3, ['gabebw']).perform
+      expect { GithubFulfillmentJob.new(3, 'gabebw').perform }.
+        to raise_error(error_class)
 
       expect(PurchaseMailer).to(
         have_received(:fulfillment_error).
           with(instance_of(Purchase), 'gabebw').
           never
       )
-    end
-
-    it "notifies Airbrake when #{error_class} is raised" do
-      purchase_id = create(:purchase).id
-      client = stub_octokit
-      client.stubs(:add_team_member).raises(error_class)
-      Airbrake.stubs(:notify)
-
-      GithubFulfillmentJob.new(3, ['gabebw'], purchase_id).perform
-
-      Airbrake.should have_received(:notify).once
     end
   end
 

--- a/spec/models/github_fulfillment_spec.rb
+++ b/spec/models/github_fulfillment_spec.rb
@@ -1,42 +1,13 @@
 require 'spec_helper'
 
 describe GithubFulfillment do
-  describe 'fulfill' do
-    it "doesn't add users to the github team when there are blank usernames" do
-      product = create(:book, :github)
-      GithubFulfillmentJob.stubs(:enqueue)
-      purchase = build(
-        :book_purchase,
-        purchaseable: product, 
-        github_usernames: ['', '']
-      )
-
-      GithubFulfillment.new(purchase).fulfill
-
-      GithubFulfillmentJob.should have_received(:enqueue).never
-    end
-
-    it 'adds user to the github team' do
+  describe '#fulfill' do
+    it 'adds each user to the github team' do
       product = build(:book, :github)
       GithubFulfillmentJob.stubs(:enqueue)
       purchase = build(
         :book_purchase,
-        purchaseable: product, 
-        github_usernames: ['cpytel']
-      )
-
-      GithubFulfillment.new(purchase).fulfill
-
-      GithubFulfillmentJob.should have_received(:enqueue).
-        with(product.github_team, ['cpytel'], purchase.id)
-    end
-
-    it 'adds multiple users to the github team' do
-      product = build(:book, :github)
-      GithubFulfillmentJob.stubs(:enqueue)
-      purchase = build(
-        :book_purchase,
-        purchaseable: product, 
+        purchaseable: product,
         github_usernames: ['cpytel', 'github_username2']
       )
 
@@ -47,7 +18,7 @@ describe GithubFulfillment do
     end
   end
 
-  describe 'remove' do
+  describe '#remove' do
     it 'removes user from github team' do
       GithubRemovalJob.stubs(:enqueue)
       product = build(:book, :github)

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -162,18 +162,6 @@ describe Purchase do
     end
   end
 
-  context 'when not fulfilled_with_github' do
-    it 'does not fulfill with github' do
-      purchase = build(:paid_purchase)
-      fulfillment = stub(:fulfill)
-      GithubFulfillment.stubs(:new).returns(fulfillment)
-
-      purchase.save!
-
-      fulfillment.should have_received(:fulfill).never
-    end
-  end
-
   context 'when fulfilled_with_github' do
     it 'fulfills with github' do
       product = create(:book, :github)
@@ -184,6 +172,26 @@ describe Purchase do
       purchase.save!
 
       fulfillment.should have_received(:fulfill)
+    end
+  end
+
+  describe '#github_usernames' do
+    it 'serializes an array of stripped, non-empty strings' do
+      expect(serialize_github_usernames(['', '  one  ', 'two'])).
+        to eq(%w(one two))
+    end
+
+    it 'serializes nil into an empty array' do
+      expect(serialize_github_usernames(nil)).to eq([])
+    end
+
+    it 'removes nil entries' do
+      expect(serialize_github_usernames([nil, 'name'])).to eq(%w(name))
+    end
+
+    def serialize_github_usernames(github_usernames)
+      purchase = create(:purchase, github_usernames: github_usernames)
+      purchase.reload.github_usernames
     end
   end
 


### PR DESCRIPTION
- Each job processes one username
- Encapsulate username serialization logic within Purchase
- Eliminates conditional check for empty usernames

I started this as an experiment to see if I could inline some of these
classes while doing a larger fulfillment refactoring. That's not really
possible, but I think the simplifications are a nice change on their own
anyway.
