### PR TITLE
Reduce ActiveRecord connection pool from 5 to 2

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: utf8
   min_messages: warning
-  pool: 5
+  pool: 2
   timeout: 5000
 
 development:

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -22,5 +22,9 @@ after_fork do |server, worker|
 
   if defined? ActiveRecord::Base
     ActiveRecord::Base.establish_connection
+    config = Rails.application.config.database_configuration[Rails.env]
+    config['reaping_frequency'] = (ENV['DB_REAPING_FREQUENCY'] || 10).to_i
+    config['pool'] = (ENV['DB_POOL'] || 2).to_i
+    ActiveRecord::Base.establish_connection(config)
   end
 end


### PR DESCRIPTION
We currently have four dynos with three processes each, plus a worker
process. That's 13 process total, with a maximum of 5 connections per
process, resulting in a potential total of 65 connections. Our database is
limited to 60 connections.

https://devcenter.heroku.com/articles/concurrency-and-database-connections

This commit also sets up the Rails 4 reaper, which will close dead
connections every 10 seconds, limiting the total to 1 per process (8 in this
case).

2 is a good default as opposed to 1 because New Relic's auto-EXPLAIN feature
also adds 1 connection per Unicorn (or background job).

https://www.apptrajectory.com/thoughtbot/learn/stories/15638682
