### PR TITLE
Delegate fulfillment to purchaseable

### DIFF
--- a/app/models/github_fulfillment.rb
+++ b/app/models/github_fulfillment.rb
@@ -4,14 +4,22 @@ class GithubFulfillment
   end
 
   def fulfill
-    GithubFulfillmentJob.enqueue(team, usernames, @purchase.id)
+    if fulfilled_with_github?
+      GithubFulfillmentJob.enqueue(team, usernames, @purchase.id)
+    end
   end
 
   def remove
-    GithubRemovalJob.enqueue(team, usernames)
+    if fulfilled_with_github?
+      GithubRemovalJob.enqueue(team, usernames)
+    end
   end
 
   private
+
+  def fulfilled_with_github?
+    team.present?
+  end
 
   def team
     purchaseable.github_team

--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -74,6 +74,10 @@ class IndividualPlan < ActiveRecord::Base
     @announcement ||= announcements.current
   end
 
+  def fulfill(purchase, user)
+    SubscriptionFulfillment.new(purchase, user).fulfill
+  end
+
   private
 
   def stripe_plan

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -121,6 +121,10 @@ class Product < ActiveRecord::Base
     end
   end
 
+  def fulfill(purchase, user)
+    GithubFulfillment.new(purchase).fulfill
+  end
+
   private
 
   def apply_discount(price)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -186,13 +186,7 @@ class Purchase < ActiveRecord::Base
   end
 
   def fulfill
-    if fulfilled_with_github?
-      GithubFulfillment.new(self).fulfill
-    end
-
-    if subscription?
-      SubscriptionFulfillment.new(self, user).fulfill
-    end
+    purchaseable.fulfill(self, user)
   end
 
   def generate_lookup

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -143,6 +143,10 @@ class Section < ActiveRecord::Base
     'sections/aside'
   end
 
+  def fulfill(purchase, user)
+    GithubFulfillment.new(purchase).fulfill
+  end
+
   private
 
   def self.xml_content(document, tag_name)

--- a/app/models/team_plan.rb
+++ b/app/models/team_plan.rb
@@ -46,4 +46,8 @@ class TeamPlan < ActiveRecord::Base
   def minimum_quantity
     5
   end
+
+  def fulfill(purchase, user)
+    SubscriptionFulfillment.new(purchase, user).fulfill
+  end
 end

--- a/app/services/purchase_refunder.rb
+++ b/app/services/purchase_refunder.rb
@@ -10,9 +10,7 @@ class PurchaseRefunder < SimpleDelegator
   private
 
   def remove_fullfilments
-    if fulfilled_with_github?
-      GithubFulfillment.new(self).remove
-    end
+    GithubFulfillment.new(self).remove
   end
 
   def set_as_unpaid_and_save

--- a/spec/models/github_fulfillment_spec.rb
+++ b/spec/models/github_fulfillment_spec.rb
@@ -13,8 +13,21 @@ describe GithubFulfillment do
 
       GithubFulfillment.new(purchase).fulfill
 
-      GithubFulfillmentJob.should have_received(:enqueue).
-        with(product.github_team, ['cpytel', 'github_username2'], purchase.id)
+      GithubFulfillmentJob.should have_received(:enqueue)
+    end
+
+    it "doesn't fulfill using GitHub with a blank GitHub team" do
+      product = build(:book, github_team: nil)
+      GithubFulfillmentJob.stubs(:enqueue)
+      purchase = build(
+        :book_purchase,
+        purchaseable: product,
+        github_usernames: ['cpytel']
+      )
+
+      GithubFulfillment.new(purchase).fulfill
+
+      GithubFulfillmentJob.should have_received(:enqueue).never
     end
   end
 
@@ -24,7 +37,7 @@ describe GithubFulfillment do
       product = build(:book, :github)
       purchase = build(
         :book_purchase,
-        purchaseable: product, 
+        purchaseable: product,
         github_usernames: ['jayroh', 'cpytel']
       )
 
@@ -32,6 +45,20 @@ describe GithubFulfillment do
 
       GithubRemovalJob.should have_received(:enqueue).
         with(product.github_team, ['jayroh', 'cpytel'])
+    end
+
+    it "doesn't remove using GitHub with a blank GitHub team" do
+      GithubRemovalJob.stubs(:enqueue)
+      product = build(:book, github_team: nil)
+      purchase = build(
+        :book_purchase,
+        purchaseable: product,
+        github_usernames: ['jayroh']
+      )
+
+      GithubFulfillment.new(purchase).remove
+
+      GithubRemovalJob.should have_received(:enqueue).never
     end
   end
 end

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -176,6 +176,19 @@ describe IndividualPlan do
     end
   end
 
+  describe '#fulfill' do
+    it 'starts a subscription' do
+      user = build_stubbed(:user)
+      purchase = build_stubbed(:purchase, user: user)
+      plan = build_stubbed(:individual_plan)
+      fulfillment = stub_subscription_fulfillment(purchase)
+
+      plan.fulfill(purchase, user)
+
+      expect(fulfillment).to have_received(:fulfill)
+    end
+  end
+
   def create_inactive_subscription_for(plan)
     create(:inactive_subscription, plan: plan)
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -83,4 +83,18 @@ describe Product do
       expect(Product.new).not_to be_collection
     end
   end
+
+  describe '#fulfill' do
+    it 'fulfills using GitHub with a GitHub team' do
+      purchase = build_stubbed(:purchase)
+      user = build_stubbed(:user)
+      fulfillment = stub('fulfillment', :fulfill)
+      product = build_stubbed(:product, github_team: 'example')
+      GithubFulfillment.stubs(:new).with(purchase).returns(fulfillment)
+
+      product.fulfill(purchase, user)
+
+      fulfillment.should have_received(:fulfill)
+    end
+  end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -365,4 +365,19 @@ describe Section do
       expect(Section.new.to_aside_partial).to eq 'sections/aside'
     end
   end
+
+  describe '#fulfill' do
+    it 'fulfills using GitHub with a GitHub team' do
+      purchase = build_stubbed(:purchase)
+      user = build_stubbed(:user)
+      fulfillment = stub('fulfillment', :fulfill)
+      workshop = build_stubbed(:workshop, github_team: 'example')
+      section = build_stubbed(:section, workshop: workshop)
+      GithubFulfillment.stubs(:new).with(purchase).returns(fulfillment)
+
+      section.fulfill(purchase, user)
+
+      fulfillment.should have_received(:fulfill)
+    end
+  end
 end

--- a/spec/models/team_plan_spec.rb
+++ b/spec/models/team_plan_spec.rb
@@ -93,6 +93,19 @@ describe TeamPlan do
     end
   end
 
+  describe '#fulfill' do
+    it 'starts a subscription' do
+      user = build_stubbed(:user)
+      purchase = build_stubbed(:purchase, user: user)
+      plan = build_stubbed(:team_plan)
+      fulfillment = stub_subscription_fulfillment(purchase)
+
+      plan.fulfill(purchase, user)
+
+      expect(fulfillment).to have_received(:fulfill)
+    end
+  end
+
   def team_plan
     build(:team_plan)
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -10,7 +10,7 @@ describe Team do
     it "fulfils that user's subscription" do
       team = create(:team)
       user = create(:user, :with_mentor)
-      fulfillment = stub_subscription_fulfillment(team.subscription, user)
+      fulfillment = stub_team_fulfillment(team, user)
 
       team.add_user(user)
 
@@ -22,8 +22,8 @@ describe Team do
   describe '#remove_user' do
     it "removes that user's subscription" do
       team = create(:team)
-      user = create(:user, :with_mentor, team: team)
-      fulfillment = stub_subscription_fulfillment(team.subscription, user)
+      user = create(:user, :with_mentor)
+      fulfillment = stub_team_fulfillment(team, user)
 
       team.remove_user(user)
 
@@ -32,14 +32,9 @@ describe Team do
     end
   end
 
-  def stub_subscription_fulfillment(subscription, user)
+  def stub_team_fulfillment(team, user)
     purchase = build_stubbed(:purchase)
-    subscription.stubs(:purchase).returns(purchase)
-    stub('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
-      SubscriptionFulfillment.
-        stubs(:new).
-        with(purchase, user).
-        returns(fulfillment)
-    end
+    team.subscription.stubs(:purchase).returns(purchase)
+    stub_subscription_fulfillment(purchase, user)
   end
 end

--- a/spec/services/purchase_refunder_spec.rb
+++ b/spec/services/purchase_refunder_spec.rb
@@ -20,18 +20,6 @@ describe PurchaseRefunder, '#refund' do
     expect(purchase).not_to be_paid
   end
 
-  context 'when not fulfilled_with_github' do
-    it 'does not remove from github' do
-      purchase = create(:paid_purchase)
-      fulfillment = stub(:remove)
-      GithubFulfillment.stubs(:new).returns(fulfillment)
-
-      PurchaseRefunder.new(purchase).refund
-
-      expect(fulfillment).to have_received(:remove).never
-    end
-  end
-
   context 'when fulfilled_with_github' do
     it 'removes from github' do
       product = create(:book, :github)

--- a/spec/support/fulfillment_stubs.rb
+++ b/spec/support/fulfillment_stubs.rb
@@ -1,0 +1,14 @@
+module FulfillmentStubs
+  def stub_subscription_fulfillment(purchase, user = purchase.user)
+    stub('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
+      SubscriptionFulfillment.
+        stubs(:new).
+        with(purchase, user).
+        returns(fulfillment)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include FulfillmentStubs, type: :model
+end


### PR DESCRIPTION
- Follow Tell, Don't Ask from Purchase
- Different purchaseable types can define fulfillment differently
- Decreases complexity in Purchase
- Introduces some duplication and complexity in Purchaseables
