### PR TITLE
Raise ActiveRecord::RecordNotFound for bad team plan IDs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,28 +40,16 @@ class ApplicationController < ActionController::Base
   helper_method :current_user_is_admin?
 
   def requested_purchaseable
-    if product_param
-      Product.find(product_param)
-    elsif params[:individual_plan_id]
-      IndividualPlan.where(sku: params[:individual_plan_id]).first
-    elsif params[:team_plan_id]
-      TeamPlan.where(sku: params[:team_plan_id]).first
-    elsif params[:section_id]
-      Section.find(params[:section_id])
-    else
-      raise "Could not find a purchaseable object from given params: #{params}"
-    end
+    PolymorphicFinder.
+      finding(Section, :id, [:section_id]).
+      finding(TeamPlan, :sku, [:team_plan_id]).
+      finding(IndividualPlan, :sku, [:individual_plan_id]).
+      finding(Product, :id, [:product_id, :screencast_id, :book_id, :show_id]).
+      find(params)
   end
 
   def topics
     Topic.top
   end
   helper_method :topics
-
-  def product_param
-    params[:product_id] ||
-      params[:screencast_id] ||
-      params[:book_id] ||
-      params[:show_id]
-  end
 end

--- a/app/services/polymorphic_finder.rb
+++ b/app/services/polymorphic_finder.rb
@@ -1,0 +1,57 @@
+# Finds one of several possible polymorphic members from params based on a list
+# of relations to look in and attributes to look for.
+#
+# Each polymorphic member will be tried in turn. If an ID is present that
+# doesn't correspond to an existing row, or if none of the possible IDs are
+# present in the params, an exception will be raised.
+class PolymorphicFinder
+  def initialize(finder)
+    @finder = finder
+  end
+
+  def self.finding(*args)
+    new(NullFinder.new).finding(*args)
+  end
+
+  def finding(relation, attribute, param_names)
+    new_finder = param_names.inject(@finder) do |fallback, param_name|
+      Finder.new(relation, attribute, param_name, fallback)
+    end
+
+    self.class.new(new_finder)
+  end
+
+  def find(params)
+    @finder.find(params)
+  end
+
+  private
+
+  class Finder
+    def initialize(relation, attribute, param_name, fallback)
+      @relation = relation
+      @attribute = attribute
+      @param_name = param_name
+      @fallback = fallback
+    end
+
+    def find(params)
+      if id = params[@param_name]
+        @relation.where(@attribute => id).first!
+      else
+        @fallback.find(params)
+      end
+    end
+  end
+
+  class NullFinder
+    def find(params)
+      raise(
+        ActiveRecord::RecordNotFound,
+        "Can't find a polymorphic record without an ID: #{params.inspect}"
+      )
+    end
+  end
+
+  private_constant :Finder, :NullFinder
+end

--- a/spec/services/polymorphic_finder_spec.rb
+++ b/spec/services/polymorphic_finder_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe PolymorphicFinder do
+  describe '#find' do
+    it 'finds the first given finder when present' do
+      individual_plan = create(:individual_plan, sku: 'abc')
+
+      result = PolymorphicFinder.
+        finding(IndividualPlan, :sku, [:individual_plan_id]).
+        find(individual_plan_id: 'abc')
+
+      expect(result).to eq(individual_plan)
+    end
+
+    it 'finds the first of several possible params' do
+      screencast = create(:screencast)
+
+      result = PolymorphicFinder.
+        finding(Product, :id, [:book_id, :screencast_id, :product_id]).
+        find(screencast_id: screencast.to_param)
+
+      expect(result).to eq(screencast)
+    end
+
+    it 'cascades when the first finder is not present' do
+      create(:individual_plan, sku: 'abc')
+      team_plan = create(:team_plan, sku: 'def')
+
+      result = PolymorphicFinder.
+        finding(IndividualPlan, :sku, [:individual_plan_id]).
+        finding(TeamPlan, :sku, [:team_plan_id]).
+        find(team_plan_id: 'def')
+
+      expect(result).to eq(team_plan)
+    end
+
+    it 'raises an exception for an unknown ID' do
+      create(:individual_plan, sku: 'abc')
+
+      finder = PolymorphicFinder.
+        finding(IndividualPlan, :sku, [:individual_plan_id])
+
+      expect { finder.find(individual_plan_id: 'def') }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises an exception without any ID' do
+      params = { 'key' => 'value' }
+      finder = PolymorphicFinder.
+        finding(IndividualPlan, :sku, [:individual_plan_id])
+
+      expect { finder.find(params) }.
+        to raise_error(ActiveRecord::RecordNotFound, /#{Regexp.escape(params.inspect)}/)
+    end
+  end
+end


### PR DESCRIPTION
- Uses `first!` instead of `first`
- Extract polymorphic finding logic to a class

https://www.apptrajectory.com/thoughtbot/learn/stories/15638804
