### PR TITLE
Create a new team when users sign up for a team subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -65,6 +65,10 @@ class Subscription < ActiveRecord::Base
     user.purchases.for_purchaseable(plan).first
   end
 
+  def team?
+    team.present?
+  end
+
   private
 
   def self.canceled_within_period(start_time, end_time)

--- a/app/models/team_fulfillment.rb
+++ b/app/models/team_fulfillment.rb
@@ -1,0 +1,24 @@
+class TeamFulfillment
+  def initialize(purchase, user)
+    @user = user
+  end
+
+  def fulfill
+    @user.team = create_team
+    @user.save!
+  end
+
+  private
+
+  def create_team
+    Team.create!(name: generate_team_name, subscription: subscription)
+  end
+
+  def generate_team_name
+    @user.email.sub(/^.*@/, '').split('.')[-2].titleize
+  end
+
+  def subscription
+    @user.subscription
+  end
+end

--- a/app/models/team_plan.rb
+++ b/app/models/team_plan.rb
@@ -49,5 +49,6 @@ class TeamPlan < ActiveRecord::Base
 
   def fulfill(purchase, user)
     SubscriptionFulfillment.new(purchase, user).fulfill
+    TeamFulfillment.new(purchase, user).fulfill
   end
 end

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -8,6 +8,10 @@
     <p>Canceled on <%= subscription.deactivated_on.to_s(:simple) %></p>
   <% end %>
 
+  <% if subscription.team? %>
+    <%= render subscription.team %>
+  <% end %>
+
   <%= link_to 'View all invoices', subscriber_invoices_path, class: 'invoices' %>
   <% if subscription.active? && subscription.scheduled_for_cancellation_on.blank? %>
     <%= link_to t('subscriptions.cancel'), new_subscriber_cancellation_path, class: 'cancel' %>

--- a/app/views/teams/_team.html.erb
+++ b/app/views/teams/_team.html.erb
@@ -1,0 +1,1 @@
+<p><strong>Team:</strong> <%= team.name %></p>

--- a/spec/features/visitor_purchases_team_subscription_spec.rb
+++ b/spec/features/visitor_purchases_team_subscription_spec.rb
@@ -12,10 +12,14 @@ feature 'Visitor can purchase a subscription for their team' do
 
     click_link team_plan.name
 
-    fill_out_account_creation_form
+    fill_out_account_creation_form email: 'user@fabtabulous.com'
     fill_out_credit_card_form_with_valid_credit_card
 
     expect_to_see_purchase_success_flash_for(team_plan.name)
+
+    click_link 'Settings'
+
+    expect_to_see_team_name 'Fabtabulous'
   end
 
   def expect_to_see_featured_team_plans
@@ -29,5 +33,9 @@ feature 'Visitor can purchase a subscription for their team' do
         expect(page).not_to have_content team_plan.name
       end
     end
+  end
+
+  def expect_to_see_team_name(team_name)
+    expect(page).to have_content(team_name)
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -209,4 +209,18 @@ describe Subscription do
       SubscriptionFulfillment.stubs(:new).returns(fulfillment)
     end
   end
+
+  describe '#team?' do
+    it 'returns true with a team' do
+      subscription = create(:team).subscription
+
+      expect(subscription.team?).to be_true
+    end
+
+    it 'returns false without a team' do
+      subscription = create(:subscription)
+
+      expect(subscription.team?).to be_false
+    end
+  end
 end

--- a/spec/models/team_fulfillment_spec.rb
+++ b/spec/models/team_fulfillment_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe TeamFulfillment do
+  describe '#fulfill' do
+    it 'creates a new team with just that user' do
+      user = create(
+        :user,
+        :with_subscription,
+        email: 'user.name@whatever.somethingcool.com'
+      )
+      purchase = build_stubbed(:purchase)
+
+      TeamFulfillment.new(purchase, user).fulfill
+
+      team = user.reload.team
+      expect(team).to be_present
+      expect(team.name).to eq('Somethingcool')
+      expect(team.subscription).to eq(user.subscription)
+    end
+  end
+end

--- a/spec/models/team_plan_spec.rb
+++ b/spec/models/team_plan_spec.rb
@@ -94,15 +94,26 @@ describe TeamPlan do
   end
 
   describe '#fulfill' do
-    it 'starts a subscription' do
+    it 'starts a subscription for a new team' do
       user = build_stubbed(:user)
       purchase = build_stubbed(:purchase, user: user)
       plan = build_stubbed(:team_plan)
-      fulfillment = stub_subscription_fulfillment(purchase)
+      subscription_fulfillment = stub_subscription_fulfillment(purchase)
+      team_fulfillment = stub_team_fulfillment(purchase)
 
       plan.fulfill(purchase, user)
 
-      expect(fulfillment).to have_received(:fulfill)
+      expect(subscription_fulfillment).to have_received(:fulfill)
+      expect(team_fulfillment).to have_received(:fulfill)
+    end
+
+    def stub_team_fulfillment(purchase)
+      stub('team-fulfillment', :fulfill).tap do |fulfillment|
+        TeamFulfillment.
+          stubs(:new).
+          with(purchase, purchase.user).
+          returns(fulfillment)
+      end
     end
   end
 


### PR DESCRIPTION
- TeamPlan creates a Team when fulfilled
- Team names start out with a generated name based on the user's name
- Display the user's team name on the settings page

This brings up a separate issue: we don't currently have a place to
collect the team name. This change generates a name, since it's
required. I think this is probably okay, and we can let users edit it on
the subsequent screen we're adding for invitations. Let me know if you
disagree.

https://www.apptrajectory.com/thoughtbot/learn/stories/15638425
