### PR TITLE
Calculate the actual discounted amount

### DIFF
--- a/app/models/subscription_invoice.rb
+++ b/app/models/subscription_invoice.rb
@@ -83,7 +83,7 @@ class SubscriptionInvoice
   end
 
   def discount_amount
-    cents_to_dollars(stripe_invoice.discount.coupon.amount_off)
+    cents_to_dollars(stripe_invoice.subtotal - stripe_invoice.total)
   end
 
   def user

--- a/spec/models/subscription_invoice_spec.rb
+++ b/spec/models/subscription_invoice_spec.rb
@@ -127,4 +127,12 @@ describe SubscriptionInvoice do
       invoice.to_partial_path.should eq 'subscriber/invoices/subscription_invoice'
     end
   end
+
+  context 'invoice which has discount in percent' do
+    let(:invoice) { SubscriptionInvoice.new('in_3Eh5UIbuDVdhat') }
+
+    it 'returns the correct discount amount' do
+      expect(invoice.discount_amount).to eq 99.00
+    end
+  end
 end

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -251,7 +251,13 @@ class FakeStripe < Sinatra::Base
 
   get '/v1/invoices/:id' do
     content_type :json
-    customer_invoice.to_json
+
+    case params[:id]
+    when 'in_1s4JSgbcUaElzU'
+      customer_invoice.to_json
+    when 'in_3Eh5UIbuDVdhat'
+      customer_invoice_with_discount_in_percent.to_json
+    end
   end
 
   get "/v1/events/#{EVENT_ID_FOR_SUCCESSFUL_INVOICE_PAYMENT}" do
@@ -352,6 +358,36 @@ class FakeStripe < Sinatra::Base
       amount_due: 7900,
       customer: CUSTOMER_ID
     }
+  end
+
+  def customer_invoice_with_discount_in_percent
+    customer_invoice.merge(
+      id: "in_3Eh5UIbuDVdhat",
+      discount: {
+        id: "di_3Eh51qD66WOIHs",
+        coupon: {
+          id: "RESOLVE2014",
+          percent_off: 100,
+          amount_off: nil,
+          currency: nil,
+          object: "coupon",
+          livemode: true,
+          duration: "once",
+          redeem_by: 1389225599,
+          max_redemptions: nil,
+          times_redeemed: 77,
+          duration_in_months: nil,
+          valid: true
+        },
+        start: 1388677692,
+        object: "discount",
+        customer: CUSTOMER_ID,
+        end: nil
+      },
+      total: 0,
+      subtotal: 9900,
+      amount_due: 0
+    )
   end
 
   def customer_subscription


### PR DESCRIPTION
Stripe return an invoice with null `amount_off` when the `percent_off` coupon is used. In order to get the actual discounted amount, we need to determine it from the subtotal (before discount amount) instead.

https://www.apptrajectory.com/thoughtbot/learn/stories/15638803
