### PR TITLE
Fix Subscription#purchase when plan changed

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -62,7 +62,10 @@ class Subscription < ActiveRecord::Base
   end
 
   def purchase
-    user.purchases.for_purchaseable(plan).first
+    user.
+      purchases.
+      includes(:purchaseable).
+      detect { |purchase| purchase.subscription? }
   end
 
   def team?

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -191,15 +191,25 @@ describe Subscription do
 
       user = create(:user)
       plan = create(:plan)
-      other_plan = create(:plan)
       other_user = create(:user)
       subscription = create(:subscription, user: user, plan: plan)
       other_user_purchase =
         create(:plan_purchase, purchaseable: plan, user: other_user)
-      other_plan_purchase =
-        create(:plan_purchase, purchaseable: other_plan, user: user)
       subscription_purchase =
         create(:plan_purchase, purchaseable: plan, user: user)
+
+      expect(subscription.purchase).to eq(subscription_purchase)
+    end
+
+    it 'returns the purchase before the plan was changed' do
+      stub_fulfillment
+
+      user = create(:user)
+      original_plan = create(:plan)
+      new_plan = create(:plan)
+      subscription = create(:subscription, user: user, plan: new_plan)
+      subscription_purchase =
+        create(:plan_purchase, purchaseable: original_plan, user: user)
 
       expect(subscription.purchase).to eq(subscription_purchase)
     end


### PR DESCRIPTION
- Subscriptions with changed plans couldn't find their purchase
- Now ignores plan when trying to find a subscription purchase

Alternatively, we could bite the bullet and add a `purchase_id` column
to `subscriptions`, as well as logic and migrations to populate it. This
would likely require some manual tweaking, as there are at least some
purchases and subscriptions that are referentially invalid.
