### PR TITLE
Default includes_mentoring to false

### DIFF
--- a/db/migrate/20140113204616_change_mentoring_default_to_false.rb
+++ b/db/migrate/20140113204616_change_mentoring_default_to_false.rb
@@ -1,0 +1,11 @@
+class ChangeMentoringDefaultToFalse < ActiveRecord::Migration
+  def up
+    change_column_default :individual_plans, :includes_mentor, false
+    change_column_default :team_plans, :includes_mentor, false
+  end
+
+  def down
+    change_column_default :team_plans, :includes_mentor, true
+    change_column_default :individual_plans, :includes_mentor, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140106122343) do
+ActiveRecord::Schema.define(version: 20140113204616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,18 +98,18 @@ ActiveRecord::Schema.define(version: 20140106122343) do
   add_index "follow_ups", ["workshop_id"], name: "index_follow_ups_on_workshop_id", using: :btree
 
   create_table "individual_plans", force: true do |t|
-    t.string   "name",                              null: false
-    t.string   "sku",                               null: false
-    t.string   "short_description",                 null: false
-    t.text     "description",                       null: false
-    t.boolean  "active",             default: true, null: false
-    t.integer  "individual_price",                  null: false
+    t.string   "name",                               null: false
+    t.string   "sku",                                null: false
+    t.string   "short_description",                  null: false
+    t.text     "description",                        null: false
+    t.boolean  "active",             default: true,  null: false
+    t.integer  "individual_price",                   null: false
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: true
+    t.boolean  "includes_mentor",    default: false
     t.boolean  "includes_workshops", default: true
-    t.boolean  "featured",           default: true, null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.boolean  "featured",           default: true,  null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
   end
 
   create_table "mentors", force: true do |t|
@@ -298,15 +298,15 @@ ActiveRecord::Schema.define(version: 20140106122343) do
   end
 
   create_table "team_plans", force: true do |t|
-    t.string   "sku",                               null: false
-    t.string   "name",                              null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.string   "sku",                                null: false
+    t.string   "name",                               null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.integer  "individual_price"
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: true, null: false
-    t.boolean  "includes_workshops", default: true, null: false
-    t.boolean  "featured",           default: true, null: false
+    t.boolean  "includes_mentor",    default: false, null: false
+    t.boolean  "includes_workshops", default: true,  null: false
+    t.boolean  "featured",           default: true,  null: false
     t.text     "description"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -141,8 +141,11 @@ FactoryGirl.define do
 
     factory :basic_plan do
       sku IndividualPlan::PRIME_BASIC_SKU
-      includes_mentor false
       includes_workshops false
+    end
+
+    trait :includes_mentor do
+      includes_mentor true
     end
   end
 
@@ -323,6 +326,12 @@ FactoryGirl.define do
 
     factory :subscriber do
       with_subscription
+
+      trait :includes_mentor do
+        ignore do
+          plan { create(:individual_plan, :includes_mentor) }
+        end
+      end
     end
 
     trait :with_github do
@@ -344,8 +353,13 @@ FactoryGirl.define do
       with_github
       stripe_customer_id 'cus12345'
 
-      after :create do |instance|
-        instance.purchased_subscription = create(:subscription, user: instance)
+      ignore do
+        plan { create(:plan) }
+      end
+
+      after :create do |instance, attributes|
+        instance.purchased_subscription =
+          create(:subscription, plan: attributes.plan, user: instance)
       end
     end
 

--- a/spec/features/subscriber_contacts_mentor_spec.rb
+++ b/spec/features/subscriber_contacts_mentor_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Subscriber can contact his mentor' do
   scenario 'from the dashboard' do
-    sign_in_as_user_with_subscription
+    sign_in_as_user_with_mentoring_subscription
     mentor = @current_user.mentor
 
     expect(page).to have_content(I18n.t('dashboards.show.contact_your_mentor', mentor_name: mentor.first_name))

--- a/spec/mailers/purchase_mailer_spec.rb
+++ b/spec/mailers/purchase_mailer_spec.rb
@@ -171,8 +171,9 @@ describe PurchaseMailer do
         end
 
         it 'mentions the mentor email' do
-          user = create(:subscriber)
-          purchase = create(:plan_purchase, user: user)
+          plan = create(:individual_plan, :includes_mentor)
+          user = create(:subscriber, plan: plan)
+          purchase = create(:plan_purchase, user: user, purchaseable: plan)
 
           expect(email_for(purchase)).to have_body_text(/mentor/)
         end

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -45,7 +45,7 @@ describe Mentor do
   describe '#active_mentees' do
     it 'returns the list of active mentees' do
       mentor = create(:mentor)
-      active = create(:subscriber)
+      active = create(:subscriber, :includes_mentor)
       inactive = create(:user, :with_inactive_subscription)
       without_mentoring = create(:user, :with_basic_subscription)
       mentor.mentees = [active, inactive, without_mentoring]
@@ -58,8 +58,8 @@ describe Mentor do
     it 'returns the list of active mentees' do
       mentor = create(:mentor)
       mentor.mentees = [
-        create(:subscriber),
-        create(:subscriber)
+        create(:subscriber, :includes_mentor),
+        create(:subscriber, :includes_mentor)
       ]
 
       expect(mentor.active_mentee_count).to eq 2

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -27,8 +27,11 @@ describe Subscription do
 
   describe '.deliver_welcome_emails' do
     it 'sends emails for each new mentored subscriber in the last 24 hours' do
-      old_subscription = create(:subscription, created_at: 25.hours.ago)
-      new_subscription = create(:subscription, created_at: 10.hours.ago)
+      plan = create(:individual_plan, includes_mentor: true)
+      old_subscription =
+        create(:subscription, plan: plan, created_at: 25.hours.ago)
+      new_subscription =
+        create(:subscription, plan: plan, created_at: 10.hours.ago)
       mailer = stub(deliver: true)
       SubscriptionMailer.stubs(welcome_to_prime_from_mentor: mailer)
 

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -1,10 +1,15 @@
 module Subscriptions
-  def sign_in_as_user_with_subscription
+  def sign_in_as_user_with_subscription(*traits)
     @current_user = create(
       :subscriber,
+      *traits,
       stripe_customer_id: FakeStripe::CUSTOMER_ID
     )
     visit dashboard_path(as: @current_user)
+  end
+
+  def sign_in_as_user_with_mentoring_subscription
+    sign_in_as_user_with_subscription(:includes_mentor)
   end
 
   def sign_in_as_user_with_downgraded_subscription


### PR DESCRIPTION
- Most plans set this to false
- New plans should probably use the most common value
- Mentoring requires mentors, which increases test setup
