### PR TITLE
Use db:setup instead of db:migrate on TDDium

### DIFF
--- a/config/tddium.yml
+++ b/config/tddium.yml
@@ -3,5 +3,5 @@
   :ruby_version: ruby-2.0.0-p247
   :bundler_version: 1.3.5
   :hooks:
-    :worker: bundle exec rake db:migrate
+    :worker: bundle exec rake db:setup
     :post: bundle exec rake assets:precompile


### PR DESCRIPTION
- Migrations can't run from an empty database.

https://api.tddium.com/reports/558119
