### PR TITLE
Copy quantity onto teams for team subscription

### DIFF
--- a/app/models/team_fulfillment.rb
+++ b/app/models/team_fulfillment.rb
@@ -1,5 +1,6 @@
 class TeamFulfillment
   def initialize(purchase, user)
+    @purchase = purchase
     @user = user
   end
 
@@ -11,7 +12,11 @@ class TeamFulfillment
   private
 
   def create_team
-    Team.create!(name: generate_team_name, subscription: subscription)
+    Team.create!(
+      name: generate_team_name,
+      subscription: subscription,
+      max_users: @purchase.quantity
+    )
   end
 
   def generate_team_name

--- a/db/migrate/20140114195456_add_users_allowed_to_teams.rb
+++ b/db/migrate/20140114195456_add_users_allowed_to_teams.rb
@@ -1,0 +1,11 @@
+class AddUsersAllowedToTeams < ActiveRecord::Migration
+  def up
+    add_column :teams, :max_users, :integer
+
+    change_column_null :teams, :max_users, false, 0
+  end
+
+  def down
+    remove_column :teams, :max_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140113204616) do
+ActiveRecord::Schema.define(version: 20140114195456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -316,6 +316,7 @@ ActiveRecord::Schema.define(version: 20140113204616) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.integer  "subscription_id", null: false
+    t.integer  "max_users",       null: false
   end
 
   create_table "topics", force: true do |t|

--- a/spec/models/team_fulfillment_spec.rb
+++ b/spec/models/team_fulfillment_spec.rb
@@ -8,7 +8,7 @@ describe TeamFulfillment do
         :with_subscription,
         email: 'user.name@whatever.somethingcool.com'
       )
-      purchase = build_stubbed(:purchase)
+      purchase = build_stubbed(:purchase, quantity: 4)
 
       TeamFulfillment.new(purchase, user).fulfill
 
@@ -16,6 +16,7 @@ describe TeamFulfillment do
       expect(team).to be_present
       expect(team.name).to eq('Somethingcool')
       expect(team.subscription).to eq(user.subscription)
+      expect(team.max_users).to eq(purchase.quantity)
     end
   end
 end


### PR DESCRIPTION
- Prevents need to lookup a purchase for a team
- Allows changing quantity after purchase is complete

https://www.apptrajectory.com/thoughtbot/learn/stories/15638425
