### PR TITLE
Include Product in rails_admin dropbox

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,6 +4,7 @@ class Product < ActiveRecord::Base
   has_many :downloads, as: :purchaseable
   has_many :purchases, as: :purchaseable
   has_many :topics, through: :classifications
+  has_many :videos, as: :watchable, dependent: :destroy
 
   accepts_nested_attributes_for :downloads, allow_destroy: true
 

--- a/app/models/screencast.rb
+++ b/app/models/screencast.rb
@@ -1,6 +1,4 @@
 class Screencast < Product
-  has_many :videos, as: :watchable
-
   def collection?
     videos.count > 1
   end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -1,6 +1,4 @@
 class Show < Product
-  has_many :videos, as: :watchable, dependent: :destroy
-
   private
 
   def product_licenses


### PR DESCRIPTION
RailsAdmin gets the list of models from seeing which models include the 
polymorphic association. Unfortunately, this is not what Rails expects with
STI. The Videos need to have watchable_type `Product` not `Show`
