### PR TITLE
explain mentor duties more clearly in feature details

### DIFF
--- a/app/views/plans/_mentoring_detail.html.erb
+++ b/app/views/plans/_mentoring_detail.html.erb
@@ -1,5 +1,5 @@
 <article>
-  <p><strong>This is <%= mentor.first_name %></strong>. If you choose this plan, <%= mentor.first_name %> will be your mentor. <%= mentor.bio %></p>
+  <p><strong>This is <%= mentor.first_name %></strong>. If you choose this plan, they'll be your mentor — <%= mentor.first_name %> will coach you one-on-one for 30 mins a month, focusing on whatever you like: getting that first Rails position, salary negotiation, a specific problem in a side-project, etc. <%= mentor.bio %></p>
   <p>Don't worry! If it turns out that <%= mentor.first_name %> isn't a good fit for you, we'll happily swap you to someone else.</p>
 </article>
 


### PR DESCRIPTION
from https://www.apptrajectory.com/thoughtbot/learn/stories/15639265

The structure of our mentor feature description is "This is X, bio bio bio, you can switch if you want" — We really ought to say "This is X, X will coach you one-on-one once a month for 30 mins. Bio bio bio. You can switch if you want." We do already explain on the marketing page, but I think it should be re-iterated.
