### PR TITLE
Use to_json to ensure well-formed JS in analytics

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,23 @@
+module AnalyticsHelper
+  def analytics_hash
+    {
+      created: current_user.created_at,
+      email: current_user.email,
+      has_active_subscription: current_user.has_active_subscription?,
+      has_logged_in_to_forum: current_user.has_logged_in_to_forum?,
+      mentor_name: current_user.mentor_name,
+      name: current_user.name,
+      plan: current_user.plan_name,
+      subscribed_at: current_user.subscribed_at,
+      username: current_user.github_username
+    }
+  end
+
+  def intercom_hash
+    {
+      'Intercom' => {
+        userHash: OpenSSL::HMAC.hexdigest('sha256', ENV['INTERCOM_API_SECRET'], current_user.id.to_s)
+      }
+    }
+  end
+end

--- a/app/views/shared/_signed_in_analytics.html.erb
+++ b/app/views/shared/_signed_in_analytics.html.erb
@@ -1,17 +1,7 @@
 <script type="text/javascript">
-  analytics.identify('<%= current_user.id %>', {
-    created : '<%= current_user.created_at %>',
-    email : '<%= current_user.email %>',
-    has_active_subscription : '<%= current_user.has_active_subscription? %>',
-    has_logged_in_to_forum : '<%= current_user.has_logged_in_to_forum? %>',
-    mentor_name : '<%= current_user.mentor_name %>',
-    name : '<%= current_user.name %>',
-    plan : '<%= current_user.plan_name %>',
-    subscribed_at : '<%= current_user.subscribed_at %>',
-    username : '<%= current_user.github_username %>'
-  }, {
-    Intercom : {
-      userHash : '<%= OpenSSL::HMAC.hexdigest('sha256', ENV['INTERCOM_API_SECRET'], current_user.id.to_s) %>'
-    }
-  });
+  analytics.identify(
+    '<%= current_user.id %>',
+    <%= raw analytics_hash.to_json %>,
+    <%= raw intercom_hash.to_json %>
+  );
 </script>

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe 'shared/_analytics.html.erb' do
+  context 'when signed out' do
+    before do
+      view_stubs(signed_in?: false)
+    end
+
+    it 'loads the Segment.io JavaScript library' do
+      segment_load_line = 'window.analytics.load("2nexpdgku3");'
+
+      render
+
+      expect(rendered).to include(segment_load_line)
+    end
+
+    it 'records a pageview' do
+      record_pageview_line = 'window.analytics.page();'
+
+      render
+
+      expect(rendered).to include(record_pageview_line)
+    end
+
+    it 'does not load user-specific analytics' do
+      render
+
+      expect(rendered).to have_received(:render).
+        with('shared/signed_in_analytics').
+        never
+    end
+  end
+
+  context 'when signed in' do
+    around(:each) do |example|
+      ClimateControl.modify INTERCOM_API_SECRET: secret do
+        example.run
+      end
+    end
+
+    before(:each) do
+      view_stubs(
+        current_user: stub_everything('current user', id: current_user_id),
+        signed_in?: true
+      )
+    end
+
+    it 'identifies the user' do
+      identify_line = 'analytics.identify('
+
+      render
+
+      expect(rendered).to include(identify_line)
+    end
+
+    it 'records current properties of user' do
+      user_properties = {
+        created: nil,
+        email: nil,
+        has_active_subscription: nil,
+        has_logged_in_to_forum: nil,
+        mentor_name: nil,
+        name: nil,
+        plan: nil,
+        subscribed_at: nil,
+        username: nil
+      }.to_json
+
+      render
+
+      expect(rendered).to include(user_properties)
+    end
+
+    it 'uses Intercom secure mode' do
+      intercom_secure_mode = {
+        'Intercom' => {
+          userHash: OpenSSL::HMAC.hexdigest('sha256', secret, current_user_id.to_s)
+        }
+      }.to_json
+
+      render
+
+      expect(rendered).to include(intercom_secure_mode)
+    end
+
+    def secret
+      'secret'
+    end
+
+    def current_user_id
+      1
+    end
+  end
+end


### PR DESCRIPTION
It's best to send dates to Segment.io as iso8601 date strings. Example:

```
"2014-01-14T18:39:32.731Z"
```

https://www.apptrajectory.com/thoughtbot/learn/stories/15639415
