### PR TITLE
Clarify/expand mentor duties, clarify coaching medium

### DIFF
--- a/app/views/plans/_mentoring_detail.html.erb
+++ b/app/views/plans/_mentoring_detail.html.erb
@@ -1,5 +1,4 @@
 <article>
-  <p><strong>This is <%= mentor.first_name %></strong>. If you choose this plan, they'll be your mentor — <%= mentor.first_name %> will coach you one-on-one for 30 mins a month, focusing on whatever you like: getting that first Rails position, salary negotiation, a specific problem in a side-project, etc. <%= mentor.bio %></p>
-  <p>Don't worry! If it turns out that <%= mentor.first_name %> isn't a good fit for you, we'll happily swap you to someone else.</p>
+  <p><strong>This is <%= mentor.first_name %></strong>, your first mentor if you choose this plan. <%= mentor.first_name %> will coach you one-on-one for 30 mins a month in a video chat, focusing on whatever you like: getting that first Rails position, salary negotiation, a specific problem in a side-project, etc. <%= mentor.bio %></p>
 </article>
 


### PR DESCRIPTION
Let's try to sell this mentoring a bit more.

As is, a sample excerpt might read like:

> "This is Jason. If you choose this plan, they'll be your mentor — Jason will coach you one-on-one for 30 mins a month, focusing on whatever you like: getting that first Rails position, salary negotiation, a specific problem in a side-project, etc. Jason began his programming career at Virginia Tech writing applications in Ruby on Rails. Since then he has taken every opportunity to improve his coding and TDD skills. Graduating from Radford University tucked in the mountains of Virginia, he enjoys the outdoors, wakeboarding, snowboarding, and riding curves on his motorcycle. Don't worry! If it turns out that Jason isn't a good fit for you, we'll happily swap you to someone else."

The second sentence is causing a little hesitation in some users — they're questioning whether "just 30 mins" is worth the extra cash. Maybe we could pitch it better. I've already added "in a video chat" but we should consider adding more ways the mentor might help a mentee. Maybe there's a way we can do this without sounding like we're making promises? Maybe we could include a testimonial?
