### PR TITLE
Redirect to dashboard with nil Omniauth origin

### DIFF
--- a/app/controllers/auth_callbacks_controller.rb
+++ b/app/controllers/auth_callbacks_controller.rb
@@ -28,6 +28,6 @@ class AuthCallbacksController < ApplicationController
   end
 
   def auth_origin
-    request.env['omniauth.origin']
+    request.env['omniauth.origin'] || dashboard_url
   end
 end

--- a/spec/controllers/auth_callbacks_controller_spec.rb
+++ b/spec/controllers/auth_callbacks_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe AuthCallbacksController do
+  context '#create' do
+    it 'redirects to the dashboard path without an auth origin' do
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:github]
+      request.env['omniauth.origin'] = nil
+
+      get :create, provider: 'github'
+
+      should redirect_to(dashboard_url)
+    end
+  end
+end


### PR DESCRIPTION
Omniauth sometimes fails to pass an origin URL. Redirect to the dashboard when
this is the case.

https://github.com/intridea/omniauth/issues/306
