### PR TITLE
Toggle analytics

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,4 +1,8 @@
 module AnalyticsHelper
+  def analytics?
+    ENV['ANALYTICS']
+  end
+
   def analytics_hash
     {
       created: current_user.created_at,

--- a/app/views/shared/_javascript.html.erb
+++ b/app/views/shared/_javascript.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag 'application', 'prefilled_input' %>
 
-<% if Rails.env.production? %>
+<% if analytics? %>
   <%= render 'shared/analytics' %>
 <% end %>
 

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe AnalyticsHelper, '#analytics?' do
+  it "is true when ENV['ANALYTICS'] is present" do
+    ENV['ANALYTICS'] = 'anything'
+
+    expect(analytics?).to be_true
+
+    ENV['ANALYTICS'] = nil
+  end
+
+  it "is false when ENV['ANALYTICS'] is not present" do
+    ENV['ANALYTICS'] = nil
+
+    expect(analytics?).to be_false
+  end
+end


### PR DESCRIPTION
By default, we only want analytics recorded in Segment.io in the production
environment. When tracking new events, we want to be able to test on staging
before deploying to production.

This introduces a ENV['ANALYTICS'] variable to toggle analytics tracking on
and off.

https://www.apptrajectory.com/thoughtbot/learn/stories/15639571
