### PR TITLE
Update TeamPlan name on polymorphic relationships

### DIFF
--- a/db/migrate/20140123145010_update_team_plans_type.rb
+++ b/db/migrate/20140123145010_update_team_plans_type.rb
@@ -1,0 +1,21 @@
+class UpdateTeamPlansType < ActiveRecord::Migration
+  def up
+    update_type :subscriptions, :plan_type, 'TeamPlan', 'Teams::TeamPlan'
+    update_type :purchases, :purchaseable_type, 'TeamPlan', 'Teams::TeamPlan'
+  end
+
+  def down
+    update_type :subscriptions, :plan_type, 'Teams::TeamPlan', 'TeamPlan'
+    update_type :purchases, :purchaseable_type, 'Teams::TeamPlan', 'TeamPlan'
+  end
+
+  def update_type(table, column, previous, new)
+    say_with_time "Changing #{previous} to #{new} on #{table}.#{column}" do
+      connection.update(<<-SQL)
+        UPDATE #{table}
+        SET #{column} = '#{new}'
+        WHERE #{column} = '#{previous}'
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140114195457) do
+ActiveRecord::Schema.define(version: 20140123145010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
- We renamed TeamPlan to Teams::TeamPlan
- Two tables had polymorphic relationships that included TeamPlan
- The *_type columns for TeamPlan needed to be updated

https://www.apptrajectory.com/thoughtbot/learn/stories/15639570
