### PR TITLE
Authorize users of the subscriber/purchases controller

### DIFF
--- a/app/controllers/subscriber/purchases_controller.rb
+++ b/app/controllers/subscriber/purchases_controller.rb
@@ -1,5 +1,7 @@
 module Subscriber
   class PurchasesController < ApplicationController
+    before_filter :authorize
+
     def new
       @purchaseable = PurchaseableDecorator.new(requested_purchaseable)
     end

--- a/spec/controllers/subscriber/purchases_controller_spec.rb
+++ b/spec/controllers/subscriber/purchases_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Subscriber::PurchasesController do
+  describe '#new when attempting to purchase without being signed in' do
+    it 'redirects to sign in page' do
+      workshop = build_stubbed(:workshop)
+
+      get :new, workshop_id: workshop.id
+
+      expect(response).to redirect_to sign_in_path
+    end
+  end
+end


### PR DESCRIPTION
https://www.apptrajectory.com/thoughtbot/learn/stories/15639091

Attempting to view `subscriber/purchases#new` without being logged in
raised an error due to missing `current_user`.
