### PR TITLE
Skip application authorization with Doorkeeper

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -65,7 +65,7 @@ Doorkeeper.configure do
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.
   # For example if dealing with trusted a application.
-  # skip_authorization do |resource_owner, client|
-  #   client.superapp? or resource_owner.admin?
-  # end
+  skip_authorization do |resource_owner, client|
+    true
+  end
 end

--- a/spec/features/oauth_client_authenticates_spec.rb
+++ b/spec/features/oauth_client_authenticates_spec.rb
@@ -43,7 +43,6 @@ feature 'An OAuth client authenticates', js: true do
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
     click_button 'Sign in'
-    click_button 'Authorize'
   end
 
   def authorize_via_password(user)


### PR DESCRIPTION
- We control all the applications; users can't make their own.
- Our users implicitly trust our app, so there's no reason to reauthorize.
- We'll want to add a flag to applications if we allow user apps.

https://www.apptrajectory.com/thoughtbot/learn/stories/15640210
