### PR TITLE
Create "Weekly Iteration" landing pages

### DIFF
--- a/app/assets/stylesheets/_landing-pages.scss
+++ b/app/assets/stylesheets/_landing-pages.scss
@@ -1,0 +1,3 @@
+body.weekly_iterations-show #videos {
+  margin-top: 25px;
+}

--- a/app/assets/stylesheets/_products-workshops-show.scss
+++ b/app/assets/stylesheets/_products-workshops-show.scss
@@ -141,6 +141,8 @@ body.products-show aside,
 body.workshops-show aside,
 body.books-show aside,
 body.screencasts-show aside,
+body.weekly_iterations-show aside,
+body.episodes-show aside,
 body.purchases-new aside {
   #license > div:last-child {
     margin-bottom: 2rem;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,6 +24,7 @@
 @import "teams-edit";
 @import "products-index";
 @import "dashboards-show";
+@import "landing-pages";
 @import "products-workshops-show";
 @import "purchases-new";
 @import "purchases-show";

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -39,6 +39,7 @@ body.passwords-create {
     }
 
     img, span {
+      color: $learnred;
       position: relative;
       display: inline-block;
       vertical-align: top;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,4 +59,10 @@ class ApplicationController < ActionController::Base
     Topic.top
   end
   helper_method :topics
+
+  def current_user_purchase_of(purchaseable)
+    if signed_in?
+      purchaseable.purchase_for(current_user)
+    end
+  end
 end

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -1,0 +1,12 @@
+class EpisodesController < ApplicationController
+  layout 'landing_pages'
+
+  def show
+    @video = Video.find(params[:id])
+    @plan = IndividualPlan.basic
+
+    if purchase = current_user_purchase_of(@video.watchable)
+      redirect_to [purchase, @video]
+    end
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -8,8 +8,8 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
     @offering = @product
 
-    if signed_in? && @product.purchase_for(current_user)
-      redirect_to @product.purchase_for(current_user)
+    if purchase = current_user_purchase_of(@product)
+      redirect_to purchase
     end
   end
 end

--- a/app/controllers/weekly_iterations_controller.rb
+++ b/app/controllers/weekly_iterations_controller.rb
@@ -1,0 +1,12 @@
+class WeeklyIterationsController < ApplicationController
+  layout 'landing_pages'
+
+  def show
+    @show = Show.the_weekly_iteration
+    @plan = IndividualPlan.basic
+
+    if signed_in?
+      redirect_to @show
+    end
+  end
+end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -3,8 +3,8 @@ class WorkshopsController < ApplicationController
     @workshop = Workshop.find(params[:id])
     @offering = @workshop
 
-    if signed_in? && @workshop.purchase_for(current_user)
-      redirect_to @workshop.purchase_for(current_user)
+    if purchase = current_user_purchase_of(@workshop)
+      redirect_to purchase
     end
   end
 end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -1,4 +1,10 @@
 class Show < Product
+  THE_WEEKLY_ITERATION = 'The Weekly Iteration'
+
+  def self.the_weekly_iteration
+    where(name: THE_WEEKLY_ITERATION).first
+  end
+
   private
 
   def product_licenses

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -38,6 +38,10 @@ class Video < ActiveRecord::Base
     @wistia_thumbnail ||= wistia_hash["thumbnail"]["url"] rescue nil
   end
 
+  def full_sized_wistia_thumbnail
+    wistia_thumbnail.try(:split, '?').try(:first)
+  end
+
   def has_notes?
     notes.present?
   end

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for :landing_page_back_link do %>
+  <%= link_to '&larr; All Videos'.html_safe, '/the-weekly-iteration' %>
+<% end %>
+
+<% cache(@video) do %>
+  <div class="text-box-wrapper">
+    <div class="text-box">
+      <%= image_tag @video.full_sized_wistia_thumbnail, alt: @video.title, class: "thumbnail" %>
+
+      <section class='video-notes'>
+        <h3>Notes</h3>
+        <%= raw(@video.notes_html) %>
+      </section>
+    </div>
+  </div>
+
+  <aside>
+    <% if signed_out? %>
+      <%= render 'weekly_iterations/subscribe', plan: @plan, show: @video.watchable %>
+    <% else %>
+      <%= render @video.watchable.licenses_for(current_user) %>
+    <% end %>
+
+    <%= render 'products/terms', product: @video.watchable %>
+  </aside>
+<% end %>

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head prefix="og: http://ogp.me/ns#">
+    <%= render 'application/head_contents' %>
+  </head>
+
+  <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
+    <section id="header-wrapper">
+      <div class="header-container">
+        <h1 class="small-logo">
+          <%= image_tag('learn/learn-ralph-small.png') %>
+          <span><%= t 'shared.learn' %></span>
+        </h1>
+        <nav class="left">
+          <ul>
+            <li class="back">
+              <%= yield(:landing_page_back_link) %>
+            </li>
+          </ul>
+        </nav>
+        <nav>
+          <ul>
+            <li class="account"><%= link_to 'Sign in', sign_in_path %></li>
+          </ul>
+        </nav>
+      </div>
+    </section>
+
+    <section class="content">
+      <% if content_for?(:subject_block) %>
+        <div class="subject"><%= yield(:subject_block) %></div>
+      <% end %>
+      <%= yield %>
+    </section>
+
+    <footer class="links">
+      <p id="copyright">
+        © 2012 - <%= Time.zone.today.year %> thoughtbot, inc. The
+        <em>design of a robot</em> and <em>thoughtbot</em> are registered
+        trademarks of thoughtbot,&nbsp;inc. See our
+        <%= link_to 'Privacy Policy', privacy_path %> and
+        <%= link_to 'Terms & Conditions', terms_path %>.
+      </p>
+    </footer>
+
+    <%= render 'chat' %>
+    <%= render 'shared/javascript' %>
+  </body>
+</html>

--- a/app/views/weekly_iterations/_subscribe.html.erb
+++ b/app/views/weekly_iterations/_subscribe.html.erb
@@ -1,0 +1,9 @@
+<section id="license" class="show">
+  <div class="prime-purchase">
+    <div class="license">
+      <%= link_to new_individual_plan_purchase_path(plan), class: 'license-button button prime-button' do %>
+        <%= t('weekly_iteration_subscribe_cta') %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/weekly_iterations/show.html.erb
+++ b/app/views/weekly_iterations/show.html.erb
@@ -1,0 +1,24 @@
+<%= render 'offerings/meta', offering: @show %>
+
+<div class="text-box-wrapper">
+  <div class="text-box">
+    <p class="videowrapper">
+      <iframe src="//fast.wistia.net/embed/iframe/ol6e0miehm?controlsVisibleOnLoad=true&version=v1&videoHeight=415&videoWidth=738&volumeControl=true" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" width="653" height="367"></iframe>
+    </p>
+
+    <section id="videos">
+      <% @show.videos.ordered.each do |video| %>
+        <%= content_tag_for :div, video do %>
+          <%= link_to public_video_path(video) do %>
+            <%= render 'videos/thumbnail', video: video %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </section>
+  </div>
+</div>
+
+<aside>
+  <%= render 'subscribe', plan: @plan, show: @show %>
+  <%= render 'products/terms', product: @show %>
+</aside>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,3 +194,6 @@ en:
         success: Your subscription has been downgraded.
       cancel:
         success: We're sorry to see you go. You will have access to all the benefits of Prime until the end of your current billing cycle.
+
+  weekly_iteration_subscribe_cta:
+    Subscribe to Watch the Weekly Iteration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Workshops::Application.routes.draw do
     end
   end
 
-
   namespace :teams do
     resources :invitations, only: [:create] do
       resources :acceptances, only: [:new, :create]
@@ -61,6 +60,9 @@ Workshops::Application.routes.draw do
     resources :redemptions, only: [:new]
     resources :purchases, only: [:show]
   end
+
+  get '/the-weekly-iteration' => 'weekly_iterations#show'
+  get '/videos/:id' => 'episodes#show', as: :public_video
 
   resources :purchases, only: [:show] do
     resources :videos, only: [:show]

--- a/spec/controllers/episodes_controller_spec.rb
+++ b/spec/controllers/episodes_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+include StubCurrentUserHelper
+
+describe EpisodesController do
+  describe '#show when viewing a video as a subscriber' do
+    it 'redirects to purchase view so they can watch video' do
+      user = create(:subscriber)
+      video = create(:video)
+      purchase = create(:purchase, user: user, purchaseable: video.watchable)
+      controller.stubs(:signed_in?).returns(true)
+      stub_current_user_with(user)
+
+      get :show, id: video
+
+      expect(response).to(
+        redirect_to([purchase, video])
+      )
+    end
+  end
+end

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -79,5 +79,25 @@ describe 'Videos' do
 
       expect(page).to have_content("includes support")
     end
+
+    it 'redirects subscribers from Weekly Iteration landing page' do
+      sign_in_as_user_with_subscription
+
+      show = create(:show, name: Show::THE_WEEKLY_ITERATION)
+
+      visit '/the-weekly-iteration'
+
+      expect(page.current_path).to eq show_path(show)
+    end
+
+    it 'encourages subscribers to purchase The Weekly Iteration' do
+      user = create(:subscriber)
+      show = create(:show)
+      video = create(:video, watchable: show)
+
+      visit public_video_path(video, as: user)
+
+      expect(page).to have_content 'Get this show'
+    end
   end
 end

--- a/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
+++ b/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+feature 'Visitor' do
+  scenario 'views Weekly Iteration episodes' do
+    show_name = Show::THE_WEEKLY_ITERATION
+    show = create(:show, name: show_name)
+    create(:individual_plan, sku: IndividualPlan::PRIME_BASIC_SKU)
+    video_title = 'Unfriendly Nil'
+    video_notes = 'Nil is contagious.'
+    create(:video, title: video_title, notes: video_notes, watchable: show)
+
+    visit '/the-weekly-iteration'
+
+    expect(page).to have_content(show_name)
+
+    click_link video_title
+
+    expect(page).to have_content(video_notes)
+    expect(page).to have_content(I18n.t('weekly_iteration_subscribe_cta'))
+  end
+end

--- a/spec/models/show_spec.rb
+++ b/spec/models/show_spec.rb
@@ -22,4 +22,14 @@ describe Show do
       expect(show.licenses_for(user).first).to be_a(SubscriberLicense)
     end
   end
+
+  describe '.the_weekly_iteration' do
+    it 'finds the show named The Weekly Iteration' do
+      show = create(:show, name: Show::THE_WEEKLY_ITERATION)
+
+      result = Show.the_weekly_iteration
+
+      expect(result).to eq show
+    end
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -24,6 +24,19 @@ describe Video do
     end
   end
 
+  context '#full_sized_wistia_thumbnail' do
+    it 'returns the full sized thumbnail cached from wistia' do
+      video = build_stubbed(:video,
+        wistia_hash: {
+          'thumbnail' => {
+            'url' => 'http://images.com/hi.jpg?image_crop_resized=100x60'
+          }
+        }
+      )
+      video.full_sized_wistia_thumbnail.should == 'http://images.com/hi.jpg'
+    end
+  end
+
   context 'watchable_name' do
     it 'returns the name of the watchable' do
       workshop = create(:workshop, name: 'Workshop')


### PR DESCRIPTION
- Create publicly-accessible "Weekly Iteration" landing page.
- Create publicly-accessible landing pages for each of the "Weekly
  Iteration" videos.
- Remove almost all header and footer nav, except Privacy Policy and
  Terms of Service (landing page best practices).
- Redirect subscribers from "Weekly Iteration" landing page to internal
  page.
- Redirect subscribers who have purchased "Weekly Iteration" on video
  landing pages.
- Display "Get this show" on video landing pages to subscribers who have
  not purchased "Weekly Iteration".

https://www.apptrajectory.com/thoughtbot/learn/stories/15640213
