### PR TITLE
Using asset path to server images 

### DIFF
--- a/app/assets/stylesheets/_authenticating.scss
+++ b/app/assets/stylesheets/_authenticating.scss
@@ -15,7 +15,7 @@
     text-transform: uppercase;
 
     &:after {
-      content: url('/assets/GitHub-Mark-32px.png');
+      content: url(<%= asset_path 'GitHub-Mark-32px.png' %>);
       height: 32px;
       left: 14px;
       margin-top: -15px;

--- a/app/assets/stylesheets/_base-extends.scss.erb
+++ b/app/assets/stylesheets/_base-extends.scss.erb
@@ -27,7 +27,7 @@
 }
 
 %goal-bullet-add {
-  background: url(/assets/plus.svg) $learnred center center no-repeat;
+  background: url(<%= asset_path 'plus.svg' %>) $learnred center center no-repeat;
   background-size: .9rem;
   border-color: transparent;
   color: #fff;

--- a/app/assets/stylesheets/_components.scss.erb
+++ b/app/assets/stylesheets/_components.scss.erb
@@ -32,7 +32,7 @@
   }
 
   &.complete .status {
-    background: url(/assets/check.svg) no-repeat 5px 5px #83EBA8;
+    background: url(<%= asset_path 'check.svg' %>) no-repeat 5px 5px #83EBA8;
     background-size: 18px;
     color: darken(#83EBA8, 45%);
     display: block;

--- a/app/assets/stylesheets/_dashboards-show.scss.erb
+++ b/app/assets/stylesheets/_dashboards-show.scss.erb
@@ -9,7 +9,7 @@ body.dashboards-show {
   }
 
   .workshops.disabled {
-    background: url(stripe.png) repeat rgba(0, 0, 0, .05);
+    background: url(<%= asset_path 'stripe.png' %>) repeat rgba(0, 0, 0, .05);
     border-top: 1px solid rgba(0, 0, 0, .1);
 
     .disabled-text {


### PR DESCRIPTION
These assets needs to be served via CF. And should be using asset_path as others.  

This PR will solve this story as well  https://www.apptrajectory.com/thoughtbot/learn/stories/15639520 
Attached screenshot is showing that one of these image served via HTTP instead of HTTPS.

![thoughtbot_learn_20140211_144845](https://f.cloud.github.com/assets/3948/2137343/3ae3c462-9324-11e3-9a47-e22384e5f569.jpg)
