### PR TITLE
Add four new exercises to the dashboard

### DIFF
--- a/app/assets/stylesheets/_components.scss.erb
+++ b/app/assets/stylesheets/_components.scss.erb
@@ -297,7 +297,7 @@
     }
   }
 
-  > figure, > .figure-container {
+  > figure {
     margin-right: $product-card-margin;
     margin-right: calc(#{$product-card-margin} - 4px); // remove inline-block 4px space issue
     @include transition(.15s);
@@ -376,20 +376,24 @@
     text-transform: uppercase;
   }
 
-  &.screencasts {
+  &.screencasts, &.exercises {
     background-color: #fff;
     height: 300px;
     margin-bottom: $product-card-margin;
     margin-top: 0;
     padding-top: $product-card-margin;
 
-    > figure, > .figure-container {
-      height: 200px;
-    }
-
     .nav.show-all {
       background: #fff;
     }
+  }
+
+  &.screencasts > figure {
+    height: 200px;
+  }
+
+  &.exercises > figure {
+    height: 300px;
   }
 
   &.exercises {
@@ -409,7 +413,7 @@
     }
   }
 
-  > figure, > .figure-container {
+  > figure {
     float: left;
     margin: 0 $product-card-margin/2 $product-card-margin;
     @include transition(.15s);

--- a/app/views/dashboards/_exercises.html.erb
+++ b/app/views/dashboards/_exercises.html.erb
@@ -2,7 +2,7 @@
   <figure class='exercise thumbnail product-card'>
     <%= link_to 'https://github.com/thoughtbot/shakespeare_analyzer', title: 'Shakespeare Analyzer Exercise' do %>
       <figure>
-        <p class='console-illustration'>>_</p>
+        <p class='console-illustration'>&gt;_</p>
       </figure>
       <h5>Exercise</h5>
       <h4>Shakespeare Analyzer</h4>
@@ -13,12 +13,55 @@
   <figure class='exercise thumbnail product-card'>
     <%= link_to 'https://github.com/thoughtbot/sudoku_validator', title: 'Sudoku Validator Exercise' do %>
       <figure>
-        <p class='console-illustration'>>_</p>
+        <p class='console-illustration'>&gt;_</p>
       </figure>
       <h5>Exercise</h5>
       <h4>Sudoku Validator</h4>
       <p>Write a program that reads a file containing a sudoku grid and validates it.</p>
     <% end %>
   </figure>
-</section>
 
+  <figure class='exercise thumbnail product-card'>
+    <%= link_to 'https://github.com/thoughtbot/extract-class-exercise', title: 'Extract Class Exercise' do %>
+      <figure>
+        <p class='console-illustration'>&gt;_</p>
+      </figure>
+      <h5>Exercise</h5>
+      <h4>Extract Class</h4>
+      <p>Learn how to safely split up classes in small steps.</p>
+    <% end %>
+  </figure>
+
+  <figure class='exercise thumbnail product-card'>
+    <%= link_to 'https://github.com/thoughtbot/inject-exercise', title: 'Inject Exercise' do %>
+      <figure>
+        <p class='console-illustration'>&gt;_</p>
+      </figure>
+      <h5>Exercise</h5>
+      <h4>Inject</h4>
+      <p>Learn to use Ruby's <code>inject</code> with these quick exercises.</p>
+    <% end %>
+  </figure>
+
+  <figure class='exercise thumbnail product-card'>
+    <%= link_to 'https://github.com/thoughtbot/null_object_exercise', title: 'Null Object Exercise: Part One' do %>
+      <figure>
+        <p class='console-illustration'>&gt;_</p>
+      </figure>
+      <h5>Exercise</h5>
+      <h4>Null Object: Part One</h4>
+      <p>Learn to encapsulate logic surrounding <code>nil</code> by introducing Null Object classes.</p>
+    <% end %>
+  </figure>
+
+  <figure class='exercise thumbnail product-card'>
+    <%= link_to 'https://github.com/thoughtbot/null_object_exercise_part_two', title: 'Null Object Exercise: Part Two' do %>
+      <figure>
+        <p class='console-illustration'>&gt;_</p>
+      </figure>
+      <h5>Exercise</h5>
+      <h4>Null Object: Part Two</h4>
+      <p>Take your Null Object skills to the next level by completing this additional exercise.</p>
+    <% end %>
+  </figure>
+</section>


### PR DESCRIPTION
- Exercises: extract class, inject, and two on null object
- Fix CSS to support multiple lines of exercises
- Remove unused figure-container CSS class
- Fix exercise markup to use valid entities

**NOTE**: we also need to add the Prime GitHub team to the exercise
repositories so that they have access.
