### PR TITLE
ActionView::MissingTemplate: Missing template for topics#show in JSON format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,6 @@ Workshops::Application.routes.draw do
 
   mount StripeEvent::Engine, at: 'stripe-webhook'
 
-  get ':id' => 'topics#show', as: :topic
+  get ':id' => 'topics#show', as: :topic, :constraints => { :format => /(html)/ }
   get '/:id/articles' => redirect('http://robots.thoughtbot.com/tags/%{id}')
 end


### PR DESCRIPTION
1. Removing unused route.

This controller code has been removed by this commit
6ea54cd
1. Also restricting topics/show to HTML requests.

https://thoughtbot.airbrake.io/projects/6325/groups/69621107
