### PR TITLE
New configs for spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,9 +37,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.use_instantiated_fixtures  = false
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.infer_base_class_for_anonymous_controllers = false
-  config.order = "random"
-  config.fail_fast = true
+  config.order = 'random'
 
   config.include Paperclip::Shoulda::Matchers
   config.include EmailSpec::Helpers


### PR DESCRIPTION
Also wanted to use 

  config.expect_with :rspec do |c|
    c.syntax = :expect
  end

But this require a lot spec changes.
