### PR TITLE
Display multiple word / compound last names.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
   end
 
   def last_name
-    name.split(" ").drop(1).join(" ")
+    name.split(' ').drop(1).join(' ')
   end
 
   def external_auth?


### PR DESCRIPTION
Currently `last_name` only grabs the last word of your name. This is inaccurate in a multiple word last name like mine, "Jean van der Walt", as this results in the last name being "Walt" instead of "van der Walt".
