### PR TITLE
Display videos at full viewport width

### DIFF
--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -37,6 +37,8 @@
 }
 
 .assets-wrapper {
+  margin-bottom: 1rem;
+
   .assets {
     .asset-download {
       float: left;
@@ -68,6 +70,12 @@
     list-style-type: none;
     margin-top: 0;
     margin-bottom: 20px;
+  }
+}
+
+.video-notes {
+  h3 {
+    margin-top: .8rem;
   }
 }
 

--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -15,6 +15,10 @@ img {
   max-width: 1100px;
   padding: 0 2em 3em 2em;
 
+  &.fullscreen {
+    max-width: 100%;
+  }
+
   div.subject {
     margin: 0 auto 2rem;
     text-align: center;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
 
     <%= render 'shared/flashes' %>
 
-    <section class="content">
+    <section class="content <%= yield(:additional_content_classes) %>">
       <% if content_for?(:subject) %>
         <h1 class="subject"><%= yield(:subject) %></h1>
       <% end %>

--- a/app/views/screencasts/screencast_purchase_show.html.erb
+++ b/app/views/screencasts/screencast_purchase_show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :additional_content_classes, 'fullscreen' %>
+
 <% content_for :subject_block do %>
   <h1><%= @purchaseable.name %></h1>
   <h2 class="tagline">
@@ -10,16 +12,16 @@
   </h2>
 <% end %>
 
-<div class="text-box-wrapper">
-  <div class="text-box">
-    <% if @purchaseable.collection? %>
+<% if @purchaseable.collection? %>
+  <div class="text-box-wrapper">
+    <div class="text-box">
       <section id="videos">
         <%= render @purchaseable.videos.ordered, purchase: @purchase %>
       </section>
-    <% else %>
-      <%= render 'videos/watch_video', video: @purchaseable.videos.first, purchase: @purchase %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% else %>
+  <%= render 'videos/watch_video', video: @purchaseable.videos.first, purchase: @purchase %>
+<% end %>
 
 <%= render 'screencasts/aside', purchaseable: @purchaseable, purchase: @purchase %>

--- a/app/views/videos/_watch_video.html.erb
+++ b/app/views/videos/_watch_video.html.erb
@@ -11,8 +11,10 @@
 <% end %>
 
 <% if video.has_notes? %>
-  <section class='video-notes'>
-    <h3>Notes</h3>
-    <%= raw(video.notes_html) %>
-  </section>
+  <div class="text-box">
+    <section class='video-notes'>
+      <h3>Notes</h3>
+      <%= raw(video.notes_html) %>
+    </section>
+  </div>
 <% end %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_content_classes, 'fullscreen' %>
 <% if @purchaseable.collection? %>
   <% content_for :additional_header_links do %>
     <li class="all-videos"><%= link_to 'All Videos', @purchase %></li>
@@ -15,10 +16,4 @@
   </h2>
 <% end %>
 
-<div class="text-box-wrapper">
-  <div class="text-box">
-    <%= render 'watch_video', video: @video, purchase: @purchase %>
-  </div>
-</div>
-
-<%= render @purchaseable.to_aside_partial, purchaseable: @purchaseable, purchase: @purchase %>
+<%= render 'watch_video', video: @video, purchase: @purchase %>

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -11,8 +11,6 @@ describe 'Workshops' do
     visit purchase_path(purchase)
 
     expect(page).to have_css('.resources li', text: 'Item 1')
-    visit purchase_video_path(purchase, video)
-    expect(page).to have_css('.resources li', text: 'Item 1')
   end
 
   it 'lists office hours' do


### PR DESCRIPTION
I figure we don't need to display the sidebar when it's available on the video index. However, videos like "Getting the TDD Ball Rolling" throw a wrench in here since they don't have an index page. There's @purhaseable.collection? to determine whether or not we can show/hide the sidebar, but I may just add a class to the sidebar and display it under the video/notes. Making an early PR to get thoughts.

https://www.apptrajectory.com/thoughtbot/learn/stories/15640799

![screen shot 2014-02-20 at 12 11 20 pm](https://f.cloud.github.com/assets/654275/2220984/cfb5f7aa-9a53-11e3-8e99-b427c70f6fab.png)
![screen shot 2014-02-20 at 12 12 54 pm](https://f.cloud.github.com/assets/654275/2220985/cfb62900-9a53-11e3-97c5-5901c1250062.png)
