### PR TITLE
Set production log level to info instead of debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Workshops::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
 
-  config.log_level = :debug
+  config.log_level = :info
   config.log_formatter = ::Logger::Formatter.new
 
   HOST = 'learn.thoughtbot.com'


### PR DESCRIPTION
- Debug logs SQL queries, which are very verbose
- Debug may log sensitive information like passwords

https://github.com/thoughtbot/null_object_exercise_part_tw://www.apptrajectory.com/thoughtbot/learn/stories/15627246
