### PR TITLE
Reformat the welcome-from-mentor email

### DIFF
--- a/app/views/subscription_mailer/welcome_to_prime_from_mentor.text.erb
+++ b/app/views/subscription_mailer/welcome_to_prime_from_mentor.text.erb
@@ -1,28 +1,16 @@
 Hi <%= @user.first_name %>,
 
-First off, thanks for subscribing to <%= t('shared.subscription.name') %>!
-We're glad to have you.
+First off, thanks for subscribing to <%= t('shared.subscription.name') %>!  We're glad to have you.
 
-Secondly, I wanted to introduce myself. My name is <%= @mentor.name %> and I'll
-be your mentor. I'm excited to work with you!
+Secondly, I wanted to introduce myself. My name is <%= @mentor.name %> and I'll be your mentor. I'm excited to work with you!
 
 Before our first call, please do the following:
 
-1. Send me some background on yourself and your goals for working together. Who
-are you? What are you doing now? What do you want to do?
+1. Send me some background on yourself and your goals for working together. Who are you? What are you doing now? What do you want to do?
 
-2. Add me to any repositories you'd like to work on together, or code you think
-represents where you're currently at as a developer. I'll take a look to get a
-better sense of your current experience level, and provide feedback. My github
-username is <%= @mentor.github_username %>.
+2. Add me to any repositories you'd like to work on together, or code you think represents where you're currently at as a developer. I'll take a look to get a better sense of your current experience level, and provide feedback. My github username is <%= @mentor.github_username %>.
 
-3. Send me an invitation for a monthly, recurring 30-minute Skype session using
-your favorite scheduling program. As long as you've picked a time where I'm
-free, I'll accept. You can view my calendar here:
-https://www.google.com/calendar/embed?src=<%=u @mentor.email %>&mode=week.
-
-I'm generally available <%= @mentor.availability %>. Please include your
-Skype handle in your scheduling request.
+3. Send me an invitation for a monthly, recurring 30-minute Skype session using your favorite scheduling program. As long as you've picked a time where I'm free, I'll accept. You can view my calendar here: https://www.google.com/calendar/embed?src=<%=u @mentor.email %>&mode=week. I'm generally available <%= @mentor.availability %>. Please include your Skype handle in your scheduling request.
 
 4. Prepare some questions for our call. How can I help you?
 


### PR DESCRIPTION
The "Welcome to Prime from Your Mentor" email is being formatted poorly
in email clients. If we take away the hard linebreaks, it should format
correctly.
