### PR TITLE
Fix analytics

### DIFF
--- a/app/views/conversions/_purchased.html.erb
+++ b/app/views/conversions/_purchased.html.erb
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-  analytics.track('Purchased',
+  window.analytics.track('Purchased',
     <%= raw purchased_hash(purchase_amount, purchase_name).to_json %>
   );
 </script>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,6 +1,6 @@
 <script type="text/javascript">
   window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
-  window.analytics.load(<%= ENV['SEGMENT_KEY']%>);
+  window.analytics.load('<%= ENV['SEGMENT_KEY']%>');
   window.analytics.page();
 </script>
 

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'shared/_analytics.html.erb' do
     end
 
     it 'loads the Segment.io JavaScript library' do
-      segment_load_line = "window.analytics.load(#{ENV['SEGMENT_KEY']});"
+      segment_load_line = "window.analytics.load('#{ENV['SEGMENT_KEY']}');"
 
       render
 


### PR DESCRIPTION
https://github.com/thoughtbot/learn/commit/d2240ad introduced an environment
variable that didn't quote the Segment.io API key, resulting in a JavaScript
token error.

This means Google Analytics and Intercom has been broken for users since that
was deployed, which looks like last Monday.

https://www.apptrajectory.com/thoughtbot/learn/stories/15641383
