### PR TITLE
Allow mentor's user to be nil during creation in admin

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -4,6 +4,8 @@ class Mentor < ActiveRecord::Base
   belongs_to :user
   has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
 
+  validates :user, presence: true
+
   delegate :name, :first_name, :email, :github_username, :bio, to: :user
 
   def self.featured

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -68,6 +68,10 @@ RailsAdmin.config do |config|
       field :accepting_new_mentees
       field :availability
     end
+
+    object_label_method do
+      :id
+    end
   end
 
   config.model User do

--- a/spec/features/admin_manages_mentor_spec.rb
+++ b/spec/features/admin_manages_mentor_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'Admin manages mentors' do
+  scenario 'creating a new mentor' do
+    user = create(:admin)
+
+    visit admin_path(as: user)
+    click_link 'Mentors'
+    click_link 'Add new'
+    select(user.name, from: 'User')
+    click_button 'Save'
+
+    expect(page).to have_content('Mentor successfully created')
+  end
+end

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Mentor do
   it { should have_many(:mentees) }
+  it { should validate_presence_of(:user) }
 
   describe '.featured' do
     it 'executes queries on the relation' do


### PR DESCRIPTION
We don't want a nil user once the mentor is created, but rails_admin throws an
exception when trying to create a new mentor because the user starts off as
nil.

This pull also adds a validation that a user is present once the mentor
is created.

I've also added integration coverage for an admin feature in this pull. We had been experimenting with not testing the admin area, but deemed it a failure (a lack of integration tests led to this bug being introduced unnoticed in 705b4cb5).
