### PR TITLE
Allow customers to refund themselves

### DIFF
--- a/app/assets/stylesheets/_cancellation.scss
+++ b/app/assets/stylesheets/_cancellation.scss
@@ -1,10 +1,18 @@
 .cancellation-discount {
   article {
     font-size: 1.5rem;
-    margin: 5em 0 0;
+    margin: 1em 0 0;
   }
 
   .cancellation-feedback {
     margin: 3em 0;
+  }
+
+  .help {
+    font-size: 1rem;
+  }
+
+  a.button {
+    margin-top: 2em;
   }
 }

--- a/app/controllers/subscriber/cancellations_controller.rb
+++ b/app/controllers/subscriber/cancellations_controller.rb
@@ -9,7 +9,7 @@ class Subscriber::CancellationsController < ApplicationController
     cancellation = build_cancellation
     cancellation.schedule
     redirect_to(
-      my_account_path,
+      after_cancellation_path,
       notice: t('subscriptions.flashes.cancel.success')
     )
   end
@@ -18,5 +18,13 @@ class Subscriber::CancellationsController < ApplicationController
 
   def build_cancellation
     Cancellation.new(current_user.subscription)
+  end
+
+  def after_cancellation_path
+    if current_user.subscription.last_charge
+      new_subscriber_refund_path
+    else
+      my_account_path
+    end
   end
 end

--- a/app/controllers/subscriber/refunds_controller.rb
+++ b/app/controllers/subscriber/refunds_controller.rb
@@ -1,0 +1,22 @@
+class Subscriber::RefundsController < ApplicationController
+  before_filter :authorize
+
+  def new
+    @cancellation = build_cancellation
+  end
+
+  def create
+    cancellation = build_cancellation
+    cancellation.cancel_and_refund
+    redirect_to(
+      my_account_path,
+      notice: t('subscriptions.flashes.refund.success')
+    )
+  end
+
+  private
+
+  def build_cancellation
+    Cancellation.new(current_user.subscription)
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -69,6 +69,10 @@ class Subscription < ActiveRecord::Base
     team.present?
   end
 
+  def last_charge
+    Stripe::Charge.all(count: 1, customer: stripe_customer_id).first
+  end
+
   private
 
   def self.canceled_within_period(start_time, end_time)

--- a/app/views/subscriber/refunds/new.html.erb
+++ b/app/views/subscriber/refunds/new.html.erb
@@ -1,0 +1,19 @@
+<div class="text-box-wrapper solo cancellation-discount">
+  <article>
+    <p>
+      Your subscription has been cancelled. We're sorry to see you go. You'll lose access to all the products acquired through your subscription at the end of this billing cycle &mdash; if you've purchased anything seperately, you'll retain access to those products on your account.
+    </p>
+    <p>
+      We hope that you've enjoyed <%= t('shared.subscription.name') %> while you've been a subscriber. If that's not the case, you can get a refund immediately for your last charge.
+    </p>
+    <p>
+      <%= link_to([:subscriber, :refund], method: :create) do %>
+        <%= t('subscriptions.take_refund') %> &rarr;
+      <% end %>
+    </p>
+    <p class="help">
+     This will refund the last charge to your account &mdash; your subscription will also be cancelled immediately and you'll lose access to the all the products acquired through your subscription.
+    </p>
+  </article>
+  <%= link_to t('subscriptions.reject_refund'), my_account_path, class: 'button' %>
+</div>

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -2,7 +2,7 @@
   <% if subscription.active? %>
     <p><strong><%= subscription.plan.name %></strong> <br /> Active since <%= subscription.created_at.to_s(:simple) %></p>
     <% if subscription.scheduled_for_cancellation_on %>
-      <p>Scheduled for cancellation on <%= subscription.scheduled_for_cancellation_on.to_s(:simple) %></p>
+      <p><%= t('subscriptions.cancellation_scheduled_on', date: subscription.scheduled_for_cancellation_on.to_s(:simple)) %></p>
     <% end %>
   <% else %>
     <p>Canceled on <%= subscription.deactivated_on.to_s(:simple) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,9 @@ en:
     change_plan: Change plan
     choose_plan_html: Sign up for %{plan_name}
     current_plan_html: <p class="current-plan">This is your current plan</p>
+    take_refund: Get a refund
+    reject_refund: No thanks, I'm happy
+    cancellation_scheduled_on: Scheduled for cancellation on %{date}
     discount:
       forever: $%{final_price}
       once: $%{final_price} the first month, then $%{full_price}
@@ -194,6 +197,8 @@ en:
         success: Your subscription has been downgraded.
       cancel:
         success: We're sorry to see you go. You will have access to all the benefits of Prime until the end of your current billing cycle.
+      refund:
+        success: We've canceled your subscription immediately and refunded the last subscription charge.
 
   weekly_iteration_subscribe_cta:
     Subscribe to Watch the Weekly Iteration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Workshops::Application.routes.draw do
     resources :invoices, only: [:index, :show]
     resource :cancellation, only: [:new, :create]
     resource :downgrade, only: :create
+    resource :refund, only: [:new, :create]
   end
 
   resource :subscription, only: [:new, :edit, :update]

--- a/spec/controllers/subscriber/cancellations_controller_spec.rb
+++ b/spec/controllers/subscriber/cancellations_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Subscriber::CancellationsController do
+  describe '#new without being signed in' do
+    it 'redirects to sign in page' do
+      get :new
+
+      expect(response).to redirect_to sign_in_path
+    end
+  end
+
+  describe '#create without being signed in' do
+    it 'redirects to sign in page' do
+      post :create
+
+      expect(response).to redirect_to sign_in_path
+    end
+  end
+
+  describe '#create with a subscription that has been charged' do
+    it 'redirects to the refund page' do
+      subscription = create(:subscription)
+      sign_in_as(subscription.user.reload)
+
+      post :create
+
+      expect(response).to redirect_to new_subscriber_refund_path
+    end
+  end
+
+  describe '#create with a subscription that has never been charged' do
+    it 'redirects to the account page' do
+      user = build_stubbed(:user)
+      subscription = stub(last_charge: nil)
+      user.stubs(subscription: subscription)
+      Cancellation.stubs(:new).returns(stub(schedule: nil))
+      sign_in_as(user)
+
+      post :create
+
+      expect(Cancellation).to have_received(:new)
+        .with(subscription)
+      expect(subscription).to have_received(:last_charge)
+      expect(response).to redirect_to my_account_path
+    end
+  end
+end

--- a/spec/controllers/subscriber/refunds_controller_spec.rb
+++ b/spec/controllers/subscriber/refunds_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Subscriber::RefundsController do
+  describe '#new without being signed in' do
+    it 'redirects to sign in page' do
+      get :new
+
+      expect(response).to redirect_to sign_in_path
+    end
+  end
+
+  describe '#create without being signed in' do
+    it 'redirects to sign in page' do
+      post :create
+
+      expect(response).to redirect_to sign_in_path
+    end
+  end
+end

--- a/spec/features/user_downgrades_subscription_spec.rb
+++ b/spec/features/user_downgrades_subscription_spec.rb
@@ -39,7 +39,15 @@ feature 'User downgrades subscription', js: true do
 
     click_button I18n.t('subscriptions.confirm_cancel')
 
-    expect(page).to have_content "Scheduled for cancellation on February 19, 2013"
     expect(page).to have_content I18n.t('subscriptions.flashes.cancel.success')
+
+    click_link I18n.t('subscriptions.reject_refund')
+
+    expect(page).to have_content(
+      I18n.t(
+        'subscriptions.cancellation_scheduled_on',
+        date: 'February 19, 2013'
+      )
+    )
   end
 end

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -147,6 +147,22 @@ feature 'User creates a subscription' do
     expect(page).not_to have_content('Your Billing Info')
   end
 
+  scenario 'does not see call out to subscribe if already subscribed' do
+    plan = create(:plan, name: 'Prime')
+    create(:workshop, name: 'A Cool Workshop')
+    sign_in_as_user_with_subscription
+
+    visit products_path
+
+    expect(find('.header-container')).not_to have_content(
+      "#{plan.name} Membership"
+    )
+
+    click_link 'View Details'
+
+    expect(page).not_to have_link("Subscribe to #{plan.name}")
+  end
+
   def visit_plan_purchase_page
     visit new_subscription_path
     click_link('Sign up for')

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -221,9 +221,21 @@ describe Subscription do
     end
 
     it 'returns false without a team' do
-      subscription = create(:subscription)
+      subscription = build_stubbed(:subscription)
 
       expect(subscription.team?).to be_false
+    end
+  end
+
+  describe '#last_charge' do
+    it 'returns the last charge for the customer' do
+      charge = stub('Stripe::Charge')
+      Stripe::Charge.stubs(:all).returns([charge])
+      subscription = build_stubbed(:subscription)
+
+      expect(subscription.last_charge).to eq charge
+      expect(Stripe::Charge).to have_received(:all)
+        .with(count: 1, customer: subscription.stripe_customer_id)
     end
   end
 end

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -150,42 +150,14 @@ class FakeStripe < Sinatra::Base
     }).to_json
   end
 
+  get '/v1/charges' do
+    content_type :json
+    [charge].to_json
+  end
+
   get '/v1/charges/:id' do
     content_type :json
-    { failure_message: nil,
-      description: nil,
-      created: 1336671705,
-      paid: true,
-      currency: "usd",
-      amount: 1500,
-      fee: 0,
-      object: "charge",
-      refunded: false,
-      card: {
-        exp_year: 2015,
-        type: "Visa",
-        address_zip: "94301",
-        fingerprint: "qhjxpr7DiCdFYTlH",
-        address_line1: "522 Ramona St",
-        last4: "4242",
-        address_line2: "Palo Alto",
-        cvc_check: "pass",
-        object: "card",
-        address_country: "USA",
-        country: "US",
-        address_zip_check: "pass",
-        name: "Java Bindings Cardholder",
-        address_state: "CA",
-        exp_month: 12,
-        id: "cc_7qBiSeyivjSSjR",
-        address_line1_check: "pass" },
-      customer: nil,
-      amount_refunded: 0,
-      id: params[:id],
-      disputed: false,
-      invoice: nil,
-      livemode: false
-    }.to_json
+    charge(params[:id]).to_json
   end
 
   post '/v1/charges/:id/refund' do
@@ -438,6 +410,44 @@ class FakeStripe < Sinatra::Base
       trial_end: nil,
       canceled_at: nil,
       quantity: 1
+    }
+  end
+
+  def charge(charge_id = 'charge_id')
+    {
+      failure_message: nil,
+      description: nil,
+      created: 1336671705,
+      paid: true,
+      currency: 'usd',
+      amount: 1500,
+      fee: 0,
+      object: 'charge',
+      refunded: false,
+      card: {
+        exp_year: 2015,
+        type: 'Visa',
+        address_zip: '94301',
+        fingerprint: 'qhjxpr7DiCdFYTlH',
+        address_line1: '522 Ramona St',
+        last4: '4242',
+        address_line2: 'Palo Alto',
+        cvc_check: 'pass',
+        object: 'card',
+        address_country: 'USA',
+        country: 'US',
+        address_zip_check: 'pass',
+        name: 'Java Bindings Cardholder',
+        address_state: 'CA',
+        exp_month: 12,
+        id: 'cc_7qBiSeyivjSSjR',
+        address_line1_check: 'pass' },
+      customer: nil,
+      amount_refunded: 0,
+      id: charge_id,
+      disputed: false,
+      invoice: nil,
+      livemode: false
     }
   end
 


### PR DESCRIPTION
This new addition gives a cancelling customer the option to get a refund
after they cancel.

If the user tries to go back to this page after they've already gotten a
refund, and tries to do another one, they will get a 500 error. Stripe
won't allow you to refund the same charge twice. I figure this is
acceptable behavior for now.

Here are what the user see's as they go through the process.

![cancel step 1](https://f.cloud.github.com/assets/5015/2410416/ddf000da-aabc-11e3-9bad-9bf0de5548f0.png)
![cancel step 2](https://f.cloud.github.com/assets/5015/2410415/dde8f678-aabc-11e3-83ca-143b5a8e5fd7.png)
![cancel step 3](https://f.cloud.github.com/assets/5015/2410417/ddf0cb50-aabc-11e3-9def-6e83bd61784b.png)
