### PR TITLE
Download public keys from GitHub

### DIFF
--- a/app/jobs/git_hub_public_key_download_fulfillment_job.rb
+++ b/app/jobs/git_hub_public_key_download_fulfillment_job.rb
@@ -1,0 +1,24 @@
+class GitHubPublicKeyDownloadFulfillmentJob
+  PRIORITY = 1
+
+  def self.enqueue(user_id)
+    Delayed::Job.enqueue(
+      GitHubPublicKeyDownloadFulfillmentJob.new(user_id),
+      priority: PRIORITY
+    )
+  end
+
+  def initialize(user_id)
+    @user_id = user_id
+  end
+
+  def perform
+    GitHubPublicKeyDownloadFulfillment.new(user).fulfill
+  end
+
+  private
+
+  def user
+    User.find(@user_id)
+  end
+end

--- a/app/models/git_hub_public_key_download_fulfillment.rb
+++ b/app/models/git_hub_public_key_download_fulfillment.rb
@@ -1,0 +1,21 @@
+class GitHubPublicKeyDownloadFulfillment
+  def initialize(user)
+    @user = user
+  end
+
+  def fulfill
+    github_keys.each do |github_key|
+      @user.public_keys.create!(data: github_key[:key])
+    end
+  end
+
+  private
+
+  def github_keys
+    github_client.user_keys(@user.github_username)
+  end
+
+  def github_client
+    Octokit::Client.new(login: GITHUB_USER, password: GITHUB_PASSWORD)
+  end
+end

--- a/app/models/public_key.rb
+++ b/app/models/public_key.rb
@@ -1,0 +1,4 @@
+class PublicKey < ActiveRecord::Base
+  validates :data, presence: true
+  validates :user_id, presence: true
+end

--- a/app/models/subscription_fulfillment.rb
+++ b/app/models/subscription_fulfillment.rb
@@ -10,6 +10,7 @@ class SubscriptionFulfillment
     assign_mentor
     create_subscription
     add_user_to_github_team
+    download_public_keys
   end
 
   def remove
@@ -35,6 +36,10 @@ class SubscriptionFulfillment
 
   def add_user_to_github_team
     GithubFulfillmentJob.enqueue(GITHUB_TEAM, [@user.github_username])
+  end
+
+  def download_public_keys
+    GitHubPublicKeyDownloadFulfillmentJob.enqueue(@user.id)
   end
 
   def remove_user_from_github_team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
   has_many :purchases
   has_many :completions
   has_many :notes, -> { order 'created_at DESC' }
+  has_many :public_keys, dependent: :destroy
   has_one :purchased_subscription, dependent: :destroy, class_name: 'Subscription'
   belongs_to :mentor
   belongs_to :team, class_name: 'Teams::Team'

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,6 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :email, :first_name, :last_name, :has_forum_access, :admin,
-    :has_active_subscription, :id
+    :has_active_subscription, :id, :public_keys
 
   def has_forum_access
     object.has_active_subscription? || object.admin?
@@ -8,5 +8,9 @@ class UserSerializer < ActiveModel::Serializer
 
   def has_active_subscription
     object.has_active_subscription?
+  end
+
+  def public_keys
+    object.public_keys.map(&:data)
   end
 end

--- a/db/migrate/20140313201034_create_public_keys.rb
+++ b/db/migrate/20140313201034_create_public_keys.rb
@@ -1,0 +1,11 @@
+class CreatePublicKeys < ActiveRecord::Migration
+  def change
+    create_table :public_keys do |table|
+      table.integer :user_id, null: false
+      table.text :data, null: false
+      table.timestamps null: false
+    end
+
+    add_index :public_keys, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140123145010) do
+ActiveRecord::Schema.define(version: 20140313201034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "announcements", force: true do |t|
     t.datetime "created_at",        null: false
@@ -194,6 +195,15 @@ ActiveRecord::Schema.define(version: 20140123145010) do
     t.string   "product_image_content_type"
     t.string   "product_image_updated_at"
   end
+
+  create_table "public_keys", force: true do |t|
+    t.integer  "user_id",    null: false
+    t.text     "data",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "public_keys", ["user_id"], name: "index_public_keys_on_user_id", using: :btree
 
   create_table "purchases", force: true do |t|
     t.string   "stripe_customer_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -80,6 +80,10 @@ FactoryGirl.define do
     workshop
   end
 
+  factory :public_key do
+    data 'ssh-rsa abc123hexadecimal'
+  end
+
   factory :product, traits: [:active], class: 'Book' do
     trait :active do
       active true

--- a/spec/jobs/git_hub_public_key_download_fulfillment_job_spec.rb
+++ b/spec/jobs/git_hub_public_key_download_fulfillment_job_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe GitHubPublicKeyDownloadFulfillmentJob do
+  describe '.enqueue' do
+    it 'enqueues a new job' do
+      user = build_stubbed(:user, :with_github)
+      Delayed::Job.stubs(:enqueue)
+
+      GitHubPublicKeyDownloadFulfillmentJob.enqueue(user.id)
+
+      expect(Delayed::Job).to have_received(:enqueue).with(
+        kind_of(GitHubPublicKeyDownloadFulfillmentJob),
+        priority: GitHubPublicKeyDownloadFulfillmentJob::PRIORITY
+      )
+    end
+  end
+
+  describe '#perform' do
+    it "downloads the user's public keys from GitHub" do
+      user = build_stubbed(:user, :with_github)
+      User.stubs(:find).with(user.id).returns(user)
+      fulfillment = stub('fulfillment', fulfill: true)
+      GitHubPublicKeyDownloadFulfillment
+        .stubs(:new)
+        .with(user)
+        .returns(fulfillment)
+      job = GitHubPublicKeyDownloadFulfillmentJob.new(user.id)
+
+      job.perform
+
+      expect(fulfillment).to have_received(:fulfill)
+    end
+  end
+end

--- a/spec/models/git_hub_public_key_download_fulfillment_spec.rb
+++ b/spec/models/git_hub_public_key_download_fulfillment_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe GitHubPublicKeyDownloadFulfillment do
+  describe '#fulfill' do
+    it "uses the GitHub API to download the user's API keys" do
+      public_keys = stub('public_keys')
+      public_keys.stubs(:create!)
+      user = build_stubbed(:user, :with_github)
+      user.stubs(:public_keys).returns(public_keys)
+      fulfillment = GitHubPublicKeyDownloadFulfillment.new(user)
+      github_keys = [
+        Hashie::Mash.new(key: 'key-one'),
+        Hashie::Mash.new(key: 'key-two')
+      ]
+      github_client = stub('github_client')
+      Octokit::Client
+        .stubs(:new)
+        .with(login: GITHUB_USER, password: GITHUB_PASSWORD)
+        .returns(github_client)
+      github_client
+        .stubs(:user_keys)
+        .with(user.github_username)
+        .returns(github_keys)
+
+      fulfillment.fulfill
+
+      github_keys.each do |github_key|
+        expect(public_keys)
+          .to have_received(:create!).with(data: github_key[:key])
+      end
+    end
+  end
+end

--- a/spec/models/public_key_spec.rb
+++ b/spec/models/public_key_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe PublicKey do
+  it { should validate_presence_of(:data) }
+  it { should validate_presence_of(:user_id) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ describe User do
     it { should have_many(:completions) }
     it { should have_many(:notes).order('created_at DESC') }
     it { should belong_to(:mentor) }
+    it { should have_many(:public_keys).dependent(:destroy) }
     it { should belong_to(:team) }
     it { should have_one(:purchased_subscription).dependent(:destroy) }
   end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -12,6 +12,20 @@ describe UserSerializer do
     user_json['email'].should == user.email
   end
 
+  context 'with public keys' do
+    it 'serializes public keys as an array of strings' do
+      public_keys = [
+        build_stubbed(:public_key, data: 'key-one'),
+        build_stubbed(:public_key, data: 'key-two')
+      ]
+      user = build_stubbed(:user, public_keys: public_keys)
+
+      user_json = parse_serialized_json(user)
+
+      user_json['public_keys'].should match_array(%w(key-one key-two))
+    end
+  end
+
   context 'when the user has an active subscription' do
     it 'includes a key granting forum access' do
       user = create(:subscriber)

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -19,6 +19,18 @@ class FakeGithub < Sinatra::Base
 
     {}.to_json
   end
+
+  get '/users/:username/keys' do
+    content_type :json
+
+    [{ 'id' => 1, 'key' => 'ssh-rsa AAA' }].to_json
+  end
+
+  not_found do
+    content_type :json
+
+    { 'error' => "Edit #{__FILE__} to fake out this request" }.to_json
+  end
 end
 
 FakeGithubRunner = Capybara::Discoball::Runner.new(FakeGithub) do |server|


### PR DESCRIPTION
Because:
- Subscribers have providers SSH public keys to GitHub already
- We need SSH public keys for Whetstone
- We don't want to add GitHub to Whetstone

This commit adds:
- SSH keys to the Learn user API
- Syncing SSH keys with GitHub for subscribers

https://trello.com/c/1vfdSSBl/3-as-a-subscriber-when-i-start-my-first-exercise-i-need-to-provide-my-public-key-so-that-i-can-access-my-fork
