### PR TITLE
Refactor topics js

### DIFF
--- a/app/assets/javascripts/topics.js.coffee
+++ b/app/assets/javascripts/topics.js.coffee
@@ -61,16 +61,19 @@ class CompletionView
     step.find(".text-complete").text complete + "/" + total + " complete"
 
   scatterIncompleteBullets: ->
-    $(".trail-bullet:not(.complete)").each (index, bullet) ->
+    $(".trail-bullet:not(.complete)").each (index, bullet) =>
       bullet = $(bullet)
       complete = bullet.parents(".steps-complete").data("complete")
       total = bullet.parents(".steps-complete").data("total")
-      max = 88
-      tempered_max = max - ((complete / total) * max)
-      height_percentage = Math.floor(Math.random() * tempered_max) + 1
-      pos_or_neg = Math.random() * 2 | 0 or -1
-      height_from_center = 50 + pos_or_neg * (height_percentage / 2)
+      height_from_center = @randomHeightFromCenter(complete, total)
       bullet.css "top", height_from_center + "%"
+
+  randomHeightFromCenter: (complete, total) ->
+    max = 88
+    tempered_max = max - ((complete / total) * max)
+    height_percentage = Math.floor(Math.random() * tempered_max) + 1
+    pos_or_neg = Math.random() * 2 | 0 or -1
+    return 50 + pos_or_neg * (height_percentage / 2)
 
   renderCompletionsAndBullets: =>
     @renderBullets()
@@ -80,23 +83,30 @@ class CompletionView
   initializeCompletionEditor: =>
     for completion in window.completions
       $("#" + completion).prop "checked", true
-    $(".trail-map-steps .trail-bullet-hit-area").on "click", ->
-      $(@).siblings('input[type=checkbox]').trigger('click')
-      if $(@).siblings('input[type=checkbox]:checked').length
-        $(@).parents('li').addClass 'complete'
+
+    $(".trail-map-steps .trail-bullet-hit-area").on "click", @markAllStepsAsCompleteHandler
+    $("input[type=checkbox]").on "change", @markSingleStepAsCompleteHandler
+
+  markAllStepsAsCompleteHandler: ->
+    $(@).siblings('input[type=checkbox]').trigger('click')
+
+    if $(@).siblings('input[type=checkbox]:checked').length
+      $(@).parents('li').addClass 'complete'
+    else
+      $(@).parents('li').removeClass 'complete'
+
+  markSingleStepAsCompleteHandler: ->
+    checkbox = $(@)
+    if window.loggedIn
+      if checkbox.prop("checked")
+        request = $.post "/api/v1/completions",
+          trail_object_id: checkbox.attr("id")
+          trail_name: checkbox.parents(".trail-map-steps").data("name")
       else
-        $(@).parents('li').removeClass 'complete'
-    $("input[type=checkbox]").on "change", ->
-      checkbox = $(@)
-      if window.loggedIn
-        if checkbox.prop("checked")
-          request = $.post "/api/v1/completions",
-            trail_object_id: checkbox.attr("id")
-            trail_name: checkbox.parents(".trail-map-steps").data("name")
-        else
-          request = $.ajax
-            url: "/api/v1/completions/" + checkbox.attr("id")
-            type: "DELETE"
-        request.done ->
-          completionView = new CompletionView
-          completionView.fetchCompletions(completionView.renderBullets)
+        request = $.ajax
+          url: "/api/v1/completions/" + checkbox.attr("id")
+          type: "DELETE"
+
+      request.done ->
+        completionView = new CompletionView
+        completionView.fetchCompletions(completionView.renderBullets)


### PR DESCRIPTION
- Refactor the coffeescript in topics.js.coffee

According to the tests (I figured this is covered by some feature specs, did not find specific js unit tests) this is in a working state, however I can´t play with this in the browser because there is no data in the redis store (I think?). I found no easy way to dump something into there?

All this PR does atm is extract some methods and remove some minimal duplication.
Review much appreciated, hope this is useful! Method names might not be spot on yet, thats just what I could
make out from code.
