### PR TITLE
Fix styling on 'Sign up with Github' button

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <section id="auth-form-container">
   <div class="github-signin">
-    <%= link_to "Sign up with GitHub", github_auth_path %>
+    <%= link_to "Sign up with GitHub", github_auth_path, class: 'button' %>
   </div>
   <div class="thoughtbot-signin">
     <%= semantic_form_for @user do |form| %>


### PR DESCRIPTION
- Add class 'button' on 'Sign up with Github' button.
- Before:

![screen shot 2014-03-19 at 1 35 46 pm](https://f.cloud.github.com/assets/1766864/2464075/b6cdda2e-af92-11e3-9bbe-9ee59d166cd7.png)
- After: 

![screen shot 2014-03-19 at 1 41 41 pm](https://f.cloud.github.com/assets/1766864/2464079/bdd41158-af92-11e3-99f3-105741d7c74d.png)
