### PR TITLE
Products do not respond to product_type anymore

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -101,7 +101,7 @@ RailsAdmin.config do |config|
       field :id
       field :name
       field :sku
-      field :product_type
+      field :type
       field :individual_price
       field :company_price
     end


### PR DESCRIPTION
Fixes runtime exception in /admin/product

Not sure how to test this. The Initializer is sensible to changes on the schema. To test it would either require to dig deep into rails_admin and see if the configurations conform to the models or a generic feature spec.
