### PR TITLE
Enables print stylesheet media

### DIFF
--- a/app/assets/stylesheets/layout/_footer.scss
+++ b/app/assets/stylesheets/layout/_footer.scss
@@ -8,6 +8,10 @@ footer.links {
   @include transition(opacity .5s);
   width: 93%;
 
+  @media print {
+    display: none;
+  }
+
   &:hover {
     opacity: 1;
   }

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -67,6 +67,10 @@ body.passwords-create {
       position: static;
     }
 
+    @media print {
+      display: none;
+    }
+
     &.left {
       right: auto;
       left: 1rem;

--- a/app/views/layouts/_stylesheets.html.erb
+++ b/app/views/layouts/_stylesheets.html.erb
@@ -1,1 +1,1 @@
-<%= stylesheet_link_tag 'application' %>
+<%= stylesheet_link_tag 'application', media: 'all' %>


### PR DESCRIPTION
Noticed this when trying to print off an invoice removed all styles and created a 2 page long print so this is mainly to solve that ready for next month :+1: .

This enables stylesheet for all media (not just screen) and I've hidden the footer to reduce the page size and header `<nav>` container to clean that bit up.
