### PR TITLE
Don't show mentor with canceled subscription

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,7 +82,7 @@ class User < ActiveRecord::Base
   end
 
   def has_subscription_with_mentor?
-    subscription.try(:includes_mentor?)
+    has_active_subscription? && subscription.try(:includes_mentor?)
   end
 
   def plan_name

--- a/spec/features/subscriber_contacts_mentor_spec.rb
+++ b/spec/features/subscriber_contacts_mentor_spec.rb
@@ -5,6 +5,9 @@ feature 'Subscriber can contact his mentor' do
     sign_in_as_user_with_mentoring_subscription
     mentor = @current_user.mentor
 
-    expect(page).to have_content(I18n.t('dashboards.show.contact_your_mentor', mentor_name: mentor.first_name))
+    expect(page).to have_content(I18n.t(
+      'dashboards.show.contact_your_mentor',
+      mentor_name: mentor.first_name
+    ))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -244,23 +244,31 @@ describe User do
 
   describe '#has_subscription_with_mentor?' do
     it 'returns true when the subscription includes mentoring' do
-      plan = create(:plan, includes_mentor: true)
-      subscription = create(:subscription, plan: plan)
-      user = create(:user, :with_mentor, subscription: subscription)
+      plan = build(:plan, includes_mentor: true)
+      subscription = build(:subscription, plan: plan)
+      user = build(:user, :with_mentor, subscription: subscription)
 
       expect(user.has_subscription_with_mentor?).to be_true
     end
 
     it 'returns false when the subscription does not include mentoring' do
-      plan = create(:plan, includes_mentor: false)
-      subscription = create(:subscription, plan: plan)
-      user = create(:user, subscription: subscription)
+      plan = build(:plan, includes_mentor: false)
+      subscription = build(:subscription, plan: plan)
+      user = build(:user, subscription: subscription)
+
+      expect(user.has_subscription_with_mentor?).to be_false
+    end
+
+    it 'returns false when the subscription is inactive' do
+      plan = build(:plan, includes_mentor: true)
+      subscription = build(:inactive_subscription, plan: plan)
+      user = build(:user, :with_mentor, subscription: subscription)
 
       expect(user.has_subscription_with_mentor?).to be_false
     end
 
     it 'returns false when there is no subscription' do
-      user = create(:user)
+      user = build(:user)
 
       expect(user.has_subscription_with_mentor?).to be_false
     end


### PR DESCRIPTION
Before, the "Contact you mentor" was still showing up after the subscription had been canceled.

Please see:
https://www.intercom.io/apps/dbd6a8c6010791c57a0a54bc99b9bfca1d80eca4/conversations/362012507
https://www.apptrajectory.com/thoughtbot/learn/stories/15642101
