### PR TITLE
Disable the refund button after clicking it

### DIFF
--- a/app/views/subscriber/refunds/new.html.erb
+++ b/app/views/subscriber/refunds/new.html.erb
@@ -7,7 +7,7 @@
       We hope that you've enjoyed <%= t('shared.subscription.name') %> while you've been a subscriber. If that's not the case, you can get a refund immediately for your last charge.
     </p>
     <p>
-      <%= link_to([:subscriber, :refund], method: :create) do %>
+    <%= link_to([:subscriber, :refund], method: :create, data: { disable_with: t('subscriptions.processing_refund') }) do %>
         <%= t('subscriptions.take_refund') %> &rarr;
       <% end %>
     </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,7 @@ en:
     choose_plan_html: Sign up for %{plan_name}
     current_plan_html: <p class="current-plan">This is your current plan</p>
     take_refund: Get a refund
+    processing_refund: Processing...
     reject_refund: No thanks, I'm happy
     cancellation_scheduled_on: Scheduled for cancellation on %{date}
     discount:


### PR DESCRIPTION
A user reported getting a 500 after clicking the button twice. This disables the button after it is clicked.
