### PR TITLE
Fix sign out link on prime page

### DIFF
--- a/app/views/pages/prime.html.erb
+++ b/app/views/pages/prime.html.erb
@@ -3,7 +3,7 @@
 <div class="prime-signin">
   <% if signed_in? %>
     <%= link_to 'Account', my_account_path %> |
-    <%= link_to 'Sign out', sign_out_path  %>
+    <%= link_to 'Sign out', sign_out_path, method: :delete %>
   <% else %>
     <%= link_to 'Sign in', sign_in_path %>
   <% end %>

--- a/spec/views/pages/prime.html.erb_spec.rb
+++ b/spec/views/pages/prime.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'pages/prime.html.erb' do
+  context 'when signed in' do
+    it 'includes a sign out link' do
+      view_stubs(:signed_in?).returns(true)
+
+      render_template
+
+      expect(rendered).
+        to include(link_to('Sign out', sign_out_path, method: :delete))
+    end
+
+    it 'includes an account link' do
+      view_stubs(:signed_in?).returns(true)
+
+      render_template
+
+      expect(rendered).to include(link_to('Account', my_account_path))
+    end
+
+    it 'does not include a sign in link' do
+      view_stubs(:signed_in?).returns(true)
+
+      render_template
+
+      expect(rendered).not_to include(link_to('Sign in', sign_in_path))
+    end
+  end
+
+  context 'when signed out' do
+    it 'includes a sign in link' do
+      view_stubs(:signed_in?).returns(false)
+
+      render_template
+
+      expect(rendered).to include(link_to('Sign in', sign_in_path))
+    end
+
+    it 'does not include a sign out link' do
+      view_stubs(:signed_in?).returns(false)
+
+      render_template
+
+      expect(rendered).
+        not_to include(link_to('Sign out', sign_out_path, method: :delete))
+    end
+
+    it 'does not include an account link' do
+      view_stubs(:signed_in?).returns(false)
+
+      render_template
+
+      expect(rendered).not_to include(link_to('Account', my_account_path))
+    end
+  end
+
+  def render_template
+    render template: 'pages/prime.html.erb'
+  end
+end


### PR DESCRIPTION
The sign out link on https://learn.thoughtbot.com/prime does not work since it is doing a normal GET request. This changes the links method to DELETE.

https://www.apptrajectory.com/thoughtbot/learn/stories/15642123
