### PR TITLE
Change the appearence of the all purchases link

### DIFF
--- a/app/assets/stylesheets/_users-edit.scss
+++ b/app/assets/stylesheets/_users-edit.scss
@@ -47,9 +47,8 @@ body.users-edit {
 
     a.view-all-purchases {
       display: block;
-      color: $darkwarmgray;
-      font-weight: bold;
       margin-top: 1em;
+      font-family: $sans-serif;
     }
   }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
         link: "subscribe to Prime"
 
   account:
-    view_purchases: 'View all purchases'
+    view_purchases: 'View all purchases →'
 
   individual_plans:
     mentoring: '1-1 Mentoring'


### PR DESCRIPTION
It now looks more like the other links on the site.

Before:
![screen shot 2014-04-07 at 11 07 05](https://cloud.githubusercontent.com/assets/66666/2629177/38e91032-be34-11e3-96e1-d58b67a5f46c.png)

After:
![screen shot 2014-04-07 at 11 07 26](https://cloud.githubusercontent.com/assets/66666/2629182/42175ba0-be34-11e3-83be-e5e34962ad93.png)
