### PR TITLE
Remove the RemoveResourcesAgain migration

### DIFF
--- a/db/migrate/20131129194559_remove_resources_again.rb
+++ b/db/migrate/20131129194559_remove_resources_again.rb
@@ -1,5 +1,0 @@
-class RemoveResourcesAgain < ActiveRecord::Migration
-  def change
-    drop_table :resources
-  end
-end


### PR DESCRIPTION
When running `rake db:drop db:create db:migrate` this migration causes the following error:

```
==  RemoveResourcesAgain: migrating ===========================================
-- drop_table(:resources)
rake aborted!
An error has occurred, this and all later migrations canceled:

PG::Error: ERROR:  table "resources" does not exist
: DROP TABLE "resources"/Users/calleerlandsson/code/thoughtbot/learn/db/migrate/20131129194559_remove_resources_again.rb:3:in `change'
Tasks: TOP => db:migrate
```

I read about the migration in [this commit message](https://github.com/thoughtbot/learn/commit/e4b49f13e9ea9f0419162096b69a2da154e98301) and [this story](https://www.apptrajectory.com/thoughtbot/learn/stories/15637547) but as the schema.rb file is now in sync with the production database schema I don't see why we still need this migration. Is it ok to remove it or am I missing something?
