### PR TITLE
Makes all inputs that take an email of the type email

### DIFF
--- a/app/modules/teams/views/teams/invitations/_form.html.erb
+++ b/app/modules/teams/views/teams/invitations/_form.html.erb
@@ -1,7 +1,7 @@
 <%= semantic_form_for invitation do |form| %>
   <%= form.semantic_errors :team %>
   <%= form.inputs do %>
-    <%= form.input :email %>
+    <%= form.input :email, as: :email %>
     <%= form.submit 'Send invite' %>
   <% end %>
 <% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -3,7 +3,7 @@
     <%= semantic_form_for :password, :url => passwords_path do |form| %>
       <p>We will email you a link to reset your password.</p>
       <%= form.inputs do -%>
-        <%= form.input :email %>
+        <%= form.input :email, as: :email %>
       <% end %>
       <%= form.actions do %>
         <%= form.action :submit, label: 'Reset password' %>

--- a/app/views/purchases/_form.html.erb
+++ b/app/views/purchases/_form.html.erb
@@ -13,7 +13,7 @@
     <%= form.input :stripe_coupon_id, as: :hidden %>
     <%= form.input :variant, as: :hidden %>
     <%= form.input :name %>
-    <%= form.input :email %>
+    <%= form.input :email, as: :email %>
     <%= render purchase_form_partial(@purchase.purchaseable), form: form, purchase: @purchase %>
     <%= render 'purchases/github_usernames', form: form, purchase: @purchase %>
   <% end %>


### PR DESCRIPTION
Using the HTML5 input type email makes it easier for mobile users to
fill forms, since most mobile devices adapt the keyboard to take this
into account.
