### PR TITLE
Eager load mentor data

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -17,9 +17,9 @@ class Mentor < ActiveRecord::Base
   end
 
   def active_mentees
-    mentees.select do |mentee|
-      mentee.has_active_subscription? && mentee.has_subscription_with_mentor?
-    end
+    mentees
+      .with_active_subscription
+      .select(&:has_subscription_with_mentor?)
   end
 
   def active_mentee_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,11 @@ class User < ActiveRecord::Base
   delegate :first_name, to: :mentor, prefix: true, allow_nil: true
   delegate :name, to: :mentor, prefix: true, allow_nil: true
 
+  def self.with_active_subscription
+    includes(purchased_subscription: :plan, team: { subscription: :plan }).
+      select(&:has_active_subscription?)
+  end
+
   def subscription_purchases
     paid_purchases.where(payment_method: 'subscription')
   end

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -53,6 +53,13 @@ describe Mentor do
 
       expect(mentor.active_mentees).to eq [active]
     end
+
+    it 'eager loads mentees' do
+      mentor = create(:mentor)
+
+      expect { mentor.reload.active_mentees }.
+        to eager_load { create(:subscriber, :includes_mentor, mentor: mentor) }
+    end
   end
 
   describe '#active_mentee_count' do

--- a/spec/support/matchers/eager_load.rb
+++ b/spec/support/matchers/eager_load.rb
@@ -1,0 +1,51 @@
+module EagerLoadMatcher
+  class Matcher
+    def initialize(data_creator)
+      @data_creator = data_creator
+    end
+
+    def matches?(eager_loaded_block)
+      @eager_loaded_block = eager_loaded_block
+
+      @output = 3.times.map do
+        @data_creator.call
+        trace_queries { @eager_loaded_block.call }
+      end
+
+      @output.second.size == @output.third.size
+    end
+
+    def failure_message
+      'Expected block to be eager loaded, but received extra queries. ' \
+        "Queries:\n#{@output.third.join("\n")}"
+    end
+
+    private
+
+    def trace_queries(&block)
+      output = StringIO.new
+      logger = ActiveSupport::Logger.new(output)
+      with_logger(logger, &block)
+      output.rewind
+      output
+        .read
+        .split("\n")
+    end
+
+    def with_logger(logger)
+      old_logger = ActiveRecord::Base.logger
+      ActiveRecord::Base.logger = logger
+      yield
+    ensure
+      ActiveRecord::Base.logger = old_logger
+    end
+  end
+
+  def eager_load(&data_creator)
+    Matcher.new(data_creator)
+  end
+end
+
+RSpec.configure do |config|
+  config.include EagerLoadMatcher
+end


### PR DESCRIPTION
Because:
- Mentors list how many active mentees they have
- We need to check for active subscriptions to know who is a mentee
- We were loading subscription, team, and plan data for each mentee

This commit:
- Eager loads subscription, team, and plan data for mentees

https://logentries.com/app/b47aeedd#f=1396890990000&id=e2e78c62-c97e-4bfb-b367-882a0dcbf7cb&l=Last+24h&log_p=&log_q=&log_tag=2&r=d&s=log&t=1396977390000
