### PR TITLE
Show newest Weekly Iteration first

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -18,6 +18,10 @@ class Video < ActiveRecord::Base
     where('published_on <= ?', Time.zone.today)
   end
 
+  def self.recently_published_first
+    order('published_on desc')
+  end
+
   def video_sizes
     @video_sizes ||= wistia_hash['assets'].inject({}) do |result, asset|
       result.merge(asset['type'] => human_file_size(asset['fileSize']))

--- a/app/views/shows/show_purchase_show.html.erb
+++ b/app/views/shows/show_purchase_show.html.erb
@@ -8,7 +8,8 @@
 <div class="text-box-wrapper">
   <div class="text-box">
     <section id="videos">
-      <%= render @purchaseable.published_videos.ordered, purchase: @purchase %>
+      <%= render @purchaseable.published_videos.recently_published_first,
+        purchase: @purchase %>
     </section>
   </div>
 </div>

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -34,6 +34,18 @@ describe Video do
     end
   end
 
+  context '.recently_published_first' do
+    it 'sorts the collection so that recently published videos are first' do
+      create(:video, published_on: Date.today, title: 'new')
+      create(:video, published_on: 2.days.ago, title: 'old')
+      create(:video, published_on: Date.yesterday, title: 'middle')
+
+      expect(Video.recently_published_first.map(&:title)).to eq ['new',
+                                                                 'middle',
+                                                                 'old']
+    end
+  end
+
   context '#wistia_thumbnail' do
     it 'returns the thumbnail cached from wistia' do
       video = build_stubbed(:video,


### PR DESCRIPTION
- Lets subscribers view newest episode without scrolling.
- Adds a recently_published_first scope to Video.
