### PR TITLE
Show preview video instead of thumbnail if present

### DIFF
--- a/app/helpers/wistia_helper.rb
+++ b/app/helpers/wistia_helper.rb
@@ -17,7 +17,9 @@ module WistiaHelper
   private
 
   def wistia_video_url_with_settings(video_hash, width, height)
-    unless Rails.env.test?
+    if Rails.env.test?
+      "#{request.host}/#{video_hash}"
+    else
       "#{wistia_video_url(video_hash)}?#{wistia_query(width, height)}".html_safe
     end
   end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -46,6 +46,10 @@ class Video < ActiveRecord::Base
     @wistia_thumbnail ||= wistia_hash["thumbnail"]["url"] rescue nil
   end
 
+  def preview_video_hash_id
+    @preview_video_hash_id ||= preview_wistia_hash['hashed_id']
+  end
+
   def full_sized_wistia_thumbnail
     wistia_thumbnail.try(:split, '?').try(:first)
   end
@@ -59,6 +63,12 @@ class Video < ActiveRecord::Base
   end
 
   private
+
+  def preview_wistia_hash
+    unless preview_wistia_id.nil?
+      @preview_wistia_hash ||= Wistia.get_media_hash_from_id(preview_wistia_id)
+    end
+  end
 
   def human_file_size num
     helpers.number_to_human_size(num)

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -5,7 +5,11 @@
 <% cache(@video) do %>
   <div class="text-box-wrapper">
     <div class="text-box">
-      <%= image_tag @video.full_sized_wistia_thumbnail, alt: @video.title, class: "thumbnail" %>
+      <% if @video.preview_wistia_id.present? %>
+        <%= wistia_video_embed(@video.preview_video_hash_id) %>
+      <% else %>
+        <%= image_tag @video.full_sized_wistia_thumbnail, alt: @video.title, class: "thumbnail" %>
+      <% end %>
 
       <section class='video-notes'>
         <h3>Notes</h3>

--- a/db/migrate/20131129194559_remove_resources_again.rb
+++ b/db/migrate/20131129194559_remove_resources_again.rb
@@ -1,5 +1,0 @@
-class RemoveResourcesAgain < ActiveRecord::Migration
-  def change
-    drop_table :resources
-  end
-end

--- a/db/migrate/20140509152714_add_preview_to_videos.rb
+++ b/db/migrate/20140509152714_add_preview_to_videos.rb
@@ -1,0 +1,5 @@
+class AddPreviewToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :preview_wistia_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140407144214) do
+ActiveRecord::Schema.define(version: 20140509152714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -367,12 +367,13 @@ ActiveRecord::Schema.define(version: 20140407144214) do
     t.integer  "watchable_id"
     t.string   "wistia_id"
     t.string   "title"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.string   "watchable_type"
-    t.integer  "position",       default: 0, null: false
+    t.integer  "position",          default: 0, null: false
     t.text     "notes"
     t.date     "published_on"
+    t.string   "preview_wistia_id"
   end
 
   add_index "videos", ["watchable_type", "watchable_id"], name: "index_videos_on_watchable_type_and_watchable_id", using: :btree

--- a/lib/wistia.rb
+++ b/lib/wistia.rb
@@ -4,7 +4,7 @@ class Wistia
   basic_auth 'api', ENV['WISTIA_API_KEY']
 
   def self.get_media_hash_from_id id
-    self.get("/medias/#{id}.json")
+    get("/medias/#{id}.json").body
   rescue *HTTP_ERRORS => e
     Airbrake.notify e
     {}

--- a/spec/helpers/wistia_helper_spec.rb
+++ b/spec/helpers/wistia_helper_spec.rb
@@ -1,24 +1,10 @@
 require 'spec_helper'
 
 describe WistiaHelper do
-  it 'returns an iframe with no src' do
+  it 'returns an iframe with src' do
     iframe = helper.wistia_video_embed('hash')
 
     expect(iframe).to include 'iframe'
-    expect(iframe).not_to include 'src'
-  end
-
-  context 'in a non-test environment' do
-    before do
-      env = stub(test?: false)
-      Rails.stubs(env: env)
-    end
-
-    it 'returns an iframe with src' do
-      iframe = helper.wistia_video_embed('hash')
-
-      expect(iframe).to include 'iframe'
-      expect(iframe).to include 'src'
-    end
+    expect(iframe).to include 'src'
   end
 end

--- a/spec/lib/wistia_spec.rb
+++ b/spec/lib/wistia_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Wistia do
+  context '.get_media_hash_from_id' do
+    it 'returns the response body as a hash' do
+      data = { 'some_key' => 'some_value' }
+      stub_request(:get, /api.wistia.com\/v1\/medias/).
+        to_return(header: { 'Content-Type' => 'text/json' }, body: data)
+
+      expect(Wistia.get_media_hash_from_id(1)).to eq data
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -67,6 +67,18 @@ describe Video do
     end
   end
 
+  context '#preview_video_hash_id' do
+    it 'returns the video_hash_id for the preview video' do
+      video = Video.new(preview_wistia_id: '123')
+      wistia_hash = { 'hashed_id' => stub }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+
+      hash_id = video.preview_video_hash_id
+
+      expect(hash_id).to eq wistia_hash['hashed_id']
+    end
+  end
+
   context 'watchable_name' do
     it 'returns the name of the watchable' do
       workshop = create(:workshop, name: 'Workshop')

--- a/spec/views/episodes/show.html.erb_spec.rb
+++ b/spec/views/episodes/show.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'episodes/show' do
+  it 'embeds a preview when available' do
+    video = build(
+      :video,
+      :published,
+      watchable: build_stubbed(:show),
+      preview_wistia_id: '123456'
+    )
+
+    video.stubs(:preview_video_hash_id).returns('abc789')
+    stub_controller(video)
+
+    render template: 'episodes/show'
+
+    expect(rendered).to have_css("iframe[src*='#{video.preview_video_hash_id}']")
+  end
+
+  it 'shows a thumbnail when there is no preview' do
+    video = build(
+      :video,
+      :published,
+      watchable: build_stubbed(:show),
+      preview_wistia_id: nil
+    )
+
+    video.
+      stubs(:full_sized_wistia_thumbnail).
+      returns('http://embed.wistia.com/some_id')
+    stub_controller(video)
+
+    render template: 'episodes/show'
+
+    expect(rendered).to have_css("img[src*='embed.wistia.com']")
+  end
+
+  def stub_controller(video)
+    assign :plan, stub
+    assign :video, video
+    view.stubs(:signed_out?).returns(true)
+  end
+end


### PR DESCRIPTION
https://www.apptrajectory.com/thoughtbot/learn/stories/15641131

When viewing a public video page, show preview video instead of
thumbnail when one is present.

We allowed the wistia helper to output the `src` attribute on the iframe
in tests. We used that attribute to test that the preview video was
shown instead of the real thing. The test speed remained the same.
