### PR TITLE
Break up Video class

### DIFF
--- a/app/helpers/wistia_helper.rb
+++ b/app/helpers/wistia_helper.rb
@@ -1,5 +1,5 @@
 module WistiaHelper
-  def wistia_video_embed(video_hash, width = 653, height = 367)
+  def wistia_video_embed(video, size = :large)
     content_tag(
       :iframe,
       '',
@@ -8,31 +8,9 @@ module WistiaHelper
       scrolling: 'no',
       class: 'wistia_embed',
       name: 'wistia_embed',
-      width: width,
-      height: height,
-      src: wistia_video_url_with_settings(video_hash, width, height)
-    )
-  end
-
-  private
-
-  def wistia_video_url_with_settings(video_hash, width, height)
-    if Rails.env.test?
-      "#{request.host}/#{video_hash}"
-    else
-      "#{wistia_video_url(video_hash)}?#{wistia_query(width, height)}".html_safe
-    end
-  end
-
-  def wistia_video_url(video_hash)
-    "https://fast.wistia.com/embed/iframe/#{video_hash}"
-  end
-
-  def wistia_query(width, height)
-    Rack::Utils.build_query(
-      videoWidth: width,
-      videoHeight: height,
-      controlsVisibleOnLoad: true
+      width: Clip::SIZES[size][:width],
+      height: Clip::SIZES[size][:height],
+      src: video.embed_url(size)
     )
   end
 end

--- a/app/models/clip.rb
+++ b/app/models/clip.rb
@@ -1,0 +1,86 @@
+class Clip
+  WISTIA_EMBED_BASE_URL = 'https://fast.wistia.com/embed/iframe/'
+  WISTIA_DOWNLOAD_BASE_URL = 'http://thoughtbotlearn.wistia.com/medias/'
+  SIZES = {
+    large: { width: 653, height: 367 }.freeze,
+    small: { width: 563, height: 317 }.freeze,
+  }.freeze
+
+  SCREENCASTS_PROMO_ID = 'nuhokhnb7s'
+  WEEKLY_ITERATION_PROMO_ID = 'ol6e0miehm'
+  WORKSHOPS_PROMO_ID = 'im3s3en4yu'
+
+  def self.screencasts_promo
+    new(SCREENCASTS_PROMO_ID)
+  end
+
+  def self.weekly_iteration_promo
+    new(WEEKLY_ITERATION_PROMO_ID)
+  end
+
+  def self.workshops_promo
+    new(WORKSHOPS_PROMO_ID)
+  end
+
+  def initialize(wistia_id)
+    @wistia_id = wistia_id
+  end
+
+  def embed_url(size)
+    WISTIA_EMBED_BASE_URL + hash_id + '?' + embed_params(size)
+  end
+
+  def download_url(type)
+    WISTIA_DOWNLOAD_BASE_URL + @wistia_id + '/download?asset=' + type
+  end
+
+  def thumbnail
+    wistia_hash['thumbnail']['url']
+  end
+
+  def full_sized_thumbnail
+    thumbnail.try(:split, '?').try(:first)
+  end
+
+  def running_time
+    wistia_hash['duration']
+  end
+
+  def sizes
+    wistia_hash['assets'].inject({}) do |result, asset|
+      result.merge(asset['type'] => human_file_size(asset['fileSize']))
+    end
+  end
+
+  def to_partial_path
+    'clips/clip'
+  end
+
+  private
+
+  def wistia_hash
+    @wistia_hash ||= Wistia.get_media_hash_from_id(@wistia_id)
+  end
+
+  def hash_id
+    wistia_hash['hashed_id']
+  end
+
+  def embed_params(size)
+    dimensions = SIZES[size]
+
+    Rack::Utils.build_query(
+      videoWidth: dimensions[:width],
+      videoHeight: dimensions[:height],
+      controlsVisibleOnLoad: true
+    )
+  end
+
+  def human_file_size(size)
+    number_formatter.number_to_human_size(size)
+  end
+
+  def number_formatter
+    Object.new.extend(ActionView::Helpers::NumberHelper)
+  end
+end

--- a/app/models/video_thumbnail.rb
+++ b/app/models/video_thumbnail.rb
@@ -1,0 +1,11 @@
+class VideoThumbnail
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def to_partial_path
+    'video_thumbnails/video_thumbnail'
+  end
+end

--- a/app/views/clips/_clip.html.erb
+++ b/app/views/clips/_clip.html.erb
@@ -1,0 +1,11 @@
+<% cache(clip) do %>
+  <p class="videowrapper"><%= wistia_video_embed(clip) %></p>
+
+  <section class="assets-wrapper">
+    <div class="assets">
+      <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
+      <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", clip: clip %>
+      <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -5,11 +5,7 @@
 <% cache(@video) do %>
   <div class="text-box-wrapper">
     <div class="text-box">
-      <% if @video.preview_wistia_id.present? %>
-        <%= wistia_video_embed(@video.preview_video_hash_id) %>
-      <% else %>
-        <%= image_tag @video.full_sized_wistia_thumbnail, alt: @video.title, class: "thumbnail" %>
-      <% end %>
+      <%= render @video.preview, title: @video.title %>
 
       <section class='video-notes'>
         <h3>Notes</h3>

--- a/app/views/pages/humans-present-oss.html.erb
+++ b/app/views/pages/humans-present-oss.html.erb
@@ -7,7 +7,9 @@
 
 <div class="text-box-wrapper">
   <div class="text-box">
-    <p class="videowrapper"><%= wistia_video_embed('39245f55fd') %></p>
+    <p class="videowrapper">
+      <iframe allowtransparency="true" class="wistia_embed" frameborder="0" height="367" name="wistia_embed" scrolling="no" src="https://fast.wistia.com/embed/iframe/39245f55fd?videoWidth=653&videoHeight=367&controlsVisibleOnLoad=true" width="653"></iframe>
+    </p>
     <h3>An interview with a Ruby developer who uses Linux and full Open Source stack</h3>
 
     <div class='assets'>

--- a/app/views/plans/_screencasts_detail.html.erb
+++ b/app/views/plans/_screencasts_detail.html.erb
@@ -1,5 +1,5 @@
 <figure>
-  <%= wistia_video_embed('nuhokhnb7s', 563, 317) %>
+  <%= wistia_video_embed(Clip.screencasts_promo, :small) %>
 </figure>
 
 <article>

--- a/app/views/plans/_weekly_iteration_detail.html.erb
+++ b/app/views/plans/_weekly_iteration_detail.html.erb
@@ -1,5 +1,5 @@
 <figure>
-  <%= wistia_video_embed('ol6e0miehm', 563, 317) %>
+  <%= wistia_video_embed(Clip.weekly_iteration_promo, :small) %>
 </figure>
 
 <article>

--- a/app/views/plans/_workshops_detail.html.erb
+++ b/app/views/plans/_workshops_detail.html.erb
@@ -1,5 +1,5 @@
 <figure>
-  <%= wistia_video_embed('im3s3en4yu', 563, 317) %>
+  <%= wistia_video_embed(Clip.workshops_promo, :small) %>
 </figure>
 
 <article>

--- a/app/views/video_thumbnails/_video_thumbnail.html.erb
+++ b/app/views/video_thumbnails/_video_thumbnail.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag video_thumbnail.url, alt: title, class: "thumbnail" %>

--- a/app/views/videos/_download_link.html.erb
+++ b/app/views/videos/_download_link.html.erb
@@ -1,6 +1,6 @@
-<% unless (size = video.video_sizes[download_type_key]).nil? %>
-  <a class="button-mini <%= download_type %>" href="http://thoughtbotlearn.wistia.com/medias/<%= video.wistia_id %>/download?asset=<%= download_type %>">
+<% if clip.sizes[download_type_key].present? %>
+  <a class="button-mini <%= download_type %>" href=<%= clip.download_url(download_type) %>">
     <%=size_display%>
-    <span class="size"><%= size %></span>
+    <span class="size"><%= clip.sizes[download_type_key] %></span>
   </a>
 <% end %>

--- a/app/views/videos/_thumbnail.html.erb
+++ b/app/views/videos/_thumbnail.html.erb
@@ -1,10 +1,10 @@
-<% cache(video) do %>
-  <%= image_tag video.wistia_thumbnail, width: 100, height: 60, alt: video.title, :class => "thumbnail" %>
+<% cache(clip) do %>
+  <%= image_tag clip.thumbnail, width: 100, height: 60, alt: title, :class => "thumbnail" %>
   <div class="thumbnail-text">
-    <h3><%= video.title %></h3>
+    <h3><%= title %></h3>
     <p class="videoinfo">
       <em>
-        <%= distance_of_time_in_words video.wistia_running_time %>
+        <%= distance_of_time_in_words clip.running_time %>
       </em>
     </p>
   </div>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag_for :div, video do %>
   <%= link_to purchase_video_path(purchase, video) do %>
-    <%= render 'videos/thumbnail', video: video, purchase: purchase %>
+    <%= render 'videos/thumbnail', clip: video.clip, title: video.title, purchase: purchase %>
   <% end %>
 <% end %>

--- a/app/views/videos/_watch_video.html.erb
+++ b/app/views/videos/_watch_video.html.erb
@@ -1,14 +1,4 @@
-<% cache(video) do %>
-  <p class="videowrapper"><%= wistia_video_embed(video.video_hash_id) %></p>
-
-  <section class="assets-wrapper">
-    <div class="assets">
-      <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", video: video %>
-      <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", video: video %>
-      <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", video: video %>
-    </div>
-  </section>
-<% end %>
+<%= render video.clip %>
 
 <% if video.has_notes? %>
   <div class="text-box">

--- a/app/views/weekly_iterations/show.html.erb
+++ b/app/views/weekly_iterations/show.html.erb
@@ -14,7 +14,7 @@
       <% @show.published_videos.ordered.each do |video| %>
         <%= content_tag_for :div, video do %>
           <%= link_to public_video_path(video) do %>
-            <%= render 'videos/thumbnail', video: video %>
+            <%= render 'videos/thumbnail', clip: video.clip, title: video.title %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -5,7 +5,7 @@ describe 'Workshops' do
 
   it 'displays their formatted resources' do
     workshop = create(:workshop, resources: "* Item 1\n*Item 2")
-    video = create(:video, watchable: workshop)
+    create(:video, watchable: workshop)
     purchase = create_subscriber_purchase_from_purchaseable(workshop)
 
     visit purchase_path(purchase)

--- a/spec/helpers/wistia_helper_spec.rb
+++ b/spec/helpers/wistia_helper_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe WistiaHelper do
   it 'returns an iframe with src' do
-    iframe = helper.wistia_video_embed('hash')
+    video = stub(embed_url: stub)
+    iframe = helper.wistia_video_embed(video)
 
     expect(iframe).to include 'iframe'
     expect(iframe).to include 'src'

--- a/spec/models/clip_spec.rb
+++ b/spec/models/clip_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Clip do
+  context '#thumbnail' do
+    it 'returns the thumbnail cached from wistia' do
+      video = Clip.new('123')
+      wistia_hash = { 'thumbnail' => { 'url' => 'http://images.com/hi.jpg' } }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+      expect(video.thumbnail).to eq 'http://images.com/hi.jpg'
+    end
+  end
+
+  context '#full_sized_thumbnail' do
+    it 'returns the full sized thumbnail cached from wistia' do
+      video = Clip.new('123')
+      wistia_hash = {
+        'thumbnail' => {
+          'url' => 'http://images.com/hi.jpg?image_crop_resized=100x60'
+        }
+      }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+
+      expect(video.full_sized_thumbnail).to eq 'http://images.com/hi.jpg'
+    end
+  end
+
+  context '#running_time' do
+    it 'returns the running time' do
+      video = Clip.new('123')
+      wistia_hash = { 'duration' => stub }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+
+      expect(video.running_time).to eq wistia_hash['duration']
+    end
+  end
+
+  context '#sizes' do
+    it 'returns the sizes' do
+      video = Clip.new('123')
+      wistia_hash = {
+        'assets' => [
+          { 'type' => 'small', 'fileSize' => '12345'},
+          { 'type' => 'large', 'fileSize' => '98765'}
+        ]
+      }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+
+      expect(video.sizes).to eq({ 'small' => '12.1 KB', 'large' => '96.5 KB' })
+    end
+  end
+
+  context '#embed_url' do
+    it 'returns the embed url for the video' do
+      video = Clip.new('123')
+      wistia_hash = { 'hashed_id' => 'abc123' }
+      Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
+
+      url = video.embed_url(:large)
+      expected_url = Clip::WISTIA_EMBED_BASE_URL +
+        'abc123?videoWidth=653&videoHeight=367&controlsVisibleOnLoad=true'
+
+      expect(url).to eq expected_url
+    end
+  end
+
+  context '#download_url' do
+    it 'returns the download url for the video' do
+      video = Clip.new('123')
+
+      url = video.download_url('original')
+      expected_url = 'http://thoughtbotlearn.wistia.com/medias/123/download?asset=original'
+
+      expect(url).to eq expected_url
+    end
+  end
+end

--- a/spec/models/video_thumbnail_spec.rb
+++ b/spec/models/video_thumbnail_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe VideoThumbnail do
+  context '#url' do
+    it 'returns the url' do
+      url = stub
+      thumbnail = VideoThumbnail.new(url)
+
+      expect(thumbnail.url).to eq url
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,11 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].e
 
 FakeStripeRunner.boot
 FakeGithubRunner.boot
+FakeWistiaRunner.boot
+
+silence_warnings do
+  Clip::WISTIA_EMBED_BASE_URL = 'localhost/'
+end
 
 Delayed::Worker.delay_jobs = false
 

--- a/spec/support/fake_wistia.rb
+++ b/spec/support/fake_wistia.rb
@@ -1,0 +1,19 @@
+require 'sinatra/base'
+require 'capybara_discoball'
+
+class FakeWistia < Sinatra::Base
+  get '/medias/:id.json' do
+    headers 'Content-Type' => 'application/json'
+    {
+      hashed_id: 'abc123',
+      assets: [{ type: 'OriginalFile', fileSize: 12345 }],
+      duration: 5,
+      thumbnail: {}
+    }.to_json
+  end
+end
+
+FakeWistiaRunner = Capybara::Discoball::Runner.new(FakeWistia) do |server|
+  url = "http://#{server.host}:#{server.port}"
+  Wistia.base_uri(url)
+end

--- a/spec/views/episodes/show.html.erb_spec.rb
+++ b/spec/views/episodes/show.html.erb_spec.rb
@@ -9,12 +9,14 @@ describe 'episodes/show' do
       preview_wistia_id: '123456'
     )
 
-    video.stubs(:preview_video_hash_id).returns('abc789')
+    preview_video = Clip.new('123456')
+    preview_video.stubs(:embed_url).returns('http://example.com/medias/xyz890')
+    video.stubs(:preview).returns(preview_video)
     stub_controller(video)
 
     render template: 'episodes/show'
 
-    expect(rendered).to have_css("iframe[src*='#{video.preview_video_hash_id}']")
+    expect(rendered).to have_css("iframe[src*='xyz890']")
   end
 
   it 'shows a thumbnail when there is no preview' do
@@ -25,9 +27,8 @@ describe 'episodes/show' do
       preview_wistia_id: nil
     )
 
-    video.
-      stubs(:full_sized_wistia_thumbnail).
-      returns('http://embed.wistia.com/some_id')
+    thumbnail = VideoThumbnail.new('http://embed.wistia.com/some_id')
+    video.stubs(:preview).returns(thumbnail)
     stub_controller(video)
 
     render template: 'episodes/show'
@@ -38,6 +39,7 @@ describe 'episodes/show' do
   def stub_controller(video)
     assign :plan, stub
     assign :video, video
-    view.stubs(:signed_out?).returns(true)
+
+    view_stubs(:signed_out?).returns(true)
   end
 end

--- a/spec/views/videos/_watch_video.html.erb_spec.rb
+++ b/spec/views/videos/_watch_video.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'videos/_watch_video.html.erb' do
   it "includes a video's notes as html" do
-    video = build_stubbed(:video, notes: 'Some notes')
+    video = Video.new(wistia_id: '123', notes: 'Some notes')
 
     render_view(video)
 
@@ -10,7 +10,8 @@ describe 'videos/_watch_video.html.erb' do
   end
 
   it "can still render a video without notes" do
-    video = build_stubbed(:video)
+    video = Video.new(wistia_id: '123')
+    video.clip.stubs(:sizes).returns({})
 
     expect { render_view(video) }.to_not raise_error
   end


### PR DESCRIPTION
The ActiveRecord `Video` class handled multiple responsibilities including the concept of an embeddable video and the concept of something a little higher level that encapsulated a video, notes, a promo video, and a thumbnail. The main video and promo video responsibilities were a particular concern because the methods to deal with them were duplicated with the prefix `preview_`. 

This led us to extract the concept of a video into a separate PORO. We named it `Video` and renamed the ActiveRecord class `Episode`. An episode has a video and a preview, both of which are now `Video` objects, eliminating the need for duplicated methods.

If there is no promo, `Episode#preview` returns a `VideoThumbnail` object. This is a light wrapper around a url to a video thumbnail. We take advantage of `to_partial_path` by simply calling `render episode.preview` in the view, eliminating the conditional that used to be there.

**Note** The variable names `episode` and `video` are scattered throughout the app and I haven't renamed them yet. The test suite is fully green but some of the variable names are deceiving. I wanted to get some feedback on whether this refactor was a good idea before I did all the work of renaming those variables correctly.
