### PR TITLE
Fix download link href

### DIFF
--- a/app/views/videos/_download_link.html.erb
+++ b/app/views/videos/_download_link.html.erb
@@ -1,5 +1,5 @@
 <% if clip.sizes[download_type_key].present? %>
-  <a class="button-mini <%= download_type %>" href=<%= clip.download_url(download_type) %>">
+  <a class="button-mini <%= download_type %>" href="<%= clip.download_url(download_type) %>">
     <%=size_display%>
     <span class="size"><%= clip.sizes[download_type_key] %></span>
   </a>


### PR DESCRIPTION
When on a download page, there's an extraneous double quote in the download links due to a missing quote in the href.

p.s. I haven't tested this at all, but it sure does look like it's the problem!
