### PR TITLE
Convert specs to RSpec 2.14.7 syntax with Transpec

### DIFF
--- a/spec/controllers/api/v1/completions_controller_spec.rb
+++ b/spec/controllers/api/v1/completions_controller_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Api::V1::CompletionsController, '#show' do
   it 'returns a 401 when users are not authenticated' do
     get :index
-    response.code.should eq '401'
+    expect(response.code).to eq '401'
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Api::V1::UsersController, '#show' do
   it 'returns a 401 when users are not authenticated' do
     get :show
-    response.code.should eq '401'
+    expect(response.code).to eq '401'
   end
 end

--- a/spec/controllers/promoted_catalogs_controller_spec.rb
+++ b/spec/controllers/promoted_catalogs_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PromotedCatalogsController do
   describe '#show' do
     it 'uses the empty-body layout' do
-      promoted_catalog = stub('promoted_catalog')
+      promoted_catalog = double('promoted_catalog')
       PromotedCatalog.stubs(:new).returns(promoted_catalog)
       get :show
 

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -85,7 +85,7 @@ describe PurchasesController do
 
       post :create, purchase: customer_params(stripe_token), product_id: product.to_param
 
-      FakeStripe.should have_charged(1500).to('test@example.com').with_token(stripe_token)
+      expect(FakeStripe).to have_charged(1500).to('test@example.com').with_token(stripe_token)
     end
   end
 
@@ -95,7 +95,7 @@ describe PurchasesController do
 
     post :create, purchase: customer_params, product_id: product
 
-    flash[:purchase_amount].should eq product.individual_price
+    expect(flash[:purchase_amount]).to eq product.individual_price
   end
 
   describe "processing on paypal" do
@@ -105,9 +105,9 @@ describe PurchasesController do
 
       post :create, purchase: { variant: "individual", name: "User", email: "test@example.com", payment_method: "paypal" }, product_id: product.to_param
 
-      response.status.should == 302
-      response.location.should == FakePaypal.outgoing_uri
-      assigns(:purchase).should_not be_paid
+      expect(response.status).to eq(302)
+      expect(response.location).to eq(FakePaypal.outgoing_uri)
+      expect(assigns(:purchase)).not_to be_paid
     end
   end
 
@@ -122,7 +122,7 @@ describe PurchasesController do
 
       get :show, id: purchase.to_param
 
-      response.should redirect_to(book_path(product))
+      expect(response).to redirect_to(book_path(product))
     end
   end
 

--- a/spec/controllers/subscriber/cancellations_controller_spec.rb
+++ b/spec/controllers/subscriber/cancellations_controller_spec.rb
@@ -31,9 +31,9 @@ describe Subscriber::CancellationsController do
   describe '#create with a subscription that has never been charged' do
     it 'redirects to the account page' do
       user = build_stubbed(:user)
-      subscription = stub(last_charge: nil)
+      subscription = double(last_charge: nil)
       user.stubs(subscription: subscription)
-      Cancellation.stubs(:new).returns(stub(schedule: nil))
+      Cancellation.stubs(:new).returns(double(schedule: nil))
       sign_in_as(user)
 
       post :create

--- a/spec/features/clearance/visitor_resets_password_spec.rb
+++ b/spec/features/clearance/visitor_resets_password_spec.rb
@@ -6,7 +6,7 @@ feature 'Visitor resets password' do
 
     click_link I18n.t('sessions.form.forgot_password')
 
-    current_path.should eq new_password_path
+    expect(current_path).to eq new_password_path
   end
 
   scenario 'with valid email' do
@@ -26,16 +26,16 @@ feature 'Visitor resets password' do
   private
 
   def reset_notification_should_be_sent_to(user)
-    user.confirmation_token.should_not be_blank
+    expect(user.confirmation_token).not_to be_blank
     mailer_should_have_delivery user.email, 'password', user.confirmation_token
   end
 
   def page_should_display_change_password_message
-    page.should have_content I18n.t('passwords.create.description')
+    expect(page).to have_content I18n.t('passwords.create.description')
   end
 
   def mailer_should_have_delivery(recipient, subject, body)
-    ActionMailer::Base.deliveries.should_not be_empty
+    expect(ActionMailer::Base.deliveries).not_to be_empty
 
     message = ActionMailer::Base.deliveries.any? do |email|
       email.to == [recipient] &&
@@ -43,10 +43,10 @@ feature 'Visitor resets password' do
         email.body =~ /#{body}/
     end
 
-    message.should be
+    expect(message).to be
   end
 
   def mailer_should_have_no_deliveries
-    ActionMailer::Base.deliveries.should be_empty
+    expect(ActionMailer::Base.deliveries).to be_empty
   end
 end

--- a/spec/features/clearance/visitor_signs_in_spec.rb
+++ b/spec/features/clearance/visitor_signs_in_spec.rb
@@ -37,7 +37,7 @@ feature 'Visitor signs in' do
   end
 
   def page_should_display_sign_in_error
-    page.body.should include(
+    expect(page.body).to include(
       I18n.t('flashes.failure_after_create', :sign_up_path => sign_up_path)
     )
   end

--- a/spec/features/clearance/visitor_signs_up_spec.rb
+++ b/spec/features/clearance/visitor_signs_up_spec.rb
@@ -6,7 +6,7 @@ feature 'Visitor signs up' do
 
     click_link I18n.t('sessions.form.sign_up')
 
-    current_path.should eq sign_up_path
+    expect(current_path).to eq sign_up_path
   end
 
   scenario 'with valid email and password' do

--- a/spec/features/clearance/visitor_updates_password_spec.rb
+++ b/spec/features/clearance/visitor_updates_password_spec.rb
@@ -22,7 +22,7 @@ feature 'Visitor updates password' do
     visit_password_reset_page_for user
     change_password_to ''
 
-    page.should have_content I18n.t('flashes.failure_after_update')
+    expect(page).to have_content I18n.t('flashes.failure_after_update')
     user_should_be_signed_out
   end
 

--- a/spec/features/oauth_client_authenticates_spec.rb
+++ b/spec/features/oauth_client_authenticates_spec.rb
@@ -77,6 +77,6 @@ feature 'An OAuth client authenticates', js: true do
 
   def verify_signed_in_user_details(json, checked_user)
     user = json['user']
-    user['email'].should eq checked_user.email
+    expect(user['email']).to eq checked_user.email
   end
 end

--- a/spec/features/user_attempts_to_add_oauth_application_spec.rb
+++ b/spec/features/user_attempts_to_add_oauth_application_spec.rb
@@ -4,11 +4,11 @@ feature 'User attempts to add OAuth application' do
   scenario 'as non-admin' do
     user = create(:user)
     visit oauth_applications_path(as: user)
-    page.current_url.should eq sign_in_url
+    expect(page.current_url).to eq sign_in_url
   end
 
   scenario 'when not authenticated' do
     visit oauth_applications_path
-    page.current_url.should eq sign_in_url
+    expect(page.current_url).to eq sign_in_url
   end
 end

--- a/spec/features/user_can_download_books_directly_spec.rb
+++ b/spec/features/user_can_download_books_directly_spec.rb
@@ -8,9 +8,9 @@ feature 'User can download books directly' do
 
     visit product_path(product, as: user)
 
-    page.should have_css("a[href*='test-github.pdf']")
-    page.should have_css("a[href*='test-github.epub']")
-    page.should have_css("a[href*='test-github.mobi']")
+    expect(page).to have_css("a[href*='test-github.pdf']")
+    expect(page).to have_css("a[href*='test-github.epub']")
+    expect(page).to have_css("a[href*='test-github.mobi']")
   end
 
 end

--- a/spec/features/user_downgrades_subscription_spec.rb
+++ b/spec/features/user_downgrades_subscription_spec.rb
@@ -7,7 +7,7 @@ feature 'User downgrades subscription', js: true do
     workshop = create(:workshop)
 
     sign_in_as_user_with_subscription
-    @current_user.should have_active_subscription
+    expect(@current_user).to have_active_subscription
     visit products_path
     expect(find('.header-container')).not_to have_content('Prime Membership')
     expect(page).not_to have_link('Subscribe to Prime')

--- a/spec/features/visitor_purchases_product_with_coupon_spec.rb
+++ b/spec/features/visitor_purchases_product_with_coupon_spec.rb
@@ -45,7 +45,7 @@ feature 'Using coupons' do
   end
 
   def expect_payment_options_to_be_hidden
-    page.should have_no_css('#billing-information')
+    expect(page).to have_no_css('#billing-information')
   end
 
 end

--- a/spec/features/visitor_views_workshop_details_spec.rb
+++ b/spec/features/visitor_views_workshop_details_spec.rb
@@ -19,7 +19,7 @@ feature 'Visitor views workshop details' do
 
     workshop_page.load
 
-    expect(workshop_page).to have(0).questions
-    expect(workshop_page).to have(0).answers
+    expect(workshop_page.size).to eq(0)
+    expect(workshop_page.size).to eq(0)
   end
 end

--- a/spec/helpers/mentor_helper_spec.rb
+++ b/spec/helpers/mentor_helper_spec.rb
@@ -5,7 +5,7 @@ describe MentorHelper do
     include Gravatarify::Helper
 
     it 'returns an image with a gravatar' do
-      mentor = stub('mentor', email: 'someone@example.com')
+      mentor = double('mentor', email: 'someone@example.com')
 
       mentor_image_tag = helper.mentor_image(mentor)
 
@@ -13,7 +13,7 @@ describe MentorHelper do
     end
 
     it 'returns an image whose src uses https' do
-      mentor = stub('mentor', email: 'someone@example.com')
+      mentor = double('mentor', email: 'someone@example.com')
 
       mentor_image_tag = helper.mentor_image(mentor)
 
@@ -23,7 +23,7 @@ describe MentorHelper do
 
   describe '#mentor_contact_link' do
     it 'returns a mailto link for the mentor' do
-      mentor = stub('mentor',
+      mentor = double('mentor',
                     email: 'bob@thoughtbot.com',
                     first_name: 'Bob')
       anchor_text = I18n.t('dashboards.show.contact_your_mentor',

--- a/spec/helpers/open_graph_helper_spec.rb
+++ b/spec/helpers/open_graph_helper_spec.rb
@@ -8,8 +8,8 @@ describe OpenGraphHelper do
 
   it 'produces the desired open graph tags' do
     tags = helper.open_graph_tags
-    tags.should =~ %r{og:image}
-    tags.should =~ %r{og:url}
-    tags.should =~ %r{og:title}
+    expect(tags).to match(%r{og:image})
+    expect(tags).to match(%r{og:url})
+    expect(tags).to match(%r{og:title})
   end
 end

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -6,19 +6,19 @@ describe TopicsHelper, '#format_content' do
   it 'strips tags from content' do
     content   = '<strong>Hello</strong> there'
     expected  = 'Hello there'
-    helper.format_content(content).should == expected
+    expect(helper.format_content(content)).to eq(expected)
   end
 
   it 'truncates the number of characters to max of 140' do
     content   = 'On the new learn homepage, the topic excerpts are too long. It would be additionally great to add a function into the view that controls the numbers of words present, so a designer can fool with it.'
     expected  = "On the new learn homepage, the topic excerpts are too long. It would be additionally great to add a function into the view that#{ellipsis}"
-    helper.format_content(content).should == expected
-    helper.format_content(content, length: 9, omission: "...").should == "On the..."
+    expect(helper.format_content(content)).to eq(expected)
+    expect(helper.format_content(content, length: 9, omission: "...")).to eq("On the...")
   end
 
   it 'does not include an ellipsis if the content is short' do
     content = 'Hello there.'
     expected = 'Hello there.'
-    helper.format_content(content).should == expected
+    expect(helper.format_content(content)).to eq(expected)
   end
 end

--- a/spec/helpers/wistia_helper_spec.rb
+++ b/spec/helpers/wistia_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe WistiaHelper do
   it 'returns an iframe with src' do
-    video = stub(embed_url: stub)
+    video = double(embed_url: double)
     iframe = helper.wistia_video_embed(video)
 
     expect(iframe).to include 'iframe'

--- a/spec/jobs/git_hub_public_key_download_fulfillment_job_spec.rb
+++ b/spec/jobs/git_hub_public_key_download_fulfillment_job_spec.rb
@@ -19,7 +19,7 @@ describe GitHubPublicKeyDownloadFulfillmentJob do
     it "downloads the user's public keys from GitHub" do
       user = build_stubbed(:user, :with_github)
       User.stubs(:find).with(user.id).returns(user)
-      fulfillment = stub('fulfillment', fulfill: true)
+      fulfillment = double('fulfillment', fulfill: true)
       GitHubPublicKeyDownloadFulfillment
         .stubs(:new)
         .with(user)

--- a/spec/jobs/github_fullfillment_job_spec.rb
+++ b/spec/jobs/github_fullfillment_job_spec.rb
@@ -9,7 +9,7 @@ describe GithubFulfillmentJob do
 
     GithubFulfillmentJob.new(3, 'gabebw').perform
 
-    client.should have_received(:add_team_member).with(3, 'gabebw')
+    expect(client).to have_received(:add_team_member).with(3, 'gabebw')
   end
 
   [Octokit::NotFound, Net::HTTPBadResponse].each do |error_class|
@@ -17,19 +17,19 @@ describe GithubFulfillmentJob do
       purchase_id = create(:purchase).id
       client = stub_octokit
       client.stubs(:add_team_member).raises(error_class)
-      PurchaseMailer.stubs(:fulfillment_error => stub("deliver", :deliver => true))
+      PurchaseMailer.stubs(:fulfillment_error => double("deliver", :deliver => true))
 
       expect { GithubFulfillmentJob.new(3, 'gabebw', purchase_id).perform }.
         to raise_error(error_class)
 
-      PurchaseMailer.should have_received(:fulfillment_error).
+      expect(PurchaseMailer).to have_received(:fulfillment_error).
         with(instance_of(Purchase), 'gabebw')
     end
 
     it "sends no email when #{error_class} is raised with no purchase" do
       client = stub_octokit
       client.stubs(:add_team_member).raises(error_class)
-      PurchaseMailer.stubs(fulfillment_error: stub("deliver", deliver: true))
+      PurchaseMailer.stubs(fulfillment_error: double("deliver", deliver: true))
 
       expect { GithubFulfillmentJob.new(3, 'gabebw').perform }.
         to raise_error(error_class)
@@ -44,7 +44,7 @@ describe GithubFulfillmentJob do
 
 
   def stub_octokit
-    stub("Octokit::Client").tap do |client|
+    double("Octokit::Client").tap do |client|
       Octokit::Client.stubs(:new =>  client)
     end
   end

--- a/spec/jobs/github_removal_spec.rb
+++ b/spec/jobs/github_removal_spec.rb
@@ -9,8 +9,8 @@ describe GithubRemovalJob do
 
     GithubRemovalJob.new(3, ['gabebw', 'cpytel']).perform
 
-    client.should have_received(:remove_team_member).with(3, 'gabebw')
-    client.should have_received(:remove_team_member).with(3, 'cpytel')
+    expect(client).to have_received(:remove_team_member).with(3, 'gabebw')
+    expect(client).to have_received(:remove_team_member).with(3, 'cpytel')
   end
 
   [Octokit::NotFound, Net::HTTPBadResponse].each do |error_class|
@@ -21,12 +21,12 @@ describe GithubRemovalJob do
 
       GithubRemovalJob.new(3, ['gabebw']).perform
 
-      Airbrake.should have_received(:notify).with(instance_of(error_class))
+      expect(Airbrake).to have_received(:notify).with(instance_of(error_class))
     end
   end
 
   def stub_octokit
-    stub('Octokit::Client').tap do |client|
+    double('Octokit::Client').tap do |client|
       Octokit::Client.stubs(:new =>  client)
     end
   end

--- a/spec/jobs/send_purchase_receipt_email_job_spec.rb
+++ b/spec/jobs/send_purchase_receipt_email_job_spec.rb
@@ -7,7 +7,7 @@ describe SendPurchaseReceiptEmailJob do
     it 'enqueues a job' do
       purchase = create(:purchase)
 
-      SendPurchaseReceiptEmailJob.enqueue(purchase.id).should
+      expect(SendPurchaseReceiptEmailJob.enqueue(purchase.id)).to
         enqueue_delayed_job(SendPurchaseReceiptEmailJob)
     end
   end
@@ -19,8 +19,8 @@ describe SendPurchaseReceiptEmailJob do
 
       SendPurchaseReceiptEmailJob.new(purchase.id).perform
 
-      PurchaseMailer.should have_received(:purchase_receipt).with(purchase)
-      mail_stub.should have_received(:deliver)
+      expect(PurchaseMailer).to have_received(:purchase_receipt).with(purchase)
+      expect(mail_stub).to have_received(:deliver)
     end
   end
 end

--- a/spec/mailers/purchase_mailer_spec.rb
+++ b/spec/mailers/purchase_mailer_spec.rb
@@ -30,7 +30,7 @@ describe PurchaseMailer do
     end
 
     def stubbed_purchase
-      stub(
+      double(
         purchaseable_name: 'Backbone.js on Rails',
         name: 'Benny Burns',
         email: 'benny@theburns.org'

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -18,7 +18,7 @@ describe Announcement do
   describe '.current' do
     context 'without any announcements' do
       it 'returns nil' do
-        Announcement.current.should be_nil
+        expect(Announcement.current).to be_nil
       end
     end
 
@@ -27,7 +27,7 @@ describe Announcement do
         create :announcement, ends_at: Time.now.yesterday
         create :announcement, ends_at: 7.days.from_now
         current = create(:announcement, ends_at: 1.day.from_now)
-        Announcement.current.should eq(current)
+        expect(Announcement.current).to eq(current)
       end
     end
   end

--- a/spec/models/clip_spec.rb
+++ b/spec/models/clip_spec.rb
@@ -27,7 +27,7 @@ describe Clip do
   context '#running_time' do
     it 'returns the running time' do
       video = Clip.new('123')
-      wistia_hash = { 'duration' => stub }
+      wistia_hash = { 'duration' => double }
       Wistia.stubs(:get_media_hash_from_id).with('123').returns(wistia_hash)
 
       expect(video.running_time).to eq wistia_hash['duration']

--- a/spec/models/coupon_factory_spec.rb
+++ b/spec/models/coupon_factory_spec.rb
@@ -11,7 +11,7 @@ describe CouponFactory, '.for_purchase' do
   end
 
   it 'returns a subscription coupon if a stripe_coupon_id is present' do
-    subscription_coupon = stub(apply: 20)
+    subscription_coupon = double(apply: 20)
     SubscriptionCoupon.stubs(:new).returns(subscription_coupon)
     purchase = build(:plan_purchase, stripe_coupon_id: '25OFF')
 
@@ -21,7 +21,7 @@ describe CouponFactory, '.for_purchase' do
   end
 
   it 'returns a null coupon when there are no regular or subscription coupons' do
-    null_coupon_stub = stub('null_coupon')
+    null_coupon_stub = double('null_coupon')
     NullCoupon.stubs(new: null_coupon_stub)
     purchase = build(:purchase)
 

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -6,32 +6,32 @@ describe Coupon do
   context "with a discount type of percentage" do
     subject { create(:coupon, amount: 10, discount_type: "percentage") }
     it "applies the coupon as a percentage" do
-      subject.apply(50).should == 45
+      expect(subject.apply(50)).to eq(45)
     end
   end
 
   context "with a discount type of dollars" do
     subject { create(:coupon, amount: 10, discount_type: "dollars") }
     it "applies the coupon as a dollar discount" do
-      subject.apply(50).should == 40
+      expect(subject.apply(50)).to eq(40)
     end
   end
 
   context 'telling the coupon that it has been #applied' do
     it 'produces the full price on the second try if it is one-time use' do
       coupon = create(:one_time_coupon, amount: 10, discount_type: 'dollars')
-      coupon.apply(50).should == 40
+      expect(coupon.apply(50)).to eq(40)
       coupon.applied
-      coupon.apply(50).should == 50
-      coupon.should_not be_active
+      expect(coupon.apply(50)).to eq(50)
+      expect(coupon).not_to be_active
     end
 
     it 'produces the discounted price each time' do
       coupon = create(:coupon, amount: 10, discount_type: 'dollars')
-      coupon.apply(50).should == 40
+      expect(coupon.apply(50)).to eq(40)
       coupon.applied
-      coupon.apply(50).should == 40
-      coupon.should be_active
+      expect(coupon.apply(50)).to eq(40)
+      expect(coupon).to be_active
     end
   end
 end
@@ -41,6 +41,6 @@ describe Coupon, '.active' do
     active_coupon = create(:coupon, active: true)
     inactive_coupon = create(:coupon, active: false)
 
-    Coupon.active.should eq [active_coupon]
+    expect(Coupon.active).to eq [active_coupon]
   end
 end

--- a/spec/models/git_hub_public_key_download_fulfillment_spec.rb
+++ b/spec/models/git_hub_public_key_download_fulfillment_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe GitHubPublicKeyDownloadFulfillment do
   describe '#fulfill' do
     it "uses the GitHub API to download the user's API keys" do
-      public_keys = stub('public_keys')
+      public_keys = double('public_keys')
       public_keys.stubs(:create!)
       user = build_stubbed(:user, :with_github)
       user.stubs(:public_keys).returns(public_keys)
@@ -12,7 +12,7 @@ describe GitHubPublicKeyDownloadFulfillment do
         Hashie::Mash.new(key: 'key-one'),
         Hashie::Mash.new(key: 'key-two')
       ]
-      github_client = stub('github_client')
+      github_client = double('github_client')
       Octokit::Client
         .stubs(:new)
         .with(login: GITHUB_USER, password: GITHUB_PASSWORD)

--- a/spec/models/github_fulfillment_spec.rb
+++ b/spec/models/github_fulfillment_spec.rb
@@ -13,7 +13,7 @@ describe GithubFulfillment do
 
       GithubFulfillment.new(purchase).fulfill
 
-      GithubFulfillmentJob.should have_received(:enqueue)
+      expect(GithubFulfillmentJob).to have_received(:enqueue)
     end
 
     it "doesn't fulfill using GitHub with a blank GitHub team" do
@@ -27,7 +27,7 @@ describe GithubFulfillment do
 
       GithubFulfillment.new(purchase).fulfill
 
-      GithubFulfillmentJob.should have_received(:enqueue).never
+      expect(GithubFulfillmentJob).to have_received(:enqueue).never
     end
   end
 
@@ -43,7 +43,7 @@ describe GithubFulfillment do
 
       GithubFulfillment.new(purchase).remove
 
-      GithubRemovalJob.should have_received(:enqueue).
+      expect(GithubRemovalJob).to have_received(:enqueue).
         with(product.github_team, ['jayroh', 'cpytel'])
     end
 
@@ -58,7 +58,7 @@ describe GithubFulfillment do
 
       GithubFulfillment.new(purchase).remove
 
-      GithubRemovalJob.should have_received(:enqueue).never
+      expect(GithubRemovalJob).to have_received(:enqueue).never
     end
   end
 end

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -26,9 +26,9 @@ describe IndividualPlan do
 
   describe '.default' do
     it 'returns the first, active, featured, ordered plan' do
-      ordered = stub(first: stub())
-      featured = stub(ordered: ordered)
-      active = stub(featured: featured)
+      ordered = double(first: double())
+      featured = double(ordered: ordered)
+      active = double(featured: featured)
       IndividualPlan.stubs(active: active)
 
       IndividualPlan.default
@@ -86,7 +86,7 @@ describe IndividualPlan do
   describe 'subscription_interval' do
     it 'returns the interval from the stripe plan' do
       plan = build_stubbed(:plan)
-      stripe_plan = stub(interval: 'year')
+      stripe_plan = double(interval: 'year')
       Stripe::Plan.stubs(:retrieve).returns(stripe_plan)
 
       expect(plan.subscription_interval).to eq 'year'
@@ -131,7 +131,7 @@ describe IndividualPlan do
       dashboard_path = 'http://example.com/dashboard'
       plan = build_stubbed(:individual_plan)
       purchase = build_stubbed(:purchase, purchaseable: plan)
-      controller = stub('controller')
+      controller = double('controller')
       controller.stubs(:dashboard_path).returns(dashboard_path)
 
       after_purchase_url = plan.after_purchase_url(controller, purchase)

--- a/spec/models/invoice_notifier_spec.rb
+++ b/spec/models/invoice_notifier_spec.rb
@@ -27,7 +27,7 @@ describe InvoiceNotifier do
   end
 
   def stub_invoice
-    stub(
+    double(
       'invoice',
       user: true,
       user_email: 'someone@example.com',
@@ -37,7 +37,7 @@ describe InvoiceNotifier do
   end
 
   def stub_invoice_with_no_user
-    stub(
+    double(
       'invoice',
       user: nil,
       user_email: nil,
@@ -49,7 +49,7 @@ describe InvoiceNotifier do
 
   def customer_should_receive_receipt_email(invoice)
     email = ActionMailer::Base.deliveries.first
-    email.subject.should include('receipt')
-    email.to.should eq [invoice.user_email]
+    expect(email.subject).to include('receipt')
+    expect(email.to).to eq [invoice.user_email]
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -5,14 +5,14 @@ describe Invoice do
     invoices = Invoice.
       find_all_by_stripe_customer_id(FakeStripe::CUSTOMER_ID)
 
-    invoices.length.should eq 1
-    invoices.first.stripe_invoice_id.should eq 'in_1s4JSgbcUaElzU'
+    expect(invoices.length).to eq 1
+    expect(invoices.first.stripe_invoice_id).to eq 'in_1s4JSgbcUaElzU'
   end
 
   it 'does not find invoices with a blank customer' do
-    Invoice.find_all_by_stripe_customer_id(' ').length.should eq 0
-    Invoice.find_all_by_stripe_customer_id('').length.should eq 0
-    Invoice.find_all_by_stripe_customer_id(nil).length.should eq 0
+    expect(Invoice.find_all_by_stripe_customer_id(' ').length).to eq 0
+    expect(Invoice.find_all_by_stripe_customer_id('').length).to eq 0
+    expect(Invoice.find_all_by_stripe_customer_id(nil).length).to eq 0
   end
 
   describe 'invoice fields' do
@@ -20,74 +20,74 @@ describe Invoice do
 
     it 'has a number equal to its subscription id and date' do
       date = Time.zone.at(1369159688)
-      invoice.number.should == date.to_s(:invoice)
+      expect(invoice.number).to eq(date.to_s(:invoice))
     end
 
     it 'returns the invoice total from stripe' do
-      invoice.total.should == 79
+      expect(invoice.total).to eq(79)
     end
 
     it 'returns the invoice subtotal from stripe' do
-      invoice.subtotal.should == 99
+      expect(invoice.subtotal).to eq(99)
     end
 
     it 'returns the amount_due from stripe' do
-      invoice.amount_due.should == 79
+      expect(invoice.amount_due).to eq(79)
     end
 
     it 'returns the invoice paid status from stripe' do
-      invoice.should be_paid
+      expect(invoice).to be_paid
     end
 
     it 'returns the invoice date from stripe' do
-      invoice.date.should eq Time.zone.at(1369159688)
+      expect(invoice.date).to eq Time.zone.at(1369159688)
     end
 
     it 'returns true if there is a discount on the invoice' do
-      invoice.should be_discounted
+      expect(invoice).to be_discounted
     end
 
     it 'returns the name of the discount from stripe' do
-      invoice.discount_name.should eq 'railsconf'
+      expect(invoice.discount_name).to eq 'railsconf'
     end
 
     it 'returns the amount of the discount from stripe' do
-      invoice.discount_amount.should eq 20
+      expect(invoice.discount_amount).to eq 20
     end
 
     it 'returns the user who matches the stripe customer' do
       user = create(:user, stripe_customer_id: FakeStripe::CUSTOMER_ID)
 
-      invoice.user.should eq user
+      expect(invoice.user).to eq user
     end
 
     it 'returns a zero balance when paid' do
-      invoice.balance.should eq 0.00
+      expect(invoice.balance).to eq 0.00
     end
 
     it 'returns a balance equal to the amount_due when not paid' do
       stripe_invoice = Invoice.new('in_1s4JSgbcUaElzU')
-      stub_invoice = stub(paid: false, amount_due: 500)
+      stub_invoice = double(paid: false, amount_due: 500)
       Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
 
-      invoice.balance.should eq 5.00
+      expect(invoice.balance).to eq 5.00
     end
 
     describe '#amount_paid' do
       it 'returns zero when not paid' do
         stripe_invoice = Invoice.new('in_1s4JSgbcUaElzU')
-        stub_invoice = stub(paid: false)
+        stub_invoice = double(paid: false)
         Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
 
-        invoice.amount_paid.should eq 0.00
+        expect(invoice.amount_paid).to eq 0.00
       end
 
       it 'returns the amount_due when paid' do
         stripe_invoice = Invoice.new('in_1s4JSgbcUaElzU')
-        stub_invoice = stub(paid: true, amount_due: 500)
+        stub_invoice = double(paid: true, amount_due: 500)
         Stripe::Invoice.stubs(:retrieve).returns(stub_invoice)
 
-        invoice.amount_paid.should eq 5.00
+        expect(invoice.amount_paid).to eq 5.00
       end
     end
 
@@ -104,19 +104,19 @@ describe Invoice do
         country: 'USA'
       )
 
-      invoice.user_name.should == user.name
-      invoice.user_organization.should eq user.organization
-      invoice.user_address1.should eq user.address1
-      invoice.user_address2.should eq user.address2
-      invoice.user_city.should eq user.city
-      invoice.user_state.should eq user.state
-      invoice.user_zip_code.should eq user.zip_code
-      invoice.user_country.should eq user.country
-      invoice.user_email.should eq user.email
+      expect(invoice.user_name).to eq(user.name)
+      expect(invoice.user_organization).to eq user.organization
+      expect(invoice.user_address1).to eq user.address1
+      expect(invoice.user_address2).to eq user.address2
+      expect(invoice.user_city).to eq user.city
+      expect(invoice.user_state).to eq user.state
+      expect(invoice.user_zip_code).to eq user.zip_code
+      expect(invoice.user_country).to eq user.country
+      expect(invoice.user_email).to eq user.email
     end
 
     it 'returns the proper partial path' do
-      invoice.to_partial_path.should eq 'subscriber/invoices/invoice'
+      expect(invoice.to_partial_path).to eq 'subscriber/invoices/invoice'
     end
   end
 
@@ -130,13 +130,13 @@ describe Invoice do
 
   describe '#line_items' do
     it 'returns line items for all the stripe invoice lines' do
-      lines = stub(
+      lines = double(
         'lines',
         invoiceitems: [:invoiceitem],
         prorations: [:proration],
         subscriptions: [:subscription],
       )
-      stripe_invoice = stub('stripe_invoice', lines: lines)
+      stripe_invoice = double('stripe_invoice', lines: lines)
       invoice = Invoice.new(stripe_invoice)
 
       stripe_line_items = stripe_invoice.lines.invoiceitems +

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe LineItem do
   describe '#==' do
     it 'returns true if the other line item has the same stripe line item' do
-      stripe_line_item = stub('stripe_line_item')
+      stripe_line_item = double('stripe_line_item')
       line_item_one = LineItem.new(stripe_line_item)
       line_item_two = LineItem.new(stripe_line_item)
 
@@ -11,8 +11,8 @@ describe LineItem do
     end
 
     it 'returns false if the other line item has another stripe line item' do
-      stripe_line_item_one = stub('stripe_line_item_one')
-      stripe_line_item_two = stub('stripe_line_item_two')
+      stripe_line_item_one = double('stripe_line_item_one')
+      stripe_line_item_two = double('stripe_line_item_two')
       line_item_one = LineItem.new(stripe_line_item_one)
       line_item_two = LineItem.new(stripe_line_item_two)
 
@@ -20,7 +20,7 @@ describe LineItem do
     end
 
     it 'returns false if the other object is not a line item' do
-      line_item = LineItem.new(stub('stripe_line_item'))
+      line_item = LineItem.new(double('stripe_line_item'))
 
       expect(line_item).not_to eq(Object.new)
     end
@@ -28,7 +28,7 @@ describe LineItem do
 
   describe '#amount' do
     it 'returns the dollar amount of the stripe line item' do
-      stripe_line_item = stub('stripe_line_item', amount: 1234)
+      stripe_line_item = double('stripe_line_item', amount: 1234)
       line_item = LineItem.new(stripe_line_item)
 
       expect(line_item.amount).to eq(12.34)
@@ -39,8 +39,8 @@ describe LineItem do
     context 'the stripe line item is a subscription' do
       context 'the subscription is not canceled' do
         it 'returns a description based on the subscription plan' do
-          plan = stub('plan', name: 'Plan')
-          stripe_line_item = stub(
+          plan = double('plan', name: 'Plan')
+          stripe_line_item = double(
             'stripe_line_item',
             object: 'line_item',
             type: 'subscription',
@@ -54,7 +54,7 @@ describe LineItem do
 
       context 'the subscription is canceled' do
         it 'returns a description based on the subscription plan' do
-          stripe_line_item = stub(
+          stripe_line_item = double(
             'stripe_line_item',
             object: 'line_item',
             type: 'subscription',
@@ -70,7 +70,7 @@ describe LineItem do
 
     context 'the stripe line item is not a subscription' do
       it 'returns the stripe line items description' do
-        stripe_line_item = stub(
+        stripe_line_item = double(
           'stripe_line_item',
           object: 'invoiceitem',
           description: 'Some line item'

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -6,7 +6,7 @@ describe Mentor do
 
   describe '.promoted' do
     it 'executes queries on the relation' do
-      mentors = stub('mentors', :sample)
+      mentors = double('mentors', :sample)
       Mentor.stubs(accepting_new_mentees: mentors)
 
       Mentor.promoted

--- a/spec/models/payments/factory_spec.rb
+++ b/spec/models/payments/factory_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Payments::Factory do
   context '#new' do
     it 'builds a payment for the given purchase and payment method' do
-      purchase = stub('purchase')
-      payment = stub('payment')
-      payment_class = stub('payment_class')
+      purchase = double('purchase')
+      payment = double('payment')
+      payment_class = double('payment_class')
       payment_method = 'fake'
       Payments.stubs(:const_get).with('FakePayment').returns(payment_class)
       payment_class.stubs(:new).with(purchase).returns(payment)
@@ -13,7 +13,7 @@ describe Payments::Factory do
 
       result = factory.new(purchase)
 
-      result.should eq payment
+      expect(result).to eq payment
     end
   end
 end

--- a/spec/models/payments/free_payment_spec.rb
+++ b/spec/models/payments/free_payment_spec.rb
@@ -30,6 +30,6 @@ describe Payments::FreePayment do
   end
 
   def build_free_purchase
-    stub('purchase', set_as_paid: true)
+    double('purchase', set_as_paid: true)
   end
 end

--- a/spec/models/payments/paypal_payment_spec.rb
+++ b/spec/models/payments/paypal_payment_spec.rb
@@ -12,8 +12,8 @@ describe Payments::PaypalPayment do
 
       payment.place
 
-      Paypal::Payment::Request.
-        should have_received(:new).
+      expect(Paypal::Payment::Request).
+        to have_received(:new).
         with(
           currency_code: :USD,
           amount: purchase.price,
@@ -22,16 +22,16 @@ describe Payments::PaypalPayment do
             { amount: purchase.price, description: purchase.purchaseable_name }
           ]
         )
-      express_request.
-        should have_received(:setup).
+      expect(express_request).
+        to have_received(:setup).
           with(
             payment_request,
             paypal_purchase_url(purchase, host: Payments::PaypalPayment.host),
             products_url(host: Payments::PaypalPayment.host)
           )
-      purchase.paypal_url.should == 'http://paypalurl'
-      purchase.should have_received(:set_as_unpaid)
-      purchase.should have_received(:set_as_paid).never
+      expect(purchase.paypal_url).to eq('http://paypalurl')
+      expect(purchase).to have_received(:set_as_unpaid)
+      expect(purchase).to have_received(:set_as_paid).never
     end
   end
 
@@ -44,9 +44,9 @@ describe Payments::PaypalPayment do
 
       payment.complete token: 'TOKEN', PayerID: 'PAYERID'
 
-      purchase.payment_transaction_id.should == 'TRANSACTION-ID'
-      purchase.should have_received(:set_as_paid)
-      purchase.should have_received(:set_as_unpaid).never
+      expect(purchase.payment_transaction_id).to eq('TRANSACTION-ID')
+      expect(purchase).to have_received(:set_as_paid)
+      expect(purchase).to have_received(:set_as_unpaid).never
     end
   end
 
@@ -58,7 +58,7 @@ describe Payments::PaypalPayment do
 
       payment.refund
 
-      express_request.should have_received(:refund!).with('TRANSACTION-ID')
+      expect(express_request).to have_received(:refund!).with('TRANSACTION-ID')
     end
   end
 
@@ -67,7 +67,7 @@ describe Payments::PaypalPayment do
       purchase = stub_purchase
       payment = Payments::PaypalPayment.new(purchase)
 
-      expect { payment.update_user(stub('user')) }.not_to raise_error
+      expect { payment.update_user(double('user')) }.not_to raise_error
     end
   end
 
@@ -83,23 +83,23 @@ describe Payments::PaypalPayment do
 
     it 'can produce the host after setting it' do
       Payments::PaypalPayment.host = 'hottiesandcreepers.com:123467'
-      Payments::PaypalPayment.host.should == 'hottiesandcreepers.com:123467'
+      expect(Payments::PaypalPayment.host).to eq('hottiesandcreepers.com:123467')
     end
 
     it 'gives default host when host is not set' do
       Payments::PaypalPayment.host = nil
-      Payments::PaypalPayment.host.
-        should eq ActionMailer::Base.default_url_options[:host]
+      expect(Payments::PaypalPayment.host).
+        to eq ActionMailer::Base.default_url_options[:host]
     end
   end
 
   def stub_express_request(overrides = {})
     transaction_id = overrides[:transaction_id] || 'TRANSACTION-123'
 
-    stub(
+    double(
       'express_request',
-      setup: stub(redirect_uri: 'http://paypalurl'),
-      checkout!: stub(payment_info: [stub(transaction_id: transaction_id)]),
+      setup: double(redirect_uri: 'http://paypalurl'),
+      checkout!: double(payment_info: [double(transaction_id: transaction_id)]),
       refund!: nil
     ).tap do |express_request|
       Paypal::Express::Request.stubs(new: express_request)
@@ -107,7 +107,7 @@ describe Payments::PaypalPayment do
   end
 
   def stub_payment_request
-    stub('payment_request').tap do |payment_request|
+    double('payment_request').tap do |payment_request|
       Paypal::Payment::Request.stubs(new: payment_request)
     end
   end

--- a/spec/models/payments/stripe_payment_spec.rb
+++ b/spec/models/payments/stripe_payment_spec.rb
@@ -9,9 +9,9 @@ describe Payments::StripePayment do
 
       result = payment.place
 
-      result.should be_true
-      purchase.payment_transaction_id.should ==  'TRANSACTION-123'
-      purchase.should be_paid
+      expect(result).to be_true
+      expect(purchase.payment_transaction_id).to eq('TRANSACTION-123')
+      expect(purchase).to be_paid
     end
 
     it "updates the customer's plan for a subscription" do
@@ -41,7 +41,7 @@ describe Payments::StripePayment do
 
     it 'updates the subscription with the given coupon' do
       customer = stub_existing_customer
-      coupon = stub('coupon', amount_off: 25)
+      coupon = double('coupon', amount_off: 25)
       Stripe::Coupon.stubs(:retrieve).returns(coupon)
       purchase = build_plan_purchase(stripe_coupon_id: '25OFF')
       payment = Payments::StripePayment.new(purchase)
@@ -60,7 +60,7 @@ describe Payments::StripePayment do
 
       payment.place
 
-      purchase.stripe_customer_id.should == 'stripe'
+      expect(purchase.stripe_customer_id).to eq('stripe')
     end
 
     it "doesn't create a customer if one is already assigned" do
@@ -71,7 +71,7 @@ describe Payments::StripePayment do
 
       payment.place
 
-      purchase.stripe_customer_id.should == 'original'
+      expect(purchase.stripe_customer_id).to eq('original')
     end
 
     it 'it adds an error message with a bad card' do
@@ -84,8 +84,8 @@ describe Payments::StripePayment do
 
       result = payment.place
 
-      result.should be_false
-      purchase.errors[:base].should include(
+      expect(result).to be_false
+      expect(purchase.errors[:base]).to include(
         'There was a problem processing your credit card, your card was declined'
       )
     end
@@ -101,7 +101,7 @@ describe Payments::StripePayment do
 
       payment.update_user(user)
 
-      user.reload.stripe_customer_id.should eq 'stripe'
+      expect(user.reload.stripe_customer_id).to eq 'stripe'
     end
   end
 
@@ -113,8 +113,8 @@ describe Payments::StripePayment do
 
       payment.refund
 
-      Stripe::Charge.should have_received(:retrieve).with('TRANSACTION-ID')
-      charge.should have_received(:refund).with(amount: 1500)
+      expect(Stripe::Charge).to have_received(:retrieve).with('TRANSACTION-ID')
+      expect(charge).to have_received(:refund).with(amount: 1500)
     end
 
     it 'ignores a missing charge' do
@@ -132,26 +132,26 @@ describe Payments::StripePayment do
 
       payment.refund
 
-      charge.should have_received(:refund).never
+      expect(charge).to have_received(:refund).never
     end
   end
 
   def stub_existing_customer
-    customer = stub('customer', update_subscription: true)
+    customer = double('customer', update_subscription: true)
     Stripe::Customer.stubs(:retrieve).returns(customer)
     customer
   end
 
   def stub_existing_charge(overides = {})
     attributes = { refunded: false, id: 'TRANSACTION-123' }.merge(overides)
-    refunded = stub('refunded_charge', attributes.merge(refunded: true))
-    stub('charge', attributes.merge(refund: refunded)).tap do |charge|
+    refunded = double('refunded_charge', attributes.merge(refunded: true))
+    double('charge', attributes.merge(refund: refunded)).tap do |charge|
       Stripe::Charge.stubs(:retrieve).returns(charge)
     end
   end
 
   def stub_purchase(overrides = {})
-    stub(
+    double(
       'purchase',
       {
         price: 1,
@@ -166,8 +166,8 @@ describe Payments::StripePayment do
       transaction_id: 'TRANSACTION-ID'
     }.merge(overrides)
 
-    Stripe::Customer.stubs(:create).returns(stub(id: arguments[:customer_id]))
-    Stripe::Charge.stubs(:create).returns(stub(id: arguments[:transaction_id]))
+    Stripe::Customer.stubs(:create).returns(double(id: arguments[:customer_id]))
+    Stripe::Charge.stubs(:create).returns(double(id: arguments[:transaction_id]))
   end
 
   def build_plan_purchase(overrides = {})

--- a/spec/models/payments/subscription_payment_spec.rb
+++ b/spec/models/payments/subscription_payment_spec.rb
@@ -30,6 +30,6 @@ describe Payments::SubscriptionPayment do
   end
 
   def build_subscription_purchase
-    stub('purchase', set_as_paid: true)
+    double('purchase', set_as_paid: true)
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -85,13 +85,13 @@ describe Product do
     it 'fulfills using GitHub with a GitHub team' do
       purchase = build_stubbed(:purchase)
       user = build_stubbed(:user)
-      fulfillment = stub('fulfillment', :fulfill)
+      fulfillment = double('fulfillment', :fulfill)
       product = build_stubbed(:product, github_team: 'example')
       GithubFulfillment.stubs(:new).with(purchase).returns(fulfillment)
 
       product.fulfill(purchase, user)
 
-      fulfillment.should have_received(:fulfill)
+      expect(fulfillment).to have_received(:fulfill)
     end
   end
 
@@ -100,7 +100,7 @@ describe Product do
       purchase_path = 'http://example.com/purchase'
       product = build_stubbed(:product)
       purchase = build_stubbed(:purchase, purchaseable: product)
-      controller = stub('controller')
+      controller = double('controller')
       controller.stubs(:purchase_path).with(purchase).returns(purchase_path)
 
       after_purchase_url = product.after_purchase_url(controller, purchase)

--- a/spec/models/promoted_catalog_spec.rb
+++ b/spec/models/promoted_catalog_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe PromotedCatalog do
   describe 'any method' do
     it 'delegates to catalog and calls promoted on the returned object' do
-      book_relation = stub('book_relation', promoted: :some_books)
-      catalog = stub('catalog', books: book_relation)
+      book_relation = double('book_relation', promoted: :some_books)
+      catalog = double('catalog', books: book_relation)
       promoted_catalog = PromotedCatalog.new(catalog)
 
       expect(promoted_catalog.books).to eq(:some_books)

--- a/spec/models/purchase_price_calculator_spec.rb
+++ b/spec/models/purchase_price_calculator_spec.rb
@@ -30,7 +30,7 @@ describe PurchasePriceCalculator, '#calculate' do
   end
 
   it 'calculates its price using the subscription coupon when there is a stripe coupon' do
-    subscription_coupon = stub(apply: 20)
+    subscription_coupon = double(apply: 20)
     SubscriptionCoupon.stubs(:new).returns(subscription_coupon)
     purchase = create(:plan_purchase, stripe_coupon_id: '25OFF')
 

--- a/spec/models/related_spec.rb
+++ b/spec/models/related_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe Related do
   it 'is initialized with an item' do
-    Related.new(stub)
+    Related.new(double)
   end
 
   describe 'to_partial_path' do
     it 'returns the proper partial path' do
-      related = Related.new(stub)
+      related = Related.new(double)
       expect(related.to_partial_path).to eq 'relateds/related'
     end
   end
 
   describe 'products' do
     it 'returns the ordered active products of the item' do
-      ordered = stub(:ordered)
-      active = stub(active: ordered)
-      item = stub(products: active)
+      ordered = double(:ordered)
+      active = double(active: ordered)
+      item = double(products: active)
 
       related = Related.new(item)
       related.products
@@ -29,9 +29,9 @@ describe Related do
 
   describe 'workshops' do
     it 'returns the active ordered workshops of the item' do
-      by_position = stub(:by_position)
-      only_active = stub(only_active: by_position)
-      item = stub(workshops: only_active)
+      by_position = double(:by_position)
+      only_active = double(only_active: by_position)
+      item = double(workshops: only_active)
 
       related = Related.new(item)
       related.workshops
@@ -44,7 +44,7 @@ describe Related do
 
   describe 'topics' do
     it 'returns the related topics of the item' do
-      item = stub(topics: [])
+      item = double(topics: [])
 
       related = Related.new(item)
       related.topics

--- a/spec/models/report_uploader_spec.rb
+++ b/spec/models/report_uploader_spec.rb
@@ -6,7 +6,7 @@ describe ReportUploader do
     it 'uploads report file to s3' do
       AWS.config(stub_requests: true)
 
-      stubbed_report = stub(rows: report_fixture, report_name: 'subscription_count')
+      stubbed_report = double(rows: report_fixture, report_name: 'subscription_count')
       report_uploader = ReportUploader.new(stubbed_report, aws_config)
 
       aws_report_object = report_uploader.bucket_report_object.expects(:write).with(report_fixture_string, acl: :public_read)
@@ -19,7 +19,7 @@ describe ReportUploader do
 
   describe '#bucket_report_object' do
     it 'returns the bucket object with correct key' do
-      stubbed_report = stub(rows: [], report_name: 'subscription_count')
+      stubbed_report = double(rows: [], report_name: 'subscription_count')
       report_uploader = ReportUploader.new(stubbed_report, aws_config)
 
       bucket_object = report_uploader.bucket_report_object

--- a/spec/models/subscriber_purchase_spec.rb
+++ b/spec/models/subscriber_purchase_spec.rb
@@ -4,7 +4,7 @@ describe '#create' do
   it 'sets the payment_method on Purchase to subscription' do
     user = create(:subscriber)
     create_subscriber_purchase(create(:book), user)
-    user.purchases.last.payment_method.should eq 'subscription'
+    expect(user.purchases.last.payment_method).to eq 'subscription'
   end
 
   context 'when the purchaseable is a github fulfilled product' do
@@ -15,7 +15,7 @@ describe '#create' do
 
       create_subscriber_purchase(product, user)
 
-      GithubFulfillmentJob.should have_received(:enqueue).
+      expect(GithubFulfillmentJob).to have_received(:enqueue).
         with(product.github_team, [user.github_username], Purchase.last.id)
     end
   end

--- a/spec/models/subscription_fulfillment_spec.rb
+++ b/spec/models/subscription_fulfillment_spec.rb
@@ -43,7 +43,7 @@ describe SubscriptionFulfillment do
 
       SubscriptionFulfillment.new(purchase, user).fulfill
 
-      GithubFulfillmentJob.should have_received(:enqueue).
+      expect(GithubFulfillmentJob).to have_received(:enqueue).
         with(SubscriptionFulfillment::GITHUB_TEAM, [user.github_username])
     end
 
@@ -54,7 +54,7 @@ describe SubscriptionFulfillment do
 
       SubscriptionFulfillment.new(purchase, user).fulfill
 
-      GitHubPublicKeyDownloadFulfillmentJob.should have_received(:enqueue)
+      expect(GitHubPublicKeyDownloadFulfillmentJob).to have_received(:enqueue)
         .with(user.id)
     end
   end
@@ -67,7 +67,7 @@ describe SubscriptionFulfillment do
 
       SubscriptionFulfillment.new(purchase, user).remove
 
-      GithubRemovalJob.should have_received(:enqueue).
+      expect(GithubRemovalJob).to have_received(:enqueue).
         with(SubscriptionFulfillment::GITHUB_TEAM, [user.github_username])
     end
 
@@ -92,7 +92,7 @@ describe SubscriptionFulfillment do
 
     def stub_refunds(purchases)
       purchases.map do |purchase|
-        stub('refunder').tap do |refunder|
+        double('refunder').tap do |refunder|
           PurchaseRefunder.stubs(:new).with(purchase).returns(refunder)
           refunder.stubs(:refund)
         end

--- a/spec/models/subscription_payment_coming_up_notifier_spec.rb
+++ b/spec/models/subscription_payment_coming_up_notifier_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe SubscriptionPaymentComingUpNotifier do
   it 'sends email to each subscribers' do
-    mailer = stub(deliver: true)
+    mailer = double(deliver: true)
     SubscriptionMailer.stubs(upcoming_payment_notification: mailer)
     subscription_one = build_stubbed(:subscription)
     subscription_two = build_stubbed(:subscription)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -12,7 +12,7 @@ describe Subscription do
   it { should validate_presence_of(:user_id) }
 
   it 'defaults paid to true' do
-    Subscription.new.should be_paid
+    expect(Subscription.new).to be_paid
   end
 
   describe 'self.paid' do
@@ -20,8 +20,8 @@ describe Subscription do
       paid = create(:subscription, paid: true)
       free = create(:subscription, paid: false)
 
-      Subscription.paid.should_not include(free)
-      Subscription.paid.should include(paid)
+      expect(Subscription.paid).not_to include(free)
+      expect(Subscription.paid).to include(paid)
     end
   end
 
@@ -32,7 +32,7 @@ describe Subscription do
         create(:subscription, plan: plan, created_at: 25.hours.ago)
       new_subscription =
         create(:subscription, plan: plan, created_at: 10.hours.ago)
-      mailer = stub(deliver: true)
+      mailer = double(deliver: true)
       SubscriptionMailer.stubs(welcome_to_prime_from_mentor: mailer)
 
       Subscription.deliver_welcome_emails
@@ -61,12 +61,12 @@ describe Subscription do
   describe '#active?' do
     it "returns true if deactivated_on is nil" do
       subscription = Subscription.new(deactivated_on: nil)
-      subscription.should be_active
+      expect(subscription).to be_active
     end
 
     it "returns false if deactivated_on is not nil" do
       subscription = Subscription.new(deactivated_on: Time.zone.today)
-      subscription.should_not be_active
+      expect(subscription).not_to be_active
     end
   end
 
@@ -81,7 +81,7 @@ describe Subscription do
     end
 
     it 'unfulfills itself' do
-      fulfillment = stub('fulfilment', :remove)
+      fulfillment = double('fulfilment', :remove)
       subscription = create(:active_subscription)
       purchase = create(
         :purchase,
@@ -95,7 +95,7 @@ describe Subscription do
 
       subscription.deactivate
 
-      fulfillment.should have_received(:remove)
+      expect(fulfillment).to have_received(:remove)
     end
   end
 
@@ -103,7 +103,7 @@ describe Subscription do
     it 'updates the plan in Stripe' do
       different_plan = create(:plan, sku: 'different')
       subscription = create(:active_subscription)
-      stripe_customer = stub(update_subscription: nil)
+      stripe_customer = double(update_subscription: nil)
       Stripe::Customer.stubs(:retrieve).returns(stripe_customer)
 
       subscription.change_plan(different_plan)
@@ -208,7 +208,7 @@ describe Subscription do
     end
 
     def stub_fulfillment
-      fulfillment = stub('fulfillment', :fulfill)
+      fulfillment = double('fulfillment', :fulfill)
       SubscriptionFulfillment.stubs(:new).returns(fulfillment)
     end
   end
@@ -229,7 +229,7 @@ describe Subscription do
 
   describe '#last_charge' do
     it 'returns the last charge for the customer' do
-      charge = stub('Stripe::Charge')
+      charge = double('Stripe::Charge')
       Stripe::Charge.stubs(:all).returns([charge])
       subscription = build_stubbed(:subscription)
 

--- a/spec/models/subscription_upcoming_invoice_updater_spec.rb
+++ b/spec/models/subscription_upcoming_invoice_updater_spec.rb
@@ -48,7 +48,7 @@ describe SubscriptionUpcomingInvoiceUpdater do
   private
 
   def stub_stripe_invoice_with_total(amount)
-    stripe_invoice = stub(total: amount, period_end: 1387929600)
+    stripe_invoice = double(total: amount, period_end: 1387929600)
     Stripe::Invoice.stubs(upcoming: stripe_invoice)
     stripe_invoice
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -20,7 +20,7 @@ describe Topic do
     end
 
     it 'generates a stripped, url encoded slug based on name' do
-      @topic.slug.should == 'test+driven+development'
+      expect(@topic.slug).to eq('test+driven+development')
     end
   end
 
@@ -32,8 +32,8 @@ describe Topic do
     end
 
     it 'returns the top 20 featured topics' do
-      Topic.top.count.should == 20
-      Topic.top.all? {|topic| topic.count >= 5 }.should be
+      expect(Topic.top.count).to eq(20)
+      expect(Topic.top.all? {|topic| topic.count >= 5 }).to be
     end
   end
 
@@ -41,8 +41,8 @@ describe Topic do
     it 'returns the featured topics' do
       normal = create(:topic, featured: false)
       featured = create(:topic, featured: true)
-      Topic.featured.should include featured
-      Topic.featured.should_not include normal
+      expect(Topic.featured).to include featured
+      expect(Topic.featured).not_to include normal
     end
   end
 

--- a/spec/models/trail_spec.rb
+++ b/spec/models/trail_spec.rb
@@ -25,13 +25,13 @@ describe Trail do
   context '#import' do
     before do
       fake_body_str = FakeTrailMap.new.trail.to_json
-      Curl.stubs(get: stub(body_str: fake_body_str, response_code: 200))
+      Curl.stubs(get: double(body_str: fake_body_str, response_code: 200))
     end
 
     it 'downloads a trail and stores it' do
       trail = create(:trail, slug: 'fake-trail')
       trail.import
-      trail.trail_map.should == FakeTrailMap.new.trail
+      expect(trail.trail_map).to eq(FakeTrailMap.new.trail)
     end
 
     it "populates the topic's summary with the trail's description" do
@@ -40,7 +40,7 @@ describe Trail do
 
       trail.import
 
-      topic.reload.summary.should == 'Description of Git'
+      expect(topic.reload.summary).to eq('Description of Git')
     end
 
     it "populates the topic's name with the trail's name" do
@@ -49,7 +49,7 @@ describe Trail do
 
       trail.import
 
-      topic.reload.name.should == 'Git'
+      expect(topic.reload.name).to eq('Git')
     end
 
     it 'leaves the existing trail map alone and notifies Airbrake when there is a json error' do
@@ -63,21 +63,21 @@ describe Trail do
       trail.import
       topic.reload
 
-      Airbrake.should have_received(:notify).with(exception)
-      trail.trail_map["old"].should == true
-      topic.summary.should == 'old summary'
+      expect(Airbrake).to have_received(:notify).with(exception)
+      expect(trail.trail_map["old"]).to eq(true)
+      expect(topic.summary).to eq('old summary')
     end
 
     it 'does not update trail map if there is a non-200 http response' do
-      Curl.stubs(get: stub(response_code: 'not 200', body_str: FakeTrailMap.new.trail.to_json))
+      Curl.stubs(get: double(response_code: 'not 200', body_str: FakeTrailMap.new.trail.to_json))
       topic = create(:topic, summary: 'old summary', name: 'old name', slug: 'old+name')
       trail = create(:trail, topic: topic, trail_map: {'name' => 'old name', 'description' => 'old summary'})
 
       trail.import
 
       topic.reload
-      topic.summary.should == 'old summary'
-      topic.name.should == 'old name'
+      expect(topic.summary).to eq('old summary')
+      expect(topic.name).to eq('old name')
     end
   end
 
@@ -86,7 +86,7 @@ describe Trail do
       fake_trail_map = FakeTrailMap.new
       fake_trail_map.prerequisites = ['exists', 'doesnotexist']
       fake_body_str = fake_trail_map.trail.to_json
-      Curl.stubs(get: stub(body_str: fake_body_str, response_code: 200))
+      Curl.stubs(get: double(body_str: fake_body_str, response_code: 200))
     end
 
     it 'associates the topic that exists' do
@@ -103,7 +103,7 @@ describe Trail do
     it 'returns the correct url based on slug' do
       trail = Trail.new
       trail.slug = 'ruby-on-rails'
-      trail.contribute_url.should eq 'https://github.com/thoughtbot/trail-map/blob/master/trails/ruby-on-rails.json'
+      expect(trail.contribute_url).to eq 'https://github.com/thoughtbot/trail-map/blob/master/trails/ruby-on-rails.json'
     end
   end
 
@@ -155,7 +155,7 @@ describe Trail do
   context '.import' do
     it 'imports each trail' do
       trail = create(:trail, trail_map: { hello: 'world' })
-      Curl.stubs(get: stub(body_str: FakeTrailMap.new.trail.to_json, response_code: 200))
+      Curl.stubs(get: double(body_str: FakeTrailMap.new.trail.to_json, response_code: 200))
 
       expect(trail.trail_map).not_to eq FakeTrailMap.new.trail
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,15 +46,15 @@ describe User do
   describe "#has_purchased?" do
     it "returns true if the user has any paid purchases" do
       user = build_stubbed(:user)
-      user.stubs(:paid_purchases).returns([stub])
+      user.stubs(:paid_purchases).returns([double])
 
-      user.should have_purchased
+      expect(user).to have_purchased
     end
 
     it "returns false if the user has no purchases" do
       user = build_stubbed(:user)
-      user.stubs(:purchases).returns([stub])
-      user.should_not have_purchased
+      user.stubs(:purchases).returns([double])
+      expect(user).not_to have_purchased
     end
   end
 
@@ -135,7 +135,7 @@ describe User do
       user.admin = true
       user.save
 
-      user.reload.should be_admin
+      expect(user.reload).to be_admin
     end
 
     def create_user_without_cached_password(attributes)
@@ -173,8 +173,8 @@ describe User do
       create_subscription_purchase(user)
       create_paid_purchase(user)
 
-      user.paid_purchases.count.should eq 2
-      user.subscription_purchases.count.should eq 1
+      expect(user.paid_purchases.count).to eq 2
+      expect(user.subscription_purchases.count).to eq 1
     end
 
     def create_subscription_purchase(user)

--- a/spec/models/video_page_spec.rb
+++ b/spec/models/video_page_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe VideoPage do
   describe '#purchaseable' do
     it 'delegates to purchase' do
-      purchaseable = stub('purchaseable')
-      purchase = stub('purchase', purchaseable: purchaseable)
+      purchaseable = double('purchaseable')
+      purchase = double('purchase', purchaseable: purchaseable)
 
       result = create_video_page(purchase: purchase).purchaseable
 
@@ -14,8 +14,8 @@ describe VideoPage do
 
   describe '#collection?' do
     it 'delegates to purchaseable' do
-      purchaseable = stub('purchaseable', collection?: true)
-      purchase = stub('purchase', purchaseable: purchaseable)
+      purchaseable = double('purchaseable', collection?: true)
+      purchase = double('purchase', purchaseable: purchaseable)
 
       result = create_video_page(purchase: purchase).collection?
 
@@ -25,8 +25,8 @@ describe VideoPage do
 
   describe '#name' do
     it 'delegates to purchaseable' do
-      purchaseable = stub('purchaseable', name: 'abc123')
-      purchase = stub('purchase', purchaseable: purchaseable)
+      purchaseable = double('purchaseable', name: 'abc123')
+      purchase = double('purchase', purchaseable: purchaseable)
 
       name = create_video_page(purchase: purchase).name
 
@@ -36,7 +36,7 @@ describe VideoPage do
 
   describe '#paid?' do
     it 'delegates to purchase' do
-      purchase = stub('purchase', paid?: true)
+      purchase = double('purchase', paid?: true)
 
       result = create_video_page(purchase: purchase)
 
@@ -46,7 +46,7 @@ describe VideoPage do
 
   describe '#title' do
     it 'delegates to video' do
-      video = stub('video', title: 'abc123')
+      video = double('video', title: 'abc123')
 
       title = create_video_page(video: video).title
 
@@ -55,8 +55,8 @@ describe VideoPage do
   end
 
   def create_video_page(options)
-    purchase = options[:purchase] || stub('purchase')
-    video = options[:video] || stub('video')
+    purchase = options[:purchase] || double('purchase')
+    video = options[:video] || double('video')
     VideoPage.new(purchase: purchase, video: video)
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -12,7 +12,7 @@ describe Video do
     it 'returns videos in order by position' do
       video1 = create(:video, position: 2)
       video2 = create(:video, position: 1)
-      Video.ordered.should == [video2, video1]
+      expect(Video.ordered).to eq([video2, video1])
     end
   end
 
@@ -68,8 +68,8 @@ describe Video do
 
     it 'returns a thumbnail if preview_wistia_id is not set' do
       video = Video.new
-      url = stub
-      clip = stub(full_sized_thumbnail: url)
+      url = double
+      clip = double(full_sized_thumbnail: url)
       Clip.stubs(:new).returns(clip)
       VideoThumbnail.stubs(:new)
 

--- a/spec/models/video_thumbnail_spec.rb
+++ b/spec/models/video_thumbnail_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe VideoThumbnail do
   context '#url' do
     it 'returns the url' do
-      url = stub
+      url = double
       thumbnail = VideoThumbnail.new(url)
 
       expect(thumbnail.url).to eq url

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -33,14 +33,14 @@ describe Workshop do
       Announcement.stubs :current
       workshop = create(:workshop)
       workshop.announcement
-      Announcement.should have_received(:current)
+      expect(Announcement).to have_received(:current)
     end
   end
 
   describe '#to_param' do
     it 'returns the id and parameterized name' do
       workshop = create(:workshop)
-      workshop.to_param.should == "#{workshop.id}-#{workshop.name.parameterize}"
+      expect(workshop.to_param).to eq("#{workshop.id}-#{workshop.name.parameterize}")
     end
   end
 
@@ -101,14 +101,14 @@ describe Workshop do
       product = build(:book, :github)
       purchase = build(:purchase, purchaseable: product)
 
-      purchase.should be_fulfilled_with_github
+      expect(purchase).to be_fulfilled_with_github
     end
 
     it 'is false when product has no github team' do
       product = build(:book, github_team: nil)
       purchase = build(:purchase, purchaseable: product)
 
-      purchase.should_not be_fulfilled_with_github
+      expect(purchase).not_to be_fulfilled_with_github
     end
   end
 
@@ -130,13 +130,13 @@ describe Workshop do
     it 'fulfills using GitHub with a GitHub team' do
       purchase = build_stubbed(:purchase)
       user = build_stubbed(:user)
-      fulfillment = stub('fulfillment', :fulfill)
+      fulfillment = double('fulfillment', :fulfill)
       workshop = build_stubbed(:workshop, github_team: 'example')
       GithubFulfillment.stubs(:new).with(purchase).returns(fulfillment)
 
       workshop.fulfill(purchase, user)
 
-      fulfillment.should have_received(:fulfill)
+      expect(fulfillment).to have_received(:fulfill)
     end
   end
 

--- a/spec/modules/teams/invitation_spec.rb
+++ b/spec/modules/teams/invitation_spec.rb
@@ -43,7 +43,7 @@ module Teams
       end
 
       def stub_mailer
-        stub('mailer', :invitation).tap do |mailer|
+        double('mailer', :invitation).tap do |mailer|
           InvitationMailer.stubs(:delay).returns(mailer)
         end
       end

--- a/spec/modules/teams/invitations_controller_spec.rb
+++ b/spec/modules/teams/invitations_controller_spec.rb
@@ -4,7 +4,7 @@ module Teams
   describe InvitationsController, type: :controller do
     it_behaves_like 'must be team member' do
       def perform_request
-        invitation = stub('invitation', deliver: true)
+        invitation = double('invitation', deliver: true)
         Invitation.stubs(:new).returns(invitation)
 
         post :create, teams_invitation: { email: 'somebody@example.com' }

--- a/spec/modules/teams/team_plan_spec.rb
+++ b/spec/modules/teams/team_plan_spec.rb
@@ -87,7 +87,7 @@ module Teams
       end
 
       def stub_team_fulfillment(purchase)
-        stub('team-fulfillment', :fulfill).tap do |fulfillment|
+        double('team-fulfillment', :fulfill).tap do |fulfillment|
           TeamFulfillment.
             stubs(:new).
             with(purchase, purchase.user).
@@ -101,7 +101,7 @@ module Teams
         edit_teams_team_path = 'http://example.com/edit_team'
         plan = build_stubbed(:team_plan)
         purchase = build_stubbed(:purchase, purchaseable: plan)
-        controller = stub('controller')
+        controller = double('controller')
         controller.stubs(:edit_teams_team_path).returns(edit_teams_team_path)
 
         after_purchase_url = plan.after_purchase_url(controller, purchase)

--- a/spec/modules/teams/team_spec.rb
+++ b/spec/modules/teams/team_spec.rb
@@ -16,7 +16,7 @@ module Teams
         team.add_user(user)
 
         expect(user.reload.team).to eq(team)
-        fulfillment.should have_received(:fulfill)
+        expect(fulfillment).to have_received(:fulfill)
       end
     end
 
@@ -29,7 +29,7 @@ module Teams
         team.remove_user(user)
 
         expect(user.reload.team).to be_nil
-        fulfillment.should have_received(:remove)
+        expect(fulfillment).to have_received(:remove)
       end
     end
 

--- a/spec/requests/content_compression_spec.rb
+++ b/spec/requests/content_compression_spec.rb
@@ -5,13 +5,13 @@ feature "A visitor visits the home page" do
   scenario "a visitor has a browser that supports compression" do
     ['deflate','gzip', 'deflate,gzip','gzip,deflate'].each do|compression_method|
       get root_path, {}, {'HTTP_ACCEPT_ENCODING' => compression_method }
-      response.headers['Content-Encoding'].should be
+      expect(response.headers['Content-Encoding']).to be
     end
   end
 
   scenario "a visitor's browser does not support compression" do
     get root_path
-    response.headers['Content-Encoding'].should_not be
+    expect(response.headers['Content-Encoding']).not_to be
   end
 
 end

--- a/spec/requests/stripe_webhooks_spec.rb
+++ b/spec/requests/stripe_webhooks_spec.rb
@@ -4,7 +4,7 @@ describe 'Stripe webhooks' do
   describe 'invoice.payment_succeeded' do
     describe 'invoice has a subscription' do
       it 'sends out a receipt email' do
-        invoice_notifier = stub('invoice_notifier')
+        invoice_notifier = double('invoice_notifier')
         invoice_notifier.stubs(:send_receipt)
         InvoiceNotifier.stubs(:new).returns(invoice_notifier)
         create(:subscriber, stripe_customer_id: FakeStripe::CUSTOMER_ID)
@@ -29,7 +29,7 @@ describe 'Stripe webhooks' do
 
     context 'invoice missing a subscription (user canceled or up/downgraded)' do
       it 'sends out a receipt email' do
-        invoice_notifier = stub('invoice_notifier')
+        invoice_notifier = double('invoice_notifier')
         invoice_notifier.stubs(:send_receipt)
         InvoiceNotifier.stubs(:new).returns(invoice_notifier)
         create(:subscriber, stripe_customer_id: FakeStripe::CUSTOMER_ID)

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -8,12 +8,12 @@ describe UserSerializer do
 
     user_json = parse_serialized_json(user)
 
-    user_json['email'].should == user.email
-    user_json['first_name'].should == user.first_name
-    user_json['username'].should == user.github_username
-    user_json['id'].should == user.id
-    user_json['last_name'].should == user.last_name
-    user_json['avatar_url'].should == gravatar_url(user.email)
+    expect(user_json['email']).to eq(user.email)
+    expect(user_json['first_name']).to eq(user.first_name)
+    expect(user_json['username']).to eq(user.github_username)
+    expect(user_json['id']).to eq(user.id)
+    expect(user_json['last_name']).to eq(user.last_name)
+    expect(user_json['avatar_url']).to eq(gravatar_url(user.email))
   end
 
   context 'with public keys' do
@@ -26,7 +26,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['public_keys'].should match_array(%w(key-one key-two))
+      expect(user_json['public_keys']).to match_array(%w(key-one key-two))
     end
   end
 
@@ -36,7 +36,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['has_forum_access'].should be_true
+      expect(user_json['has_forum_access']).to be_true
     end
 
     it 'includes a key indicating a subscription' do
@@ -44,7 +44,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['has_active_subscription'].should be_true
+      expect(user_json['has_active_subscription']).to be_true
     end
   end
 
@@ -54,7 +54,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['has_forum_access'].should be_false
+      expect(user_json['has_forum_access']).to be_false
     end
 
     it 'includes a key indicating no subscription' do
@@ -62,7 +62,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['has_active_subscription'].should be_false
+      expect(user_json['has_active_subscription']).to be_false
     end
   end
 
@@ -72,7 +72,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['has_forum_access'].should be_true
+      expect(user_json['has_forum_access']).to be_true
     end
 
     it 'includes a key indicating they are an admin' do
@@ -80,7 +80,7 @@ describe UserSerializer do
 
       user_json = parse_serialized_json(user)
 
-      user_json['admin'].should be_true
+      expect(user_json['admin']).to be_true
     end
   end
 

--- a/spec/services/associate_previous_purchases_spec.rb
+++ b/spec/services/associate_previous_purchases_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe AssociatePreviousPurchases, '.create_associations_for' do
   it 'associates purchases and the stripe customer id' do
     user = create(:user)
-    associator_stub = stub(associate_purchases: true, associate_stripe_customer_id: true)
+    associator_stub = double(associate_purchases: true, associate_stripe_customer_id: true)
     AssociatePreviousPurchases.stubs(new: associator_stub)
 
     AssociatePreviousPurchases.create_associations_for(user)

--- a/spec/services/auth_hash_service_spec.rb
+++ b/spec/services/auth_hash_service_spec.rb
@@ -43,7 +43,7 @@ describe AuthHashService, '#find_or_create_user_from_auth_hash' do
   end
 
   def stub_team_member(return_value)
-    client = stub('github_client')
+    client = double('github_client')
     client.
       stubs(:team_member?).
       with(AuthHashService::THOUGHTBOT_GITHUB_TEAM_ID, 'thoughtbot').

--- a/spec/services/purchase_info_copier_spec.rb
+++ b/spec/services/purchase_info_copier_spec.rb
@@ -25,7 +25,7 @@ describe PurchaseInfoCopier, '#copy_info_to_user' do
   context 'with address information' do
     it 'saves the address to the user' do
       user = create(:user)
-      user.address1.should be_blank
+      expect(user.address1).to be_blank
       purchase = build(
         :purchase,
         user: user,

--- a/spec/services/purchase_refunder_spec.rb
+++ b/spec/services/purchase_refunder_spec.rb
@@ -10,7 +10,7 @@ describe PurchaseRefunder, '#refund' do
   end
 
   it 'does not issue a refund if it is unpaid' do
-    payment = stub('payment', place: true)
+    payment = double('payment', place: true)
     Payments::StripePayment.stubs(:new).returns(payment)
     purchase = create(:unpaid_purchase)
 
@@ -24,7 +24,7 @@ describe PurchaseRefunder, '#refund' do
     it 'removes from github' do
       product = create(:book, :github)
       purchase = create(:paid_purchase, purchaseable: product)
-      fulfillment = stub(:remove)
+      fulfillment = double(:remove)
       GithubFulfillment.stubs(:new).returns(fulfillment)
 
       PurchaseRefunder.new(purchase).refund
@@ -36,7 +36,7 @@ describe PurchaseRefunder, '#refund' do
   context 'with stripe' do
     it 'refunds money to purchaser' do
       purchase = build(:paid_purchase, payment_method: 'stripe')
-      payment = stub('payment', refund: true, place: true)
+      payment = double('payment', refund: true, place: true)
       Payments::StripePayment.stubs(:new).with(purchase).returns(payment)
 
       PurchaseRefunder.new(purchase).refund
@@ -48,7 +48,7 @@ describe PurchaseRefunder, '#refund' do
   context 'with paypal' do
     it 'refunds money to purchaser' do
       purchase = build(:paid_purchase, payment_method: 'paypal')
-      payment = stub('payment', refund: true, place: true)
+      payment = double('payment', refund: true, place: true)
       Payments::PaypalPayment.stubs(:new).with(purchase).returns(payment)
 
       PurchaseRefunder.new(purchase).refund

--- a/spec/support/airbrake.rb
+++ b/spec/support/airbrake.rb
@@ -3,9 +3,9 @@ shared_examples 'a Delayed Job that notifies Airbrake about errors' do
     it 'notifies Airbrake when an error occurs' do
       Airbrake.stubs(:notify)
 
-      described_class.new(3).error(stub, RuntimeError)
+      described_class.new(3).error(double, RuntimeError)
 
-      Airbrake.should have_received(:notify).with(RuntimeError)
+      expect(Airbrake).to have_received(:notify).with(RuntimeError)
     end
   end
 end

--- a/spec/support/delayed_jobs.rb
+++ b/spec/support/delayed_jobs.rb
@@ -6,7 +6,7 @@ module DelayedJobsHelpers
   end
 
   def stub_mail_method(klass, method_name)
-    stub('mail', deliver: true).tap do |mail|
+    double('mail', deliver: true).tap do |mail|
       klass.stubs(method_name => mail)
     end
   end

--- a/spec/support/delegate_matcher.rb
+++ b/spec/support/delegate_matcher.rb
@@ -18,7 +18,7 @@ RSpec::Matchers.define :delegate do |delegated_method|
     @args ||= []
     return_value = 'stubbed return value'
     method_on_target = @method_on_target || delegated_method
-    stubbed_target = stub('stubbed_target', method_on_target => return_value)
+    stubbed_target = double('stubbed_target', method_on_target => return_value)
     @instance.stubs(@target_method => stubbed_target)
     begin
       @instance.send(delegated_method, *@args) == return_value

--- a/spec/support/features/clearance_helpers.rb
+++ b/spec/support/features/clearance_helpers.rb
@@ -23,7 +23,7 @@ module Features
 
   def user_should_be_signed_in
     visit root_path
-    page.should have_content I18n.t('layouts.application.sign_out')
+    expect(page).to have_content I18n.t('layouts.application.sign_out')
   end
 
   def sign_out
@@ -31,7 +31,7 @@ module Features
   end
 
   def user_should_be_signed_out
-    page.should have_content I18n.t('layouts.application.sign_in')
+    expect(page).to have_content I18n.t('layouts.application.sign_in')
   end
 
   def user_with_reset_password

--- a/spec/support/fulfillment_stubs.rb
+++ b/spec/support/fulfillment_stubs.rb
@@ -1,6 +1,6 @@
 module FulfillmentStubs
   def stub_subscription_fulfillment(purchase, user = purchase.user)
-    stub('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
+    double('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
       SubscriptionFulfillment.
         stubs(:new).
         with(purchase, user).

--- a/spec/support/product_shared_examples.rb
+++ b/spec/support/product_shared_examples.rb
@@ -14,7 +14,7 @@ shared_examples 'a class inheriting from Product' do
       Announcement.stubs :current
       product = create_product
       product.announcement
-      Announcement.should have_received(:current)
+      expect(Announcement).to have_received(:current)
     end
   end
 
@@ -81,14 +81,14 @@ shared_examples 'a class inheriting from Product' do
       product = build(factory_name, :github)
       purchase = build(:purchase, purchaseable: product)
 
-      purchase.should be_fulfilled_with_github
+      expect(purchase).to be_fulfilled_with_github
     end
 
     it 'is false when product has no github team' do
       product = build(factory_name, github_team: nil)
       purchase = build(:purchase, purchaseable: product)
 
-      purchase.should_not be_fulfilled_with_github
+      expect(purchase).not_to be_fulfilled_with_github
     end
   end
 

--- a/spec/support/related.rb
+++ b/spec/support/related.rb
@@ -2,7 +2,7 @@ shared_examples 'it has related items' do
   describe '#related' do
     it 'initializes and returns the related object' do
       item = described_class.new
-      related = stub
+      related = double
       Related.stubs(new: related)
 
       item.related

--- a/spec/views/episodes/show.html.erb_spec.rb
+++ b/spec/views/episodes/show.html.erb_spec.rb
@@ -37,7 +37,7 @@ describe 'episodes/show' do
   end
 
   def stub_controller(video)
-    assign :plan, stub
+    assign :plan, double
     assign :video, video
 
     view_stubs(:signed_out?).returns(true)

--- a/spec/views/offerings/_prime_purchase.html.erb_spec.rb
+++ b/spec/views/offerings/_prime_purchase.html.erb_spec.rb
@@ -5,18 +5,18 @@ describe 'offerings/_prime_purchase.html.erb' do
     current_user_has_subscription = false
     render_template current_user_has_subscription
 
-    rendered.should include('Subscribe to')
+    expect(rendered).to include('Subscribe to')
   end
 
   it "does not sell the user on Prime if the CTA shouldn't be displayed" do
     current_user_has_subscription = true
     render_template current_user_has_subscription
 
-    rendered.should_not include('Subscribe to')
+    expect(rendered).not_to include('Subscribe to')
   end
 
   def render_template(current_user_has_subscription)
-    product = stub('product', offering_type: 'book')
+    product = double('product', offering_type: 'book')
 
     Mocha::Configuration.allow :stubbing_non_existent_method do
       view.stubs(

--- a/spec/views/products/_forum.html.erb_spec.rb
+++ b/spec/views/products/_forum.html.erb_spec.rb
@@ -16,10 +16,10 @@ describe 'products/_forum_link' do
   end
 
   def user_without_subscription
-    stub('user', has_active_subscription?: false)
+    double('user', has_active_subscription?: false)
   end
 
   def user_with_subscription
-    stub('user', has_active_subscription?: true)
+    double('user', has_active_subscription?: true)
   end
 end

--- a/spec/views/products/_license.html.erb_spec.rb
+++ b/spec/views/products/_license.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'products/_license.html' do
 
     render_with_licenses
 
-    rendered.should_not have_buy_individually_text
+    expect(rendered).not_to have_buy_individually_text
   end
 
   it 'renders with licenses and no subscription' do
@@ -14,7 +14,7 @@ describe 'products/_license.html' do
 
     render_with_licenses
 
-    rendered.should have_buy_individually_text
+    expect(rendered).to have_buy_individually_text
   end
 
   it 'renders with no licenses and no subscription' do
@@ -22,7 +22,7 @@ describe 'products/_license.html' do
 
     render_with_no_licenses
 
-    rendered.should_not have_buy_individually_text
+    expect(rendered).not_to have_buy_individually_text
   end
 
   def stub_active_subscription

--- a/spec/views/promoted_catalogs/show.html.erb_spec.rb
+++ b/spec/views/promoted_catalogs/show.html.erb_spec.rb
@@ -128,7 +128,7 @@ describe 'promoted_catalogs/show.html.erb' do
   def assign_catalog(books: [], workshops: [], screencasts: [], mentors: [])
     assign(
       :catalog,
-      stub(
+      double(
         books: books,
         workshops: workshops,
         screencasts: screencasts,

--- a/spec/views/purchases/_github_repo_info.html.erb_spec.rb
+++ b/spec/views/purchases/_github_repo_info.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'purchases/_github_repo_info.html.erb' do
 
       render 'purchases/github_repo_info', purchaseable: purchaseable
 
-      rendered.should include(purchaseable.github_url)
+      expect(rendered).to include(purchaseable.github_url)
     end
   end
 end

--- a/spec/views/purchases/_purchase_table_row.html.erb_spec.rb
+++ b/spec/views/purchases/_purchase_table_row.html.erb_spec.rb
@@ -6,10 +6,10 @@ describe 'purchases/_purchase_table_row.html.erb' do
 
     render 'purchases/purchase_table_row', purchase: purchase
 
-    rendered.should include(link_to(purchase.purchaseable_name, purchase))
-    rendered.should include(purchase.created_at.to_s(:short_date))
-    rendered.should include(number_to_currency(purchase.price))
-    rendered.should include(
+    expect(rendered).to include(link_to(purchase.purchaseable_name, purchase))
+    expect(rendered).to include(purchase.created_at.to_s(:short_date))
+    expect(rendered).to include(number_to_currency(purchase.price))
+    expect(rendered).to include(
       t("purchases.payment_methods.#{purchase.payment_method}")
     )
   end

--- a/spec/views/videos/_watch_video.html.erb_spec.rb
+++ b/spec/views/videos/_watch_video.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'videos/_watch_video.html.erb' do
 
     render_view(video)
 
-    rendered.should include(video.notes_html)
+    expect(rendered).to include(video.notes_html)
   end
 
   it "can still render a video without notes" do


### PR DESCRIPTION
This conversion is done by Transpec 2.1.0 with the following command:
    transpec
- 186 conversions
  from: obj.should
    to: expect(obj).to
- 148 conversions
  from: stub('something')
    to: double('something')
- 43 conversions
  from: == expected
    to: eq(expected)
- 18 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 4 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 2 conversions
  from: expect(collection).to have(n).items
    to: expect(collection.size).to eq(n)

See also: https://github.com/yujinakayama/transpec#supported-conversions

There is a warning about spec/features/visitor_views_workshop_details_spec.rb, but I think these tests were invalid to begin with, since it really the same test twice:

``` ruby
  expect(workshop_page).to have(0).questions
  expect(workshop_page).to have(0).answers
```
