### PR TITLE
Fix clearance deprecation notice

### DIFF
--- a/spec/support/clearance.rb
+++ b/spec/support/clearance.rb
@@ -1,1 +1,0 @@
-require 'clearance/testing'


### PR DESCRIPTION
Avoids the following deprecation warning:

```
[DEPRECATION] Requiring `clearance/testing` in `spec/spec_helper.rb` (or in
`test/test_helper.rb`) is deprecated. Require `clearance/rspec` or
`clearance/test_unit` instead.
```
