### PR TITLE
Surplus quotation mark breaks video download links

### DIFF
--- a/app/views/videos/_download_link.html.erb
+++ b/app/views/videos/_download_link.html.erb
@@ -1,5 +1,5 @@
 <% if clip.sizes[download_type_key].present? %>
-  <a class="button-mini <%= download_type %>" href=<%= clip.download_url(download_type) %>">
+  <a class="button-mini <%= download_type %>" href=<%= clip.download_url(download_type) %>>
     <%=size_display%>
     <span class="size"><%= clip.sizes[download_type_key] %></span>
   </a>


### PR DESCRIPTION
Small html issue.. There was a surplus quotation mark which caused the download links to render incorrectly (i.e - `http://thoughtbotlearn.wistia.com/medias/lkk82mzv00/download?asset=hd_mp4"`) directing users to a file index page instead of downloading the asset.
