### PR TITLE
Define Clip#cache_key

### DIFF
--- a/app/models/clip.rb
+++ b/app/models/clip.rb
@@ -56,6 +56,10 @@ class Clip
     'clips/clip'
   end
 
+  def cache_key
+    "video-#{@wistia_id}"
+  end
+
   private
 
   def wistia_hash

--- a/spec/models/clip_spec.rb
+++ b/spec/models/clip_spec.rb
@@ -73,4 +73,12 @@ describe Clip do
       expect(url).to eq expected_url
     end
   end
+
+  context '#cache_key' do
+    it 'returns a cache key based on the wistia id' do
+      clip = Clip.new('123')
+
+      expect(clip.cache_key).to eq 'video-123'
+    end
+  end
 end


### PR DESCRIPTION
Since this is a plain Ruby class, Rails was using the object id as the cache
key, which was never the same for different requests. So non of the caching of
video data was having an effect.

https://www.apptrajectory.com/thoughtbot/learn/stories/15644182
