### PR TITLE
Don't promise a specific mentor during signup

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -97,7 +97,6 @@ class PurchasesController < ApplicationController
   def build_purchase_with_defaults
     purchase = requested_purchaseable.purchases.build(variant: variant)
     PurchasePrepopulater.new(purchase, current_user).prepopulate_with_user_info
-    purchase.mentor_id = cookies[:mentor_id]
     purchase
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,4 @@
 class SubscriptionsController < ApplicationController
-  before_filter :assign_mentor, only: [:new, :edit]
-
   def new
     @plans = IndividualPlan.featured.active.ordered
     @team_plans = Teams::TeamPlan.featured.ordered
@@ -18,15 +16,5 @@ class SubscriptionsController < ApplicationController
     plan = IndividualPlan.find_by_sku!(params[:plan_id])
     current_user.subscription.change_plan(plan)
     redirect_to my_account_path, notice: I18n.t('subscriptions.flashes.change.success')
-  end
-
-  private
-
-  def assign_mentor
-    @mentor = Mentor.find_or_sample(cookies[:mentor_id])
-
-    if cookies[:mentor_id].blank?
-      cookies[:mentor_id] ||= @mentor.id
-    end
   end
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -12,8 +12,8 @@ class Mentor < ActiveRecord::Base
     accepting_new_mentees.sample(NUMBER_OF_MENTORS_TO_PROMOTE)
   end
 
-  def self.find_or_sample(mentor_id)
-    where(id: mentor_id).first || accepting_new_mentees.sample
+  def self.random
+    accepting_new_mentees.sample
   end
 
   def active_mentees

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -8,7 +8,7 @@ class Purchase < ActiveRecord::Base
   belongs_to :coupon
   serialize :github_usernames
 
-  attr_accessor :stripe_token, :paypal_url, :password, :mentor_id
+  attr_accessor :stripe_token, :paypal_url, :password
 
   validates :email, presence: true,
     format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i }

--- a/app/models/purchase_builder.rb
+++ b/app/models/purchase_builder.rb
@@ -37,7 +37,6 @@ class PurchaseBuilder
              :country,
              :payment_method,
              :stripe_token,
-             :mentor_id,
              :quantity)
   end
 

--- a/app/models/subscription_fulfillment.rb
+++ b/app/models/subscription_fulfillment.rb
@@ -53,6 +53,6 @@ class SubscriptionFulfillment
   end
 
   def mentor
-    Mentor.find_or_sample(@purchase.mentor_id)
+    Mentor.random
   end
 end

--- a/app/views/plans/_features.html.erb
+++ b/app/views/plans/_features.html.erb
@@ -2,7 +2,7 @@
   <figure class="<%= 'inactive' if !plan.includes_mentor? %>" data-target="mentoring">
     <h4 class="feature-title">1-1 Mentoring</h4>
     <div class="circle mentoring">
-      <%= mentor_image(@mentor) %>
+      <%= image_tag('learn/face-ben.png') %>
     </div>
   </figure>
   <figure class="<%= 'inactive' if !plan.includes_workshops? %>" data-target="workshop">
@@ -46,7 +46,7 @@
 <section class="feature-details">
   <% if plan.includes_mentor? %>
     <section data-target-id="mentoring" class="feature-detail mentoring">
-      <%= render 'plans/mentoring_detail', mentor: @mentor %>
+      <%= render 'plans/mentoring_detail' %>
     </section>
   <% end %>
   <% if plan.includes_workshops? %>

--- a/app/views/plans/_mentoring_detail.html.erb
+++ b/app/views/plans/_mentoring_detail.html.erb
@@ -1,4 +1,8 @@
 <article>
-  <p><strong>This is <%= mentor.first_name %></strong>, your first mentor if you choose this plan. <%= mentor.first_name %> will coach you one-on-one for 30 mins a month in a video chat, focusing on whatever you like: getting that first Rails position, salary negotiation, a specific problem in a side-project, etc. <%= mentor.bio %></p>
+  <p><strong>This is Ben</strong>, one of Prime's mentors. If you choose
+  this plan, a mentor like Ben will coach you one-on-one for 30 mins a
+  month in a video chat, focusing on whatever you like: getting that first
+  Rails position, salary negotiation, a specific problem in a side-project,
+  etc.
 </article>
 

--- a/app/views/purchases/_subscription_form.html.erb
+++ b/app/views/purchases/_subscription_form.html.erb
@@ -1,6 +1,5 @@
 <% if need_to_create_user_account? %>
   <%= form.input :password, required: true %>
-  <%= form.input :mentor_id, as: :hidden %>
 <% end %>
 <% if need_to_create_user_account? || need_to_collect_github_username? %>
   <%= render 'first_github_username', label: 'GitHub username', purchase: purchase %>

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 describe SubscriptionsController do
   describe '#new' do
     it 'assigns featured team plans in order' do
-      mentor = build_stubbed(:mentor)
-      Mentor.stubs(:find_or_sample).returns(mentor)
-
       get :new
 
       expect(assigns(:team_plans)).

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -225,12 +225,6 @@ FactoryGirl.define do
     factory :plan_purchase do
       association :purchaseable, factory: :plan
       association :user, :with_stripe, :with_mentor, :with_github
-
-      before(:create) do |purchase|
-        if purchase.user.mentor
-          purchase.mentor_id = purchase.user.mentor.id
-        end
-      end
     end
   end
 

--- a/spec/features/subscriber_accesses_content_via_dashboard_spec.rb
+++ b/spec/features/subscriber_accesses_content_via_dashboard_spec.rb
@@ -22,7 +22,6 @@ feature 'Subscriber accesses content' do
 
   scenario 'subscriber without access to workshops attempts to begin a workshop' do
     create(:workshop)
-    create_mentors
 
     sign_in_as_user_with_downgraded_subscription
     click_workshop_detail_link

--- a/spec/features/subscriber_views_monthly_receipt_spec.rb
+++ b/spec/features/subscriber_views_monthly_receipt_spec.rb
@@ -20,7 +20,6 @@ feature 'Subscriber views subscription invoices' do
   end
 
   scenario 'Subscriber can view a subscription invoice' do
-    create_mentors
     sign_in_as_user_with_subscription
     plan_purchase = create(:plan_purchase, user: @current_user)
     @current_user.stripe_customer_id = FakeStripe::CUSTOMER_ID
@@ -94,7 +93,6 @@ feature 'Subscriber views subscription invoices' do
   end
 
   scenario "a subscriber can't view another user's invoice" do
-    create_mentors
     sign_in_as_user_with_subscription
     plan_purchase = create(:plan_purchase, user: @current_user)
     @current_user.stripe_customer_id = "cus_NOMATCH"

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 feature 'User creates a subscription' do
   background do
     create_plan
-    create_mentors
     sign_in
   end
 

--- a/spec/features/user_updates_credit_card_spec.rb
+++ b/spec/features/user_updates_credit_card_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 feature 'User updated credit card' do
   background do
     create_plan
-    create_mentors
   end
 
   scenario 'updates credit card information', js: true do

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 
 feature 'Visitor signs up for a subscription' do
-
   background do
     create_plan
-    create_mentors
   end
 
   scenario 'visitor attempts to subscribe and creates email/password user' do

--- a/spec/mailers/purchase_mailer_spec.rb
+++ b/spec/mailers/purchase_mailer_spec.rb
@@ -127,10 +127,6 @@ describe PurchaseMailer do
       end
 
       describe 'for a subscription product' do
-        before do
-          create_mentors
-        end
-
         it 'does contain the receipt' do
           user = create(:subscriber)
           purchase = create(:plan_purchase, user: user)

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -51,7 +51,6 @@ describe IndividualPlan do
 
   describe 'purchase_for' do
     it 'returns the purchase when a user has purchased the plan' do
-      create_mentors
       user = create(:user, :with_github)
       purchase = create(:plan_purchase, user: user)
       plan = purchase.purchaseable
@@ -60,7 +59,6 @@ describe IndividualPlan do
     end
 
     it 'returns nil when a user has not purchased the plan' do
-      create_mentors
       user = create(:user)
       purchase = create(:plan_purchase)
       plan = purchase.purchaseable

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -16,23 +16,17 @@ describe Mentor do
     end
   end
 
-  describe '.find_or_sample' do
-    it 'returns a mentor for the given id' do
-      mentor = create(:mentor)
+  describe '.random' do
+    it 'returns a random mentor' do
+      mentor = create(:mentor, accepting_new_mentees: true)
 
-      expect(Mentor.find_or_sample(mentor.id)).to eq mentor
-    end
-
-    it 'returns a random mentor if one cannot be found with the given id' do
-      mentor = create(:mentor)
-
-      expect(Mentor.find_or_sample(nil)).to eq mentor
+      expect(Mentor.random).to eq mentor
     end
 
     it 'does not return unavailable mentors when sampling' do
       create(:mentor, accepting_new_mentees: false)
 
-      expect(Mentor.find_or_sample(nil)).to be_nil
+      expect(Mentor.random).to be_nil
     end
   end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -408,7 +408,6 @@ describe Purchase, 'given a purchaser' do
     end
 
     it 'creates a user when saved with a password' do
-      create_mentors
       plan = create(:plan)
       purchase = build(
         :purchase,

--- a/spec/models/subscription_fulfillment_spec.rb
+++ b/spec/models/subscription_fulfillment_spec.rb
@@ -25,9 +25,9 @@ describe SubscriptionFulfillment do
 
     it 'assigns a mentor on creation' do
       mentor = build_stubbed(:mentor)
-      Mentor.stubs(:find_or_sample).returns(mentor)
+      Mentor.stubs(:random).returns(mentor)
       user = build_subscribable_user
-      purchase = build_stubbed(:plan_purchase, mentor_id: mentor.id)
+      purchase = build_stubbed(:plan_purchase)
 
       expect(user.subscription).to be_nil
 

--- a/spec/support/features/team_plan_helpers.rb
+++ b/spec/support/features/team_plan_helpers.rb
@@ -1,6 +1,5 @@
 module Features
   def visit_team_plan_purchase_page
-    create(:mentor)
     plan = create(:team_plan)
     visit new_subscription_path
     click_link plan.name

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -33,8 +33,4 @@ module Subscriptions
   def have_subscription_to(plan_name)
     have_css('.subscription', text: plan_name)
   end
-
-  def create_mentors
-    create(:mentor)
-  end
 end


### PR DESCRIPTION
- Don't promise a specific mentor during signup.
- Assign a mentor at random during subscription fulfillment.
- Stop storing `mentor_id` on `Purchase`.
- Stop storing `mentor_id` in a cookie.
- Stop creating `Mentor`s in lots of specs that no longer need one.
