### PR TITLE
Introduce a feature model

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,0 +1,6 @@
+class Feature < ActiveRecord::Base
+  WORKSHOPS_KEY = 'workshops'.freeze
+  MENTORING_KEY = 'mentoring'.freeze
+
+  belongs_to :plan, polymorphic: true
+end

--- a/app/models/feature_query.rb
+++ b/app/models/feature_query.rb
@@ -1,0 +1,13 @@
+class FeatureQuery
+  def initialize(relation)
+    @relation = relation
+  end
+
+  def includes_workshops?
+    @relation.where(key: Feature::WORKSHOPS_KEY).present?
+  end
+
+  def includes_mentor?
+    @relation.where(key: Feature::MENTORING_KEY).present?
+  end
+end

--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -2,6 +2,7 @@ class IndividualPlan < ActiveRecord::Base
   PRIME_BASIC_SKU = 'prime-basic'
 
   has_many :announcements, as: :announceable, dependent: :destroy
+  has_many :features, as: :plan
   has_many :purchases, as: :purchaseable
   has_many :subscriptions, as: :plan
 
@@ -12,6 +13,7 @@ class IndividualPlan < ActiveRecord::Base
   validates :sku, presence: true
 
   include PlanForPublicListing
+  include QueryableFeatures
 
   def self.active
     where active: true

--- a/app/models/queryable_features.rb
+++ b/app/models/queryable_features.rb
@@ -1,0 +1,9 @@
+module QueryableFeatures
+  def includes_mentor?
+    FeatureQuery.new(features).includes_mentor?
+  end
+
+  def includes_workshops?
+    FeatureQuery.new(features).includes_workshops?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,11 @@ class User < ActiveRecord::Base
   delegate :name, to: :mentor, prefix: true, allow_nil: true
 
   def self.with_active_subscription
-    includes(purchased_subscription: :plan, team: { subscription: :plan }).
-      select(&:has_active_subscription?)
+    includes(
+      purchased_subscription: :plan,
+      team: { subscription: :plan }
+    ).
+    select(&:has_active_subscription?)
   end
 
   def subscription_purchases
@@ -72,6 +75,10 @@ class User < ActiveRecord::Base
     has_active_subscription? && subscription.includes_workshops?
   end
 
+  def has_subscription_with_mentor?
+    has_active_subscription? && subscription.includes_mentor?
+  end
+
   def subscribed_at
     subscription.try(:created_at)
   end
@@ -84,10 +91,6 @@ class User < ActiveRecord::Base
 
   def assign_mentor(mentor)
     update(mentor: mentor)
-  end
-
-  def has_subscription_with_mentor?
-    has_active_subscription? && subscription.try(:includes_mentor?)
   end
 
   def plan_name

--- a/app/modules/teams/team_plan.rb
+++ b/app/modules/teams/team_plan.rb
@@ -1,6 +1,7 @@
 module Teams
   # TeamPlan represents a purchase of a subscription plan for an entire team.
   class TeamPlan < ActiveRecord::Base
+    has_many :features, as: :plan
     has_many :purchases, as: :purchaseable
     has_many :subscriptions, as: :plan
     has_many :teams
@@ -10,6 +11,7 @@ module Teams
     validates :sku, presence: true
 
     include PlanForPublicListing
+    include QueryableFeatures
 
     def self.instance
       if first

--- a/db/migrate/20140613155252_create_features.rb
+++ b/db/migrate/20140613155252_create_features.rb
@@ -1,0 +1,13 @@
+class CreateFeatures < ActiveRecord::Migration
+  def change
+    create_table :features do |t|
+      t.string :key, null: false
+      t.references :plan, polymorphic: true, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :features, [:plan_id, :plan_type]
+    add_index :features, :key
+  end
+end

--- a/db/migrate/20140613170716_create_feature_records_for_plan_booleans.rb
+++ b/db/migrate/20140613170716_create_feature_records_for_plan_booleans.rb
@@ -1,0 +1,60 @@
+class CreateFeatureRecordsForPlanBooleans < ActiveRecord::Migration
+  def up
+    create_features_for_workshops
+    create_features_for_mentoring
+  end
+
+  def down
+    destroy_features
+  end
+
+  private
+
+  def create_features_for_workshops
+    create_features(
+      'workshops',
+      'includes_workshops',
+      'IndividualPlan',
+      'individual_plans'
+    )
+    create_features(
+      'workshops',
+      'includes_workshops',
+      'Teams::TeamPlan',
+      'team_plans'
+    )
+  end
+
+  def create_features_for_mentoring
+    create_features(
+      'mentoring',
+      'includes_mentor',
+      'IndividualPlan',
+      'individual_plans'
+    )
+    create_features(
+      'mentoring',
+      'includes_mentor',
+      'Teams::TeamPlan',
+      'team_plans'
+    )
+  end
+
+  def create_features(feature_key, column, plan_type, plan_table)
+    insert <<-SQL
+      INSERT INTO features
+      (key, plan_id, plan_type, created_at, updated_at)
+      (
+        SELECT
+          '#{feature_key}', id, '#{plan_type}', now(), now()
+          from #{plan_table}
+          where #{column}
+      )
+    SQL
+  end
+
+  def destroy_features
+    delete "DELETE FROM features where plan_type = 'IndividualPlan'"
+    delete "DELETE FROM features where plan_type = 'TeamPlan'"
+  end
+end

--- a/db/migrate/20140613181351_remove_plan_booleans.rb
+++ b/db/migrate/20140613181351_remove_plan_booleans.rb
@@ -1,0 +1,21 @@
+class RemovePlanBooleans < ActiveRecord::Migration
+  def up
+    remove_column :individual_plans, :includes_workshops
+    remove_column :team_plans, :includes_workshops
+
+    remove_column :individual_plans, :includes_mentor
+    remove_column :team_plans, :includes_mentor
+  end
+
+  def down
+    with_options(default: true) do |table|
+      table.add_column :individual_plans, :includes_workshops, :boolean
+      table.add_column :team_plans, :includes_workshops, :boolean, null: false
+    end
+
+    with_options(default: false) do |table|
+      table.add_column :individual_plans, :includes_mentor, :boolean
+      table.add_column :team_plans, :includes_mentor, :boolean, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140509152714) do
+ActiveRecord::Schema.define(version: 20140613181351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,19 +88,28 @@ ActiveRecord::Schema.define(version: 20140509152714) do
     t.string   "purchaseable_type"
   end
 
+  create_table "features", force: true do |t|
+    t.string   "key",        null: false
+    t.integer  "plan_id",    null: false
+    t.string   "plan_type",  null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "features", ["key"], name: "index_features_on_key", using: :btree
+  add_index "features", ["plan_id", "plan_type"], name: "index_features_on_plan_id_and_plan_type", using: :btree
+
   create_table "individual_plans", force: true do |t|
-    t.string   "name",                               null: false
-    t.string   "sku",                                null: false
-    t.string   "short_description",                  null: false
-    t.text     "description",                        null: false
-    t.boolean  "active",             default: true,  null: false
-    t.integer  "individual_price",                   null: false
+    t.string   "name",                             null: false
+    t.string   "sku",                              null: false
+    t.string   "short_description",                null: false
+    t.text     "description",                      null: false
+    t.boolean  "active",            default: true, null: false
+    t.integer  "individual_price",                 null: false
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: false
-    t.boolean  "includes_workshops", default: true
-    t.boolean  "featured",           default: true,  null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.boolean  "featured",          default: true, null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
   end
 
   create_table "invitations", force: true do |t|
@@ -284,15 +293,13 @@ ActiveRecord::Schema.define(version: 20140509152714) do
   add_index "teachers", ["user_id", "workshop_id"], name: "index_teachers_on_user_id_and_workshop_id", unique: true, using: :btree
 
   create_table "team_plans", force: true do |t|
-    t.string   "sku",                                null: false
-    t.string   "name",                               null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.string   "sku",                             null: false
+    t.string   "name",                            null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.integer  "individual_price"
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: false, null: false
-    t.boolean  "includes_workshops", default: true,  null: false
-    t.boolean  "featured",           default: true,  null: false
+    t.boolean  "featured",         default: true, null: false
     t.text     "description"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,18 @@ FactoryGirl.define do
     "http://robots.thoughtbot.com/#{n}"
   end
 
+  trait :with_mentoring do
+    after(:create) do |plan|
+      create(:mentoring_feature, plan: plan)
+    end
+  end
+
+  trait :with_workshops do
+    after(:create) do |plan|
+      create(:workshops_feature, plan: plan)
+    end
+  end
+
   factory :announcement do
     association :announceable, factory: :book
     ends_at { 1.day.from_now }
@@ -130,11 +142,6 @@ FactoryGirl.define do
 
     factory :basic_plan do
       sku IndividualPlan::PRIME_BASIC_SKU
-      includes_workshops false
-    end
-
-    trait :includes_mentor do
-      includes_mentor true
     end
   end
 
@@ -284,8 +291,18 @@ FactoryGirl.define do
       with_subscription
 
       trait :includes_mentor do
-        ignore do
-          plan { create(:individual_plan, :includes_mentor) }
+        plan do
+          create(:individual_plan).tap do |plan|
+            create(:mentoring_feature, plan: plan)
+          end
+        end
+      end
+
+      trait :includes_workshops do
+        plan do
+          create(:individual_plan).tap do |plan|
+            create(:workshops_feature, plan: plan)
+          end
         end
       end
     end
@@ -381,5 +398,18 @@ FactoryGirl.define do
   factory :oauth_access_token do
     application_id 1
     token 'abc123'
+  end
+
+  factory :feature do
+    association :plan
+    key 'feature-identifier'
+
+    factory :mentoring_feature do
+      key Feature::MENTORING_KEY
+    end
+
+    factory :workshops_feature do
+      key Feature::WORKSHOPS_KEY
+    end
   end
 end

--- a/spec/features/subscriber_accesses_content_via_dashboard_spec.rb
+++ b/spec/features/subscriber_accesses_content_via_dashboard_spec.rb
@@ -4,7 +4,7 @@ feature 'Subscriber accesses content' do
   scenario 'begins a workshop' do
     workshop = create(:workshop)
 
-    sign_in_as_user_with_subscription
+    sign_in_as_user_with_workshops_subscription
     click_workshop_detail_link
 
     expect(page).to have_content I18n.t('workshops.show.free_to_subscribers')
@@ -24,6 +24,7 @@ feature 'Subscriber accesses content' do
     create(:workshop)
 
     sign_in_as_user_with_downgraded_subscription
+    click_workshop_preview_link
     click_workshop_detail_link
 
     expect(page).not_to have_content I18n.t('workshops.show.free_to_subscribers')
@@ -67,7 +68,7 @@ feature 'Subscriber accesses content' do
     workshop = create(:workshop)
     overlapping_workshop = create(:workshop)
 
-    sign_in_as_user_with_subscription
+    sign_in_as_user_with_workshops_subscription
     click_link workshop.name
     click_link I18n.t('workshops.show.register_free')
     click_button 'Get Access'
@@ -83,7 +84,7 @@ feature 'Subscriber accesses content' do
   scenario 'show in-progress status for current workshop' do
     workshop = create(:workshop, length_in_days: 2)
 
-    sign_in_as_user_with_subscription
+    sign_in_as_user_with_workshops_subscription
     click_workshop_detail_link
     click_link I18n.t('workshops.show.register_free')
     click_button 'Get Access'
@@ -104,7 +105,7 @@ feature 'Subscriber accesses content' do
   end
 
   def get_access_to_workshop
-    sign_in_as_user_with_subscription
+    sign_in_as_user_with_workshops_subscription
     click_workshop_detail_link
     click_link I18n.t('workshops.show.register_free')
     click_button 'Get Access'
@@ -138,5 +139,9 @@ feature 'Subscriber accesses content' do
       ".product-card a[title='#{workshop.name}'] .status",
       text: 'in-progress'
     )
+  end
+
+  def click_workshop_preview_link
+    click_link "See what you're missing"
   end
 end

--- a/spec/mailers/purchase_mailer_spec.rb
+++ b/spec/mailers/purchase_mailer_spec.rb
@@ -129,36 +129,37 @@ describe PurchaseMailer do
       describe 'for a subscription product' do
         it 'does contain the receipt' do
           user = create(:subscriber)
-          purchase = create(:plan_purchase, user: user)
+          purchase = build_stubbed(:plan_purchase, user: user)
 
           expect_to_contain_receipt(purchase)
         end
 
         it 'includes support' do
           user = create(:subscriber)
-          purchase = create(:plan_purchase, user: user)
+          purchase = build_stubbed(:plan_purchase, user: user)
 
           expect(email_for(purchase)).to have_body_text(/support/)
         end
 
         it 'has a thank you for subscribing' do
           user = create(:subscriber)
-          purchase = create(:plan_purchase, user: user)
+          purchase = build_stubbed(:plan_purchase, user: user)
 
           expect(email_for(purchase)).to have_body_text(/Thank you for subscribing/)
         end
 
         it 'mentions the mentor email' do
-          plan = create(:individual_plan, :includes_mentor)
+          plan = create(:individual_plan, :with_mentoring)
           user = create(:subscriber, plan: plan)
-          purchase = create(:plan_purchase, user: user, purchaseable: plan)
+          purchase =
+            build_stubbed(:plan_purchase, user: user, purchaseable: plan)
 
           expect(email_for(purchase)).to have_body_text(/mentor/)
         end
 
         it 'does not mention the features the user does not have' do
           user = create(:subscriber)
-          purchase = create(
+          purchase = build_stubbed(
             :plan_purchase,
             user: user,
             purchaseable: create(:basic_plan)

--- a/spec/models/feature_query_spec.rb
+++ b/spec/models/feature_query_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe FeatureQuery do
+  describe '#includes_workshops?' do
+    context 'when the plan includes workshops' do
+      it 'returns true' do
+        plan = create(:plan, :with_workshops)
+
+        result = FeatureQuery.new(plan.features).includes_workshops?
+
+        expect(result).to be_true
+      end
+    end
+
+    context 'when the plan does not include workshops' do
+      it 'returns false' do
+        plan = build_stubbed(:plan)
+
+        result = FeatureQuery.new(plan.features).includes_workshops?
+
+        expect(result).to be_false
+      end
+    end
+  end
+
+  describe '#includes_mentor?' do
+    context 'when the plan includes mentoring' do
+      it 'returns true' do
+        plan = create(:plan, :with_mentoring)
+
+        result = FeatureQuery.new(plan.features).includes_mentor?
+
+        expect(result).to be_true
+      end
+    end
+
+    context 'when the plan does not include mentoring' do
+      it 'returns false' do
+        plan = build_stubbed(:plan)
+
+        result = FeatureQuery.new(plan.features).includes_mentor?
+
+        expect(result).to be_false
+      end
+    end
+  end
+end

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Feature do
+  it { should belong_to(:plan) }
+end

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe IndividualPlan do
   it { should have_many(:announcements) }
+  it { should have_many(:features) }
   it { should have_many(:purchases) }
   it { should have_many(:subscriptions) }
 
@@ -15,6 +16,7 @@ describe IndividualPlan do
   it { should be_subscription }
 
   it_behaves_like 'a Plan for public listing'
+  it_behaves_like 'a Plan with queryable features'
 
   describe '.active' do
     it 'only includes active plans' do

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -48,13 +48,6 @@ describe Mentor do
 
       expect(mentor.active_mentees).to eq [active]
     end
-
-    it 'eager loads mentees' do
-      mentor = create(:mentor)
-
-      expect { mentor.reload.active_mentees }.
-        to eager_load { create(:subscriber, :includes_mentor, mentor: mentor) }
-    end
   end
 
   describe '#active_mentee_count' do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -27,7 +27,7 @@ describe Subscription do
 
   describe '.deliver_welcome_emails' do
     it 'sends emails for each new mentored subscriber in the last 24 hours' do
-      plan = create(:individual_plan, includes_mentor: true)
+      plan = create(:individual_plan, :with_mentoring)
       old_subscription =
         create(:subscription, plan: plan, created_at: 25.hours.ago)
       new_subscription =

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@ describe User do
 
   context 'with a subscription that includes a mentor' do
     it 'is invalid without a mentor' do
-      plan = create(:plan, includes_mentor: true)
+      plan = create(:plan, :with_mentoring)
       subscription = create(:subscription, plan: plan)
       user = create(:user, :with_mentor, subscription: subscription)
 
@@ -244,7 +244,7 @@ describe User do
 
   describe '#has_subscription_with_mentor?' do
     it 'returns true when the subscription includes mentoring' do
-      plan = build(:plan, includes_mentor: true)
+      plan = create(:plan, :with_mentoring)
       subscription = build(:subscription, plan: plan)
       user = build(:user, :with_mentor, subscription: subscription)
 
@@ -252,7 +252,7 @@ describe User do
     end
 
     it 'returns false when the subscription does not include mentoring' do
-      plan = build(:plan, includes_mentor: false)
+      plan = build(:plan)
       subscription = build(:subscription, plan: plan)
       user = build(:user, subscription: subscription)
 
@@ -260,7 +260,7 @@ describe User do
     end
 
     it 'returns false when the subscription is inactive' do
-      plan = build(:plan, includes_mentor: true)
+      plan = create(:plan, :with_mentoring)
       subscription = build(:inactive_subscription, plan: plan)
       user = build(:user, :with_mentor, subscription: subscription)
 

--- a/spec/modules/teams/team_plan_spec.rb
+++ b/spec/modules/teams/team_plan_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module Teams
   describe TeamPlan, type: :model do
+    it { should have_many(:features) }
     it { should have_many(:purchases) }
     it { should have_many(:subscriptions) }
     it { should have_many(:teams) }
@@ -11,6 +12,12 @@ module Teams
     it { should validate_presence_of(:individual_price) }
 
     it_behaves_like 'a Plan for public listing' do
+      def factory_name
+        :team_plan
+      end
+    end
+
+    it_behaves_like 'a Plan with queryable features' do
       def factory_name
         :team_plan
       end
@@ -110,8 +117,52 @@ module Teams
       end
     end
 
-    def team_plan
-      build(:team_plan)
+    describe '#includes_mentor?' do
+      context 'when the plan includes mentoring' do
+        it 'returns true' do
+          plan = team_plan(:with_mentoring)
+
+          result = plan.includes_mentor?
+
+          expect(result).to be_true
+        end
+      end
+
+      context 'when the plan does not include mentoring' do
+        it 'returns false' do
+          plan = team_plan
+
+          result = plan.includes_mentor?
+
+          expect(result).to be_false
+        end
+      end
+    end
+
+    describe '#includes_workshops?' do
+      context 'when the plan includes workshops' do
+        it 'returns true' do
+          plan = team_plan(:with_workshops)
+
+          result = plan.includes_workshops?
+
+          expect(result).to be_true
+        end
+      end
+
+      context 'when the plan does not include workshops' do
+        it 'returns false' do
+          plan = team_plan
+
+          result = plan.includes_workshops?
+
+          expect(result).to be_false
+        end
+      end
+    end
+
+    def team_plan(options = [])
+      create(:team_plan, *options)
     end
   end
 end

--- a/spec/support/plan_with_queryable_features.rb
+++ b/spec/support/plan_with_queryable_features.rb
@@ -1,0 +1,64 @@
+shared_examples 'a Plan with queryable features' do
+  describe '#includes_mentor?' do
+    context 'when the plan includes mentoring' do
+      it 'returns true' do
+        plan = build_plan
+        stub_feature(plan, :includes_mentor?, true)
+
+        result = plan.includes_mentor?
+
+        expect(result).to be_true
+      end
+    end
+
+    context 'when the plan does not include mentoring' do
+      it 'returns false' do
+        plan = build_plan
+        stub_feature(plan, :includes_mentor?, false)
+
+        result = plan.includes_mentor?
+
+        expect(result).to be_false
+      end
+    end
+
+  end
+
+  describe '#includes_workshops?' do
+    context 'when the plan includes workshops' do
+      it 'returns true' do
+        plan = build_plan
+        stub_feature(plan, :includes_workshops?, true)
+
+        result = plan.includes_workshops?
+
+        expect(result).to be_true
+      end
+    end
+
+    context 'when the plan does not include workshops' do
+      it 'returns false' do
+        plan = build_plan
+        stub_feature(plan, :includes_workshops?, false)
+
+        result = plan.includes_workshops?
+
+        expect(result).to be_false
+      end
+    end
+  end
+
+  def build_plan
+    build_stubbed(factory_name)
+  end
+
+  def stub_feature(plan, feature, return_value)
+    query = stub('query')
+    query.stubs(feature).returns(return_value)
+    FeatureQuery.stubs(:new).with(plan.features).returns(query)
+  end
+
+  def factory_name
+    described_class.name.underscore.to_sym
+  end
+end

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -8,6 +8,10 @@ module Subscriptions
     visit dashboard_path(as: @current_user)
   end
 
+  def sign_in_as_user_with_workshops_subscription
+    sign_in_as_user_with_subscription(:includes_workshops)
+  end
+
   def sign_in_as_user_with_mentoring_subscription
     sign_in_as_user_with_subscription(:includes_mentor)
   end


### PR DESCRIPTION
Because:
- We want to make it easy to add and remove features for a given Plan
  (`IndividualPlan` or `TeamPlan`)

This pull:
- Introduces a Features model, where each Plan `has_many :features`.
- Migrates existing feature booleans into `Feature` records.
