### PR TITLE
Add boolean columns to plans for features

### DIFF
--- a/db/migrate/20140617152531_add_features_to_individual_plans.rb
+++ b/db/migrate/20140617152531_add_features_to_individual_plans.rb
@@ -1,0 +1,12 @@
+class AddFeaturesToIndividualPlans < ActiveRecord::Migration
+  def change
+    with_options default: true, null: false do |table|
+      table.add_column :individual_plans, :includes_exercises, :boolean
+      table.add_column :individual_plans, :includes_source_code, :boolean
+      table.add_column :individual_plans, :includes_forum, :boolean
+      table.add_column :individual_plans, :includes_books, :boolean
+      table.add_column :individual_plans, :includes_screencasts, :boolean
+      table.add_column :individual_plans, :includes_office_hours, :boolean
+    end
+  end
+end

--- a/db/migrate/20140617182908_add_features_to_team_plans.rb
+++ b/db/migrate/20140617182908_add_features_to_team_plans.rb
@@ -1,0 +1,12 @@
+class AddFeaturesToTeamPlans < ActiveRecord::Migration
+  def change
+    with_options default: true, null: false do |table|
+      table.add_column :team_plans, :includes_exercises, :boolean
+      table.add_column :team_plans, :includes_source_code, :boolean
+      table.add_column :team_plans, :includes_forum, :boolean
+      table.add_column :team_plans, :includes_books, :boolean
+      table.add_column :team_plans, :includes_screencasts, :boolean
+      table.add_column :team_plans, :includes_office_hours, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140509152714) do
+ActiveRecord::Schema.define(version: 20140617182908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,18 +89,24 @@ ActiveRecord::Schema.define(version: 20140509152714) do
   end
 
   create_table "individual_plans", force: true do |t|
-    t.string   "name",                               null: false
-    t.string   "sku",                                null: false
-    t.string   "short_description",                  null: false
-    t.text     "description",                        null: false
-    t.boolean  "active",             default: true,  null: false
-    t.integer  "individual_price",                   null: false
+    t.string   "name",                                  null: false
+    t.string   "sku",                                   null: false
+    t.string   "short_description",                     null: false
+    t.text     "description",                           null: false
+    t.boolean  "active",                default: true,  null: false
+    t.integer  "individual_price",                      null: false
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: false
-    t.boolean  "includes_workshops", default: true
-    t.boolean  "featured",           default: true,  null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.boolean  "includes_mentor",       default: false
+    t.boolean  "includes_workshops",    default: true
+    t.boolean  "featured",              default: true,  null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "includes_exercises",    default: true,  null: false
+    t.boolean  "includes_source_code",  default: true,  null: false
+    t.boolean  "includes_forum",        default: true,  null: false
+    t.boolean  "includes_books",        default: true,  null: false
+    t.boolean  "includes_screencasts",  default: true,  null: false
+    t.boolean  "includes_office_hours", default: true,  null: false
   end
 
   create_table "invitations", force: true do |t|
@@ -284,16 +290,22 @@ ActiveRecord::Schema.define(version: 20140509152714) do
   add_index "teachers", ["user_id", "workshop_id"], name: "index_teachers_on_user_id_and_workshop_id", unique: true, using: :btree
 
   create_table "team_plans", force: true do |t|
-    t.string   "sku",                                null: false
-    t.string   "name",                               null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.string   "sku",                                   null: false
+    t.string   "name",                                  null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.integer  "individual_price"
     t.text     "terms"
-    t.boolean  "includes_mentor",    default: false, null: false
-    t.boolean  "includes_workshops", default: true,  null: false
-    t.boolean  "featured",           default: true,  null: false
+    t.boolean  "includes_mentor",       default: false, null: false
+    t.boolean  "includes_workshops",    default: true,  null: false
+    t.boolean  "featured",              default: true,  null: false
     t.text     "description"
+    t.boolean  "includes_exercises",    default: true,  null: false
+    t.boolean  "includes_source_code",  default: true,  null: false
+    t.boolean  "includes_forum",        default: true,  null: false
+    t.boolean  "includes_books",        default: true,  null: false
+    t.boolean  "includes_screencasts",  default: true,  null: false
+    t.boolean  "includes_office_hours", default: true,  null: false
   end
 
   create_table "teams", force: true do |t|


### PR DESCRIPTION
This PR includes migrations for `individual_plans` and `team_plans` to add boolean columns for each individual subscription feature, so that it will be easy to configure the new plans when we implement the new structure. I used `default: true` because all of the existing plans include all of these features.
