### PR TITLE
Hide exercises from dashboard for users without subscription

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user_has_active_subscription?
 
+  def current_user_has_access_to_exercises?
+    current_user && current_user.has_access_to_exercises?
+  end
+  helper_method :current_user_has_access_to_exercises?
+
   def current_user_has_access_to_workshops?
     current_user && current_user.has_access_to_workshops?
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,6 +7,7 @@ class Subscription < ActiveRecord::Base
 
   delegate :includes_mentor?, to: :plan
   delegate :includes_workshops?, to: :plan
+  delegate :includes_exercises?, to: :plan
   delegate :name, to: :plan, prefix: true
   delegate :stripe_customer_id, to: :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,10 @@ class User < ActiveRecord::Base
     has_active_subscription? && subscription.includes_workshops?
   end
 
+  def has_access_to_exercises?
+    has_active_subscription? && subscription.includes_exercises?
+  end
+
   def subscribed_at
     subscription.try(:created_at)
   end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -7,19 +7,28 @@
   <%= render 'trails' %>
 </section>
 
-<p class="product-headline">Hone your skills by completing these exercises</p>
-<%= render 'products/exercises' %>
+<% if current_user_has_access_to_exercises? %>
+  <p class="product-headline">Hone your skills by completing these exercises</p>
+  <%= render 'products/exercises' %>
+<% end %>
 
 <% if current_user_has_access_to_workshops? %>
   <p class="product-headline">Enroll in our online workshops</p>
   <section class='workshops'>
     <%= render partial: 'products/workshop', collection: @catalog.workshops %>
   </section>
-<% else %>
+<% end %>
+
+<% if !current_user_has_access_to_exercises? %>
   <section class='workshops disabled'>
     <div class='disabled-text'>
       <h2>
-        <% if current_user_has_access_to_shows? %>
+        <% if current_user_has_access_to_workshops? %>
+          <%= t(
+            '.no_exercises.title_html',
+            link: link_to(t('.no_exercises.link'), edit_subscription_path)
+          ) %>
+        <% elsif current_user_has_access_to_shows? %>
           <%= t(
             '.no_workshops.title_html',
             link: link_to(t('.no_workshops.link'), edit_subscription_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,11 +30,14 @@ en:
   dashboards:
     show:
       contact_your_mentor: "Contact your mentor, %{mentor_name}"
+      no_exercises:
+        title_html: "Exercises are locked &mdash; %{link} to get access"
+        link: "upgrade your subscription"
       no_workshops:
-        title_html: "Workshops are locked &mdash; %{link} to get access"
-        link: "upgrade to Prime Workshops"
+        title_html: "Exercises and workshops are locked &mdash; %{link} to get access"
+        link: "upgrade your subscription"
       no_shows:
-        title_html: "Workshops and shows are locked &mdash; %{link} to get access"
+        title_html: "Exercises, workshops, and shows are locked &mdash; %{link} to get access"
         link: "subscribe to Prime"
 
   account:

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -6,6 +6,9 @@ describe Subscription do
   it { should belong_to(:user) }
 
   it { should delegate(:stripe_customer_id).to(:user) }
+  it { should delegate(:includes_mentor?).to(:plan) }
+  it { should delegate(:includes_workshops?).to(:plan) }
+  it { should delegate(:includes_exercises?).to(:plan) }
 
   it { should validate_presence_of(:plan_id) }
   it { should validate_presence_of(:plan_type) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -401,6 +401,34 @@ describe User do
     end
   end
 
+  describe '#has_access_to_exercises?' do
+    context 'when the user does not have a subscription' do
+      it 'returns false' do
+        user = build_stubbed(:user)
+
+        expect(user.has_access_to_exercises?).to_not be
+      end
+    end
+
+    context 'when the user has an inactive subscription' do
+      it 'returns false' do
+        user = create(:subscriber)
+        user.subscription.stubs(:active?).returns(false)
+
+        expect(user.has_access_to_exercises?).to_not be
+      end
+    end
+
+    context 'when the user has an active subscription' do
+      it "delegates to the subscription's includes_exercises? method" do
+        user = create(:subscriber)
+        user.subscription.stubs(:includes_exercises?).returns('expected')
+
+        expect(user.has_access_to_exercises?).to eq 'expected'
+      end
+    end
+  end
+
   describe '#subscription' do
     it 'returns a purchased subscription' do
       subscription = build_stubbed(:subscription)

--- a/spec/views/dashboards/show.html.erb_spec.rb
+++ b/spec/views/dashboards/show.html.erb_spec.rb
@@ -2,25 +2,34 @@ require 'spec_helper'
 
 describe 'dashboards/show.html' do
   it 'renders with access to workshops and shows' do
-    render_show shows: true, workshops: true
+    render_show shows: true, workshops: true, exercises: true
 
     expect(rendered).not_to have_content('locked')
   end
 
   it 'renders with access to shows but without access to workshops' do
-    render_show shows: true, workshops: false
+    render_show shows: true, workshops: true, exercises: false
 
-    expect(rendered).to have_content('Workshops are locked')
+    expect(rendered).to have_content('Exercises are locked')
+  end
+
+  it 'renders with access to shows but without access to workshops' do
+    render_show shows: true, workshops: false, exercises: false
+
+    expect(rendered).to have_content('Exercises and workshops are locked')
   end
 
   it 'renders without access to shows or workshops' do
-    render_show shows: false, workshops: false
+    render_show shows: false, workshops: false, exercises: false
 
-    expect(rendered).to have_content('Workshops and shows are locked')
+    expect(rendered).
+      to have_content('Exercises, workshops, and shows are locked')
   end
 
   def render_show(options)
     view_stubs(:current_user).returns(build_stubbed(:user))
+    view_stubs(:current_user_has_access_to_exercises?).
+      returns(options[:exercises])
     view_stubs(:current_user_has_access_to_workshops?).
       returns(options[:workshops])
     view_stubs(:current_user_has_access_to_shows?).


### PR DESCRIPTION
In preparation for new pricing plans, we should restrict access to exercises to users whose subscriptions include them.
