### PR TITLE
Visit the purchase path directly in TeamPlan specs

### DIFF
--- a/spec/support/features/team_plan_helpers.rb
+++ b/spec/support/features/team_plan_helpers.rb
@@ -1,7 +1,6 @@
 module Features
   def visit_team_plan_purchase_page
     plan = create(:team_plan)
-    visit new_subscription_path
-    click_link plan.name
+    visit new_teams_team_plan_purchase_path(plan)
   end
 end


### PR DESCRIPTION
Rather than navigating from the plans page, just visit the purchase path 
directly.
