### PR TITLE
Prevent access to unauthorized purchaseables

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,6 +55,11 @@ class ApplicationController < ActionController::Base
       find(params)
   end
 
+  def included_in_current_users_plan?(purchaseable)
+    purchaseable.included_in_plan?(current_user.plan)
+  end
+  helper_method :included_in_current_users_plan?
+
   def topics
     Topic.top
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,8 @@ class Book < Product
   def filename
     name.parameterize
   end
+
+  def included_in_plan?(plan)
+    plan.includes_books?
+  end
 end

--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -69,6 +69,10 @@ class IndividualPlan < ActiveRecord::Base
     controller.dashboard_path
   end
 
+  def included_in_plan?(plan)
+    false
+  end
+
   private
 
   def stripe_plan

--- a/app/models/screencast.rb
+++ b/app/models/screencast.rb
@@ -2,4 +2,8 @@ class Screencast < Product
   def collection?
     published_videos.count > 1
   end
+
+  def included_in_plan?(plan)
+    plan.includes_screencasts?
+  end
 end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -5,6 +5,10 @@ class Show < Product
     where(name: THE_WEEKLY_ITERATION).first
   end
 
+  def included_in_plan?(plan)
+    plan.includes_shows?
+  end
+
   private
 
   def product_licenses

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -62,7 +62,7 @@ class Subscription < ActiveRecord::Base
   end
 
   def has_access_to?(feature)
-    active? && plan.send("includes_#{feature}?".to_sym)
+    active? && plan.public_send("includes_#{feature}?")
   end
 
   def purchase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,10 @@ class User < ActiveRecord::Base
     purchased_subscription || team_subscription
   end
 
+  def plan
+    subscription.plan
+  end
+
   private
 
   def team_subscription

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -7,6 +7,7 @@ class Video < ActiveRecord::Base
   validates :watchable_type, presence: true
   validates :wistia_id, presence: true
 
+  delegate :included_in_plan?, to: :watchable
   delegate :name, to: :watchable, prefix: true
 
   def self.ordered

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -102,4 +102,8 @@ class Workshop < ActiveRecord::Base
   def published_videos
     videos.published
   end
+
+  def included_in_plan?(plan)
+    plan.includes_workshops?
+  end
 end

--- a/app/modules/teams/team_plan.rb
+++ b/app/modules/teams/team_plan.rb
@@ -47,5 +47,9 @@ module Teams
     def after_purchase_url(controller, purchase)
       controller.edit_teams_team_path
     end
+
+    def included_in_plan?(plan)
+      false
+    end
   end
 end

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -18,7 +18,7 @@
     <% if signed_out? %>
       <%= render 'weekly_iterations/subscribe', plan: @plan, show: @video.watchable %>
     <% else %>
-      <%= render @video.watchable.licenses_for(current_user) %>
+      <%= render @video.watchable.licenses_for(current_user), product: @video %>
     <% end %>
 
     <%= render 'products/terms', product: @video.watchable %>

--- a/app/views/products/_license.html.erb
+++ b/app/views/products/_license.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <% if product.active? %>
-    <%= render licenses %>
+    <%= render licenses, product: product %>
   <% else %>
     <%= render 'products/inactive', product: product %>
   <% end %>

--- a/app/views/subscriber_licenses/_subscriber_license.html.erb
+++ b/app/views/subscriber_licenses/_subscriber_license.html.erb
@@ -1,22 +1,15 @@
 <div class="individual-purchase">
   <div class="license">
-    <h2 class="active-subscription"><span><%= t 'products.show.free_to_subscribers' %></span></h2>
-    <%= link_to(
-      new_product_purchase_path(subscriber_license, variant: :individual),
-      class: "license-button button free-with-prime",
-      id: "#{subscriber_license.sku}-purchase-individual"
-    ) do %>
-      <% if subscriber_license.collection? %>
-        <%= t(
-          'products.show.purchase_collection_for_subscribed_user',
-          offering_type: subscriber_license.offering_type
-        ) %>
-      <% else %>
-        <%= t(
-          'products.show.purchase_for_subscribed_user',
-          offering_type: subscriber_license.offering_type
-        ) %>
-      <% end %>
+    <% if included_in_current_users_plan?(product) %>
+      <%= render(
+        'subscriber_licenses/subscriber_license_included',
+        subscriber_license: subscriber_license
+      ) %>
+    <% else %>
+      <%= render(
+        'subscriber_licenses/subscriber_license_not_included',
+        subscriber_license: subscriber_license
+      ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/subscriber_licenses/_subscriber_license_included.html.erb
+++ b/app/views/subscriber_licenses/_subscriber_license_included.html.erb
@@ -1,0 +1,20 @@
+<h2 class="active-subscription">
+  <span><%= t 'products.show.free_to_subscribers' %></span>
+</h2>
+<%= link_to(
+  new_product_purchase_path(subscriber_license, variant: :individual),
+  class: "license-button button free-with-prime",
+  id: "#{subscriber_license.sku}-purchase-individual"
+) do %>
+  <% if subscriber_license.collection? %>
+    <%= t(
+      'products.show.purchase_collection_for_subscribed_user',
+      offering_type: subscriber_license.offering_type
+    ) %>
+  <% else %>
+    <%= t(
+      'products.show.purchase_for_subscribed_user',
+      offering_type: subscriber_license.offering_type
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/subscriber_licenses/_subscriber_license_not_included.html.erb
+++ b/app/views/subscriber_licenses/_subscriber_license_not_included.html.erb
@@ -1,0 +1,3 @@
+<%= link_to edit_subscription_path, class: "prime-button license-button button" do %>
+  <%= t('products.show.upgrade', offering_type: subscriber_license.offering_type) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
         company_html: "For your company: %{price}"
         subscription:
           individual_html: "%{price}"
+      upgrade: "Upgrade your plan to access this %{offering_type}"
     license:
       or_buy_individually: "Or buy individually"
 

--- a/db/migrate/20140624141447_add_includes_shows_to_plans.rb
+++ b/db/migrate/20140624141447_add_includes_shows_to_plans.rb
@@ -1,0 +1,18 @@
+class AddIncludesShowsToPlans < ActiveRecord::Migration
+  def change
+    add_column(
+      :individual_plans,
+      :includes_shows,
+      :boolean,
+      default: true,
+      null: false
+    )
+    add_column(
+      :team_plans,
+      :includes_shows,
+      :boolean,
+      default: true,
+      null: false
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140617182908) do
+ActiveRecord::Schema.define(version: 20140624141447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20140617182908) do
     t.boolean  "includes_books",        default: true,  null: false
     t.boolean  "includes_screencasts",  default: true,  null: false
     t.boolean  "includes_office_hours", default: true,  null: false
+    t.boolean  "includes_shows",        default: true,  null: false
   end
 
   create_table "invitations", force: true do |t|
@@ -306,6 +307,7 @@ ActiveRecord::Schema.define(version: 20140617182908) do
     t.boolean  "includes_books",        default: true,  null: false
     t.boolean  "includes_screencasts",  default: true,  null: false
     t.boolean  "includes_office_hours", default: true,  null: false
+    t.boolean  "includes_shows",        default: true,  null: false
   end
 
   create_table "teams", force: true do |t|

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1,25 +1,91 @@
-require 'spec_helper'
+require "spec_helper"
 
 include StubCurrentUserHelper
 
 describe PurchasesController do
-  describe '#new when purchasing a screencast as a user with an active subscription' do
-    it 'renders a subscriber-specific layout' do
-      user = create(:subscriber)
-      product = create(:screencast)
-      stub_current_user_with(user)
+  describe "#new when purchasing a screencast" do
+    context "with an active subscription that includes screencasts" do
+      it "renders a subscriber-specific layout" do
+        user = create(:subscriber, :includes_screencasts)
+        product = create(:screencast)
+        stub_current_user_with(user)
 
-      get :new, product_id: product
+        get :new, product_id: product
 
-      expect(response).to(
-        redirect_to(new_subscriber_screencast_purchase_path(product))
-      )
+        expect(response).to(
+          redirect_to(new_subscriber_screencast_purchase_path(product))
+        )
+      end
+    end
+
+    context "with an active subscription that does not includes screencasts" do
+      it "redirects them to upgrade their subscription" do
+        user = create(:basic_subscriber)
+        product = create(:screencast)
+        stub_current_user_with(user)
+
+        get :new, product_id: product
+
+        expect(response).to redirect_to(edit_subscription_path)
+      end
+    end
+
+    context "as a user without a subscription" do
+      it "renders the new template" do
+        user = create(:user)
+        product = create(:screencast)
+        stub_current_user_with(user)
+
+        get :new, product_id: product
+
+        expect(response).to render_template(:new)
+      end
     end
   end
 
-  describe '#new when purchasing a plan as a user with an active subscription' do
-    context 'when purchasing an individual plan' do
-      it 'renders a subscriber-specific layout' do
+  describe "#new when purchasing a book" do
+    context "with an active subscription that includes books" do
+      it "renders a subscriber-specific layout" do
+        user = create(:subscriber, :includes_books)
+        product = create(:book)
+        stub_current_user_with(user)
+
+        get :new, product_id: product
+
+        expect(response).to(
+          redirect_to(new_subscriber_book_purchase_path(product))
+        )
+      end
+    end
+
+    context "with an active subscription that does not include books" do
+      it "redirects them to upgrade their subscription" do
+        user = create(:basic_subscriber)
+        product = create(:book)
+        stub_current_user_with(user)
+
+        get :new, product_id: product
+
+        expect(response).to redirect_to(edit_subscription_path)
+      end
+    end
+
+    context "as a user without a subscription" do
+      it "renders the new template" do
+        user = create(:user)
+        product = create(:book)
+        stub_current_user_with(user)
+
+        get :new, product_id: product
+
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "#new when purchasing a plan as an active subscriber" do
+    context "when purchasing an individual plan" do
+      it "renders a subscriber-specific layout" do
         user = create(:subscriber)
         stub_current_user_with(user)
 
@@ -29,8 +95,8 @@ describe PurchasesController do
       end
     end
 
-    context 'when purchasing a team plan' do
-      it 'renders a subscriber-specific layout' do
+    context "when purchasing a team plan" do
+      it "renders a subscriber-specific layout" do
         user = create(:subscriber)
         stub_current_user_with(user)
 
@@ -41,32 +107,32 @@ describe PurchasesController do
     end
   end
 
-  describe '#new with no variant specified' do
-    it 'defaults purchase to individual' do
+  describe "#new with no variant specified" do
+    it "defaults purchase to individual" do
       user = create(:user)
       product = create(:screencast)
       stub_current_user_with(user)
 
       get :new, product_id: product
 
-      expect(assigns(:purchase).variant).to eq 'individual'
+      expect(assigns(:purchase).variant).to eq "individual"
     end
   end
 
-  describe '#new with company variant specified' do
-    it 'defaults purchase to company' do
+  describe "#new with company variant specified" do
+    it "defaults purchase to company" do
       user = create(:user)
       product = create(:screencast)
       stub_current_user_with(user)
 
-      get :new, product_id: product, variant: 'company'
+      get :new, product_id: product, variant: "company"
 
-      expect(assigns(:purchase).variant).to eq 'company'
+      expect(assigns(:purchase).variant).to eq "company"
     end
   end
 
-  describe '#new when attempting to purchase a workshop' do
-    it 'redirects to the subscription page' do
+  describe "#new when attempting to purchase a workshop" do
+    it "redirects to the subscription page" do
       user = create(:user)
       workshop = create(:workshop)
       stub_current_user_with(user)
@@ -77,19 +143,25 @@ describe PurchasesController do
     end
   end
 
-  describe 'processing on stripe' do
-    it 'creates and saves a stripe customer and charges it for the product' do
+  describe "processing on stripe" do
+    it "creates and saves a stripe customer and charges it for the product" do
       stub_current_user_with(create(:user))
       product = create(:product)
-      stripe_token = 'token'
+      stripe_token = "token"
 
-      post :create, purchase: customer_params(stripe_token), product_id: product.to_param
+      post(
+        :create,
+        purchase: customer_params(stripe_token),
+        product_id: product.to_param
+      )
 
-      FakeStripe.should have_charged(1500).to('test@example.com').with_token(stripe_token)
+      FakeStripe.should(
+        have_charged(1500).to("test@example.com").with_token(stripe_token)
+      )
     end
   end
 
-  it 'sets flash[:purchase_paid_price]' do
+  it "sets flash[:purchase_paid_price]" do
     stub_current_user_with(create(:user))
     product = create(:product)
 
@@ -103,7 +175,16 @@ describe PurchasesController do
       stub_current_user_with(create(:user))
       product = create(:product)
 
-      post :create, purchase: { variant: "individual", name: "User", email: "test@example.com", payment_method: "paypal" }, product_id: product.to_param
+      post(
+        :create,
+        purchase: {
+          variant: "individual",
+          name: "User",
+          email: "test@example.com",
+          payment_method: "paypal"
+        },
+        product_id: product.to_param
+      )
 
       response.status.should == 302
       response.location.should == FakePaypal.outgoing_uri
@@ -126,13 +207,13 @@ describe PurchasesController do
     end
   end
 
-  describe 'purchasing a team plan when there is more than one' do
-    it 'uses the requested plan' do
+  describe "purchasing a team plan when there is more than one" do
+    it "uses the requested plan" do
       user = create(:user)
       stub_current_user_with(user)
 
-      create(:team_plan, sku: 'sku1')
-      desired_plan = create(:team_plan, sku: 'sku2')
+      create(:team_plan, sku: "sku1")
+      desired_plan = create(:team_plan, sku: "sku2")
 
       get :new, teams_team_plan_id: desired_plan.sku
 
@@ -140,16 +221,16 @@ describe PurchasesController do
     end
   end
 
-  describe '#show' do
-    it 'should response with 404 if no purchase found' do
+  describe "#show" do
+    it "should response with 404 if no purchase found" do
       expect{
-        get :show, id: 'robots.txt'
+        get :show, id: "robots.txt"
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
-  describe '#index' do
-    it 'assigns paid purchases belonging to the current user' do
+  describe "#index" do
+    it "assigns paid purchases belonging to the current user" do
       user = create(:user, :with_github)
       purchase_two = create(
         :paid_purchase,
@@ -172,10 +253,10 @@ describe PurchasesController do
     end
   end
 
-  def customer_params(token='stripe token')
+  def customer_params(token = "stripe token")
     {
-      name: 'User',
-      email: 'test@example.com',
+      name: "User",
+      email: "test@example.com",
       variant: "individual",
       stripe_token: token,
       payment_method: "stripe"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -142,6 +142,14 @@ FactoryGirl.define do
     trait :includes_mentor do
       includes_mentor true
     end
+
+    trait :includes_screencasts do
+      includes_screencasts true
+    end
+
+    trait :includes_books do
+      includes_books true
+    end
   end
 
   factory :invitation, class: 'Teams::Invitation' do
@@ -289,9 +297,25 @@ FactoryGirl.define do
     factory :subscriber do
       with_subscription
 
+      factory :basic_subscriber do
+        plan { create(:basic_plan) }
+      end
+
       trait :includes_mentor do
         ignore do
           plan { create(:individual_plan, :includes_mentor) }
+        end
+      end
+
+      trait :includes_screencasts do
+        ignore do
+          plan { create(:individual_plan, :includes_screencasts) }
+        end
+      end
+
+      trait :includes_books do
+        ignore do
+          plan { create(:individual_plan, :includes_books) }
         end
       end
     end

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -43,7 +43,7 @@ describe Mentor do
       mentor = create(:mentor)
       active = create(:subscriber, :includes_mentor)
       inactive = create(:user, :with_inactive_subscription)
-      without_mentoring = create(:user, :with_basic_subscription)
+      without_mentoring = create(:basic_subscriber)
       mentor.mentees = [active, inactive, without_mentoring]
 
       expect(mentor.active_mentees).to eq [active]

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -60,7 +60,7 @@ describe UserSerializer do
 
   context 'when the user has subscription without access to forum' do
     it 'includes a key denying forum access' do
-      user = create(:user, :with_basic_subscription).reload
+      user = create(:basic_subscriber)
 
       user_json = parse_serialized_json(user)
 

--- a/spec/views/subscriber_licenses/_subscriber_license.html.erb_spec.rb
+++ b/spec/views/subscriber_licenses/_subscriber_license.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe "subscriber_licenses/_subscriber_license.html.erb" do
+  context "with a plan that has includes the purchaseable" do
+    it "renders a free message" do
+      stub_product_and_subscriber_license
+      stub_plan_to_include_purchaseable
+
+      render "subscriber_licenses/subscriber_license"
+
+      expect(rendered).to include(
+        html_escape(t("products.show.free_to_subscribers"))
+      )
+    end
+  end
+
+  context "with a plan that does not have access to the purchaseable" do
+    it "does not render a free message" do
+      stub_product_and_subscriber_license
+      stub_plan_to_not_include_purchaseable
+
+      render "subscriber_licenses/subscriber_license"
+
+      expect(rendered).not_to include(
+        html_escape(t("products.show.free_to_subscribers"))
+      )
+    end
+  end
+
+  def stub_plan_to_include_purchaseable
+    view_stubs(:included_in_current_users_plan?).returns(true)
+  end
+
+  def stub_plan_to_not_include_purchaseable
+    view_stubs(:included_in_current_users_plan?).returns(false)
+  end
+
+  def stub_product_and_subscriber_license
+    view_stubs(:product).returns(build_stubbed(:product))
+    view_stubs(:subscriber_license).returns(SubscriberLicense.new({}))
+  end
+end


### PR DESCRIPTION
- https://trello.com/c/RBd8oC6R
- Users who don't have the have the offering type included
  in their plan will be redirected to upgrade their subscription.
- Updated views to show "Upgrade Your Plan" buttons instead of
  'Get This Foo' buttons for users with plans that don't include
  the purchaseable type
