### PR TITLE
User methods now use the active subscription

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -362,10 +362,27 @@ FactoryGirl.define do
     trait :with_inactive_subscription do
       with_mentor
       with_github
-      stripe_customer_id 'cus12345'
+      stripe_customer_id "cus12345"
 
       after :create do |instance|
-        create(:inactive_subscription, user: instance)
+        instance.purchased_subscription =
+          create(:inactive_subscription, user: instance)
+      end
+    end
+
+    trait :with_inactive_team_subscription do
+      with_mentor
+      with_github
+      stripe_customer_id 'cus12345'
+      team
+
+      after :create do |instance|
+        create(
+          :inactive_subscription,
+          user: instance,
+          plan: create(:team_plan),
+          team: instance.team
+        )
       end
     end
 
@@ -373,12 +390,14 @@ FactoryGirl.define do
       with_mentor
       with_github
       stripe_customer_id 'cus12345'
+      team
 
       after :create do |instance|
         create(
           :subscription,
           user: instance,
-          plan: create(:team_plan)
+          plan: create(:team_plan),
+          team: instance.team
         )
       end
     end


### PR DESCRIPTION
- Fixes bug: https://trello.com/c/leM5vSoV
- We almost always only care about a User's subscription if it is active
- If the user's purchased_subscription is not active, then fallback to
  the active team subscription
- User#plan returns nil unless the plan if its associated subscription is
  active
- User#inactive_subscription is called to conditionally show the user
  info about their deactivated subscription. We don't want to message
  them at all if they have any active subscriptions (individually or via
  a team plan)
- User#has_access_to? can no longer return true for inactive
  subscriptions
