### PR TITLE
Only send Slack notifications after build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script:
 notifications:
   slack:
     secure: TWlhDWFpPYyTd8syhLf7QqRDmzVcnTJa4m05jsDxzg4FWj+yHInx5DZY+eUWRI0BfVt7sypISR1MlueLybRWzO8sapF4URaY2GeGeJyi9J8UzrsU/01Rt2gZpkX6Su4gEZKQSaLRTwHTaITD6xfa7mb1pwMyLBateGm4INF9Rkg=
+    on_success: change
+    on_failure: always
 branches:
   only:
   - master


### PR DESCRIPTION
- Notify when the build fails
- Notify when the build is fixed
