### PR TITLE
Fix bug where users were downgrading to prime basic

### DIFF
--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -1,5 +1,4 @@
 class IndividualPlan < ActiveRecord::Base
-  PRIME_BASIC_SKU = 'prime-basic'
   PRIME_249_SKU = 'prime-249'
   PRIME_99_SKU = 'prime-99'
   PRIME_49_SKU = 'prime-49'
@@ -26,7 +25,7 @@ class IndividualPlan < ActiveRecord::Base
   end
 
   def self.basic
-    where(sku: PRIME_BASIC_SKU).first
+    where(sku: PRIME_29_SKU).first
   end
 
   def self.popular

--- a/app/views/subscriber/cancellations/new.html.erb
+++ b/app/views/subscriber/cancellations/new.html.erb
@@ -4,10 +4,9 @@
       <p>
         We're sorry to hear you want to cancel. Before we remove the
         subscription from your account, we want to make sure you know about the
-        option to switch to a lower priced plan: Prime Basic is everything in
-        <%= t('shared.subscription.name') %> except for a mentor and workshops.
-        You still get books, screencasts, office hours, the forum, and you'll
-        also continue to have access to the workshops you've already taken, for
+        option to switch to a lower priced plan: with 30 Minutes a Week you'll
+        still be able to watch The Weekly Iteration, and you'll also continue to
+        have access to the <%= link_to "workshops you've already taken", purchases_path %> for
         <%= individual_price_per_month(@cancellation.downgrade_plan) %> instead of
         <%= individual_price_per_month(@cancellation.subscribed_plan) %>.
       </p>
@@ -32,7 +31,7 @@
     <% end %>
   </article>
   <%= form_for(
-    :cancellation, 
+    :cancellation,
     url: [:subscriber, :cancellation],
     html: { class: 'cancellation-feedback' }
   ) do |form| %>

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -102,7 +102,7 @@ namespace :dev do
 
   def create_individual_plans
     [29, 49, 249].each do |n|
-      FactoryGirl.create(:plan, sku: "prime_#{n}", individual_price: n)
+      FactoryGirl.create(:plan, sku: "prime-#{n}", individual_price: n)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -129,7 +129,7 @@ FactoryGirl.define do
     description 'A long description'
 
     factory :basic_plan do
-      sku IndividualPlan::PRIME_BASIC_SKU
+      sku IndividualPlan::PRIME_29_SKU
       includes_books false
       includes_exercises false
       includes_forum false

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -118,7 +118,7 @@ describe 'Videos' do
     end
 
     it 'provides RSS to distribute the Weekly Iteration to various channels' do
-      create(:plan, sku: IndividualPlan::PRIME_BASIC_SKU)
+      create(:plan, sku: IndividualPlan::PRIME_29_SKU)
       show = create(
         :show,
         name: Show::THE_WEEKLY_ITERATION,

--- a/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
+++ b/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
@@ -4,7 +4,7 @@ feature 'Visitor' do
   scenario 'views Weekly Iteration episodes' do
     show_name = Show::THE_WEEKLY_ITERATION
     show = create(:show, name: show_name)
-    create(:individual_plan, sku: IndividualPlan::PRIME_BASIC_SKU)
+    create(:individual_plan, sku: IndividualPlan::PRIME_29_SKU)
     published_video_title = 'Unfriendly Nil'
     published_video_notes = 'Nil is contagious.'
     create(


### PR DESCRIPTION
- Redefine `IndividualPlan.basic` to refer to the new $29 plan
- Replace all occurrences of PRIME_BASIC_SKU with PRIME_29_SKU
- Give users the option of downgrading to the $29 plan when they go
  to cancel a more expensive plan

https://trello.com/c/3FB7jP9S
