### PR TITLE
Feature fulfillment when subscribing/unsubcribing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,11 +31,6 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user_has_access_to_workshops?
 
-  def current_user_has_access_to_shows?
-    current_user && current_user.has_access_to_shows?
-  end
-  helper_method :current_user_has_access_to_shows?
-
   def subscription_includes_mentor?
     current_user.has_subscription_with_mentor?
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,6 +4,6 @@ class Book < Product
   end
 
   def included_in_plan?(plan)
-    plan.includes_books?
+    plan.has_feature?(:books)
   end
 end

--- a/app/models/feature_fulfillment.rb
+++ b/app/models/feature_fulfillment.rb
@@ -1,0 +1,32 @@
+# Responsible for fulfilling and unfulfilling features after a user subscribes,
+# cancels, or changes their plan
+class FeatureFulfillment
+  def initialize(new_plan:, old_plan:, user:)
+    @feature_factory = Features::Factory.new(user: user)
+    @plan_comparer = PlanComparer.new(new_plan: new_plan, old_plan: old_plan)
+  end
+
+  def fulfill_gained_features
+    gained_features.each(&:fulfill)
+  end
+
+  def unfulfill_lost_features
+    lost_features.each(&:unfulfill)
+  end
+
+  private
+
+  attr_reader :feature_factory, :plan_comparer
+
+  def gained_features
+    plan_comparer.features_gained.map do |feature_string|
+      feature_factory.new(feature_string)
+    end
+  end
+
+  def lost_features
+    plan_comparer.features_lost.map do |feature_string|
+      feature_factory.new(feature_string)
+    end
+  end
+end

--- a/app/models/features/factory.rb
+++ b/app/models/features/factory.rb
@@ -1,0 +1,38 @@
+module Features
+  class Factory
+    GENERIC_FEATURES = %w(
+      books
+      exercises
+      forum
+      office_hours
+      screencasts
+      shows
+      workshops
+    )
+    FULFILLABLE_FEATURES = %w(mentor source_code)
+    ALL_FEATURES = GENERIC_FEATURES + FULFILLABLE_FEATURES
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def new(feature_string_or_symbol)
+      @feature_string = feature_string_or_symbol.to_s
+      feature_class.new(user: @user)
+    end
+
+    private
+
+    def feature_class
+      if generic_feature?
+        Features::Generic
+      else
+        "Features::#{@feature_string.classify}".constantize
+      end
+    end
+
+    def generic_feature?
+      @feature_string.in? GENERIC_FEATURES
+    end
+  end
+end

--- a/app/models/features/generic.rb
+++ b/app/models/features/generic.rb
@@ -1,0 +1,13 @@
+# Used for features with no custom fulfilling/unfulfilling logic
+module Features
+  class Generic
+    def initialize(*args)
+    end
+
+    def fulfill
+    end
+
+    def unfulfill
+    end
+  end
+end

--- a/app/models/features/mentor.rb
+++ b/app/models/features/mentor.rb
@@ -1,0 +1,19 @@
+module Features
+  class Mentor
+    def initialize(user:)
+      @user = user
+    end
+
+    def fulfill
+      user.assign_mentor(mentor) unless user.mentor
+    end
+
+    private
+
+    attr_reader :user
+
+    def mentor
+      ::Mentor.random
+    end
+  end
+end

--- a/app/models/features/source_code.rb
+++ b/app/models/features/source_code.rb
@@ -1,0 +1,21 @@
+module Features
+  class SourceCode
+    GITHUB_TEAM = 516450
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def fulfill
+      GithubFulfillmentJob.enqueue(GITHUB_TEAM, [user.github_username])
+    end
+
+    def unfulfill
+      GithubRemovalJob.enqueue(GITHUB_TEAM, [user.github_username])
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/models/individual_plan.rb
+++ b/app/models/individual_plan.rb
@@ -80,6 +80,10 @@ class IndividualPlan < ActiveRecord::Base
     false
   end
 
+  def has_feature?(feature)
+    public_send("includes_#{feature}?")
+  end
+
   private
 
   def stripe_plan

--- a/app/models/null_plan.rb
+++ b/app/models/null_plan.rb
@@ -1,0 +1,6 @@
+# Represents the lack of a plan, i.e. a plan with no features
+class NullPlan
+  def has_feature?(feature)
+    false
+  end
+end

--- a/app/models/plan_comparer.rb
+++ b/app/models/plan_comparer.rb
@@ -1,0 +1,28 @@
+# For calculating which features have been gained or lost when
+# a user changes plans
+class PlanComparer
+  def initialize(new_plan:, old_plan:)
+    @old_plan = old_plan
+    @new_plan = new_plan
+  end
+
+  def features_gained
+    all_features.select do |feature|
+      !@old_plan.has_feature?(feature) &&
+        @new_plan.has_feature?(feature)
+    end
+  end
+
+  def features_lost
+    all_features.select do |feature|
+      @old_plan.has_feature?(feature) &&
+        !@new_plan.has_feature?(feature)
+    end
+  end
+
+  private
+
+  def all_features
+    Features::Factory::ALL_FEATURES
+  end
+end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -39,7 +39,6 @@ class Purchase < ActiveRecord::Base
     allow_nil: true
   delegate(
     :fulfilled_with_github?,
-    :includes_mentor?,
     :subscription?,
     :terms,
     to: :purchaseable

--- a/app/models/screencast.rb
+++ b/app/models/screencast.rb
@@ -4,6 +4,6 @@ class Screencast < Product
   end
 
   def included_in_plan?(plan)
-    plan.includes_screencasts?
+    plan.has_feature?(:screencasts)
   end
 end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -6,7 +6,7 @@ class Show < Product
   end
 
   def included_in_plan?(plan)
-    plan.includes_shows?
+    plan.has_feature?(:shows)
   end
 
   private

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,8 +5,6 @@ class Subscription < ActiveRecord::Base
 
   has_one :team, dependent: :destroy, class_name: 'Teams::Team'
 
-  delegate :includes_mentor?, to: :plan
-  delegate :includes_workshops?, to: :plan
   delegate :name, to: :plan, prefix: true
   delegate :stripe_customer_id, to: :user
 
@@ -56,13 +54,13 @@ class Subscription < ActiveRecord::Base
   end
 
   def deliver_welcome_email
-    if includes_mentor?
+    if has_access_to?(:mentor)
       SubscriptionMailer.welcome_to_prime_from_mentor(user).deliver
     end
   end
 
   def has_access_to?(feature)
-    active? && plan.public_send("includes_#{feature}?")
+    active? && plan.has_feature?(feature)
   end
 
   def purchase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,10 +67,6 @@ class User < ActiveRecord::Base
     subscription.present?
   end
 
-  def has_access_to_shows?
-    has_active_subscription?
-  end
-
   def has_access_to?(feature)
     subscription && subscription.has_access_to?(feature)
   end
@@ -90,7 +86,7 @@ class User < ActiveRecord::Base
   end
 
   def has_subscription_with_mentor?
-    has_active_subscription? && subscription.try(:includes_mentor?)
+    has_access_to?(:mentor)
   end
 
   def plan_name

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -104,6 +104,6 @@ class Workshop < ActiveRecord::Base
   end
 
   def included_in_plan?(plan)
-    plan.includes_workshops?
+    plan.has_feature?(:workshops)
   end
 end

--- a/app/modules/teams/team_plan.rb
+++ b/app/modules/teams/team_plan.rb
@@ -51,5 +51,9 @@ module Teams
     def included_in_plan?(plan)
       false
     end
+
+    def has_feature?(feature)
+      public_send("includes_#{feature}?")
+    end
   end
 end

--- a/app/views/purchase_mailer/_receipt_subscription_intro.text.erb
+++ b/app/views/purchase_mailer/_receipt_subscription_intro.text.erb
@@ -1,11 +1,11 @@
 Thank you for subscribing to <%= purchase.purchaseable_name %>!
 
-<%- if purchase.purchaseable.includes_mentor? -%>
+<%- if purchase.purchaseable.has_feature?(:mentor) -%>
 You will receive an email from your mentor soon.
 <%- end -%>
 
 In the meantime, one of the first things you might do is visit our Trail Maps
-<%- if purchase.purchaseable.includes_workshops? -%>
+<%- if purchase.purchaseable.has_feature?(:workshops) -%>
 and check off your skills to determine which workshops are right for you:
 <%- else -%>
 and check off your skills to identify new things to learn:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -150,6 +150,10 @@ FactoryGirl.define do
     trait :includes_books do
       includes_books true
     end
+
+    trait :no_mentor do
+      includes_mentor false
+    end
   end
 
   factory :invitation, class: 'Teams::Invitation' do
@@ -186,6 +190,14 @@ FactoryGirl.define do
     individual_price 89
     name 'Workshops for Teams'
     sku 'team_plan'
+
+    trait :includes_mentor do
+      includes_mentor true
+    end
+
+    trait :no_mentor do
+      includes_mentor false
+    end
   end
 
   factory :team, class: 'Teams::Team' do
@@ -344,8 +356,12 @@ FactoryGirl.define do
       end
 
       after :create do |instance, attributes|
-        instance.purchased_subscription =
-          create(:subscription, plan: attributes.plan, user: instance)
+        instance.purchased_subscription = create(
+          :subscription,
+          :purchased,
+          plan: attributes.plan,
+          user: instance
+        )
       end
     end
 
@@ -413,6 +429,16 @@ FactoryGirl.define do
 
     factory :inactive_subscription do
       deactivated_on { Time.zone.today }
+    end
+
+    trait :purchased do
+      after :create do |subscription|
+        create(
+          :plan_purchase,
+          purchaseable: subscription.plan,
+          user: subscription.user
+        )
+      end
     end
   end
 

--- a/spec/features/user_updates_credit_card_spec.rb
+++ b/spec/features/user_updates_credit_card_spec.rb
@@ -15,9 +15,9 @@ feature 'User updated credit card' do
   end
 
   scenario 'updates Stripe subscription with declining credit card', js: true do
-    FakeStripe.failure = true
     sign_in_as_user_with_subscription
     visit my_account_path
+    FakeStripe.failure = true
     submit_declining_credit_card_info
 
     expect(current_path).to eq my_account_path

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -195,7 +195,7 @@ describe Cancellation do
   end
 
   def subscription
-    @subscription ||= create(:subscription)
+    @subscription ||= create(:subscription, :purchased)
   end
 
   def cancellation

--- a/spec/models/feature_fulfillment_spec.rb
+++ b/spec/models/feature_fulfillment_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe FeatureFulfillment do
+  describe "#fulfill_gained_features" do
+    it "calls #fulfill on each gained feature" do
+      old_plan = build_stubbed(:plan, :no_mentor)
+      new_plan = build_stubbed(:plan, :includes_mentor)
+      mentor_feature = stub_mentor_feature
+
+      FeatureFulfillment.new(
+        new_plan: new_plan,
+        old_plan: old_plan,
+        user: build_stubbed(:user)
+      ).fulfill_gained_features
+
+      expect(mentor_feature).to have_received(:fulfill)
+    end
+  end
+
+  describe "#unfulfill_lost_features" do
+    it "calls #unfulfill on each lost feature" do
+      old_plan = create(:plan, :includes_mentor)
+      new_plan = create(:plan, :no_mentor)
+      mentor_feature = stub_mentor_feature
+
+      FeatureFulfillment.new(
+        new_plan: new_plan,
+        old_plan: old_plan,
+        user: build_stubbed(:user)
+      ).unfulfill_lost_features
+
+      expect(mentor_feature).to have_received(:unfulfill)
+    end
+  end
+
+  def stub_mentor_feature
+    stub(fulfill: nil, unfulfill: nil).tap do |mentor_feature|
+      Features::Mentor.stubs(:new).returns(mentor_feature)
+    end
+  end
+end

--- a/spec/models/features/factory_spec.rb
+++ b/spec/models/features/factory_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Features::Factory do
+  describe "#new" do
+    it "returns a specific instance for features with custom fulfillment" do
+      factory = Features::Factory.new(user: build_stubbed(:user))
+      expect(factory.new(:mentor)).to be_kind_of(Features::Mentor)
+    end
+
+    it "returns a generic instance for features without custom fulfillment" do
+      factory = Features::Factory.new(user: build_stubbed(:user))
+      expect(factory.new(:books)).to be_kind_of(Features::Generic)
+    end
+
+    it "works with string input" do
+      factory = Features::Factory.new(user: build_stubbed(:user))
+      expect(factory.new("mentor")).to be_kind_of(Features::Mentor)
+    end
+  end
+end

--- a/spec/models/features/mentor_spec.rb
+++ b/spec/models/features/mentor_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Features::Mentor do
+  describe "#fulfill" do
+    it "assigns a mentor to the user if they don't have one already" do
+      mentor = build_stubbed(:mentor)
+      Mentor.stubs(:random).returns(mentor)
+      user = build_stubbed(:user)
+      user.stubs(:assign_mentor)
+
+      Features::Mentor.new(user: user).fulfill
+
+      expect(user).to have_received(:assign_mentor).with(mentor)
+    end
+
+    it "doesn't assign a new mentor if the user already has one" do
+      user = build_stubbed(:user, :with_mentor)
+      user.stubs(:assign_mentor)
+
+      Features::Mentor.new(user: user).fulfill
+
+      expect(user).to have_received(:assign_mentor).never
+    end
+  end
+end

--- a/spec/models/features/source_code_spec.rb
+++ b/spec/models/features/source_code_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Features::SourceCode do
+  describe "#fulfill" do
+    it "adds the user to the subscriber github team" do
+      GithubFulfillmentJob.stubs(:enqueue)
+      user = build_stubbed(:user, :with_github)
+      Features::SourceCode.new(user: user).fulfill
+
+      GithubFulfillmentJob.should have_received(:enqueue).
+        with(Features::SourceCode::GITHUB_TEAM, [user.github_username])
+    end
+  end
+
+  describe "#unfulfill" do
+    it "removes the user from the subscriber github team" do
+      GithubRemovalJob.stubs(:enqueue)
+      user = build_stubbed(:user, :with_github)
+      Features::SourceCode.new(user: user).unfulfill
+
+      GithubRemovalJob.should have_received(:enqueue).
+        with(Features::SourceCode::GITHUB_TEAM, [user.github_username])
+    end
+  end
+end

--- a/spec/models/individual_plan_spec.rb
+++ b/spec/models/individual_plan_spec.rb
@@ -138,6 +138,23 @@ describe IndividualPlan do
     end
   end
 
+  describe "#has_feature?" do
+    it "returns true if the plan has the feature" do
+      plan = build_stubbed(:individual_plan, :includes_mentor)
+      expect(plan.has_feature?(:mentor)).to be_true
+    end
+
+    it "returns false if the plan does not have the feature" do
+      plan = build_stubbed(:individual_plan, :no_mentor)
+      expect(plan.has_feature?(:mentor)).to be_false
+    end
+
+    it "raises an exception with an invalid feature name" do
+      plan = build_stubbed(:individual_plan)
+      expect{ plan.has_feature?(:foo) }.to raise_error
+    end
+  end
+
   def create_inactive_subscription_for(plan)
     create(:inactive_subscription, plan: plan)
   end

--- a/spec/models/plan_comparer_spec.rb
+++ b/spec/models/plan_comparer_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe PlanComparer do
+  describe "#features_gained" do
+    it "returns features the new plan has and the old plan doesn't have" do
+      old_plan = build_stubbed(:plan, :no_mentor)
+      new_plan = build_stubbed(:plan, :includes_mentor)
+      comparer = PlanComparer.new(old_plan: old_plan, new_plan: new_plan)
+      expect(comparer.features_gained).to eq(['mentor'])
+    end
+
+    it "returns an empty array when no features are gained" do
+      old_plan = build_stubbed(:plan, :no_mentor)
+      new_plan = build_stubbed(:plan, :no_mentor)
+      comparer = PlanComparer.new(old_plan: old_plan, new_plan: new_plan)
+      expect(comparer.features_gained).to eq([])
+    end
+  end
+
+  describe "#features_lost" do
+    it "returns features that the old plan has and the new plan doesn't have" do
+      old_plan = build_stubbed(:plan, :includes_mentor)
+      new_plan = build_stubbed(:plan, :no_mentor)
+      comparer = PlanComparer.new(old_plan: old_plan, new_plan: new_plan)
+      expect(comparer.features_lost).to eq(["mentor"])
+    end
+
+    it "returns an empty array when no features are lost" do
+      old_plan = build_stubbed(:plan, :includes_mentor)
+      new_plan = build_stubbed(:plan, :includes_mentor)
+      comparer = PlanComparer.new(old_plan: old_plan, new_plan: new_plan)
+      expect(comparer.features_lost).to eq([])
+    end
+  end
+end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -15,7 +15,6 @@ describe Purchase do
     it { should_not validate_presence_of(:user_id) }
 
     it { should delegate(:subscription?).to(:purchaseable) }
-    it { should delegate(:includes_mentor?).to(:purchaseable) }
   end
 
   context '#price' do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -6,8 +6,6 @@ describe Subscription do
   it { should belong_to(:user) }
 
   it { should delegate(:stripe_customer_id).to(:user) }
-  it { should delegate(:includes_mentor?).to(:plan) }
-  it { should delegate(:includes_workshops?).to(:plan) }
 
   it { should validate_presence_of(:plan_id) }
   it { should validate_presence_of(:plan_type) }
@@ -74,7 +72,7 @@ describe Subscription do
 
   describe '#deactivate' do
     it "updates the subscription record by setting deactivated_on to today" do
-      subscription = create(:active_subscription)
+      subscription = create(:active_subscription, :purchased)
 
       subscription.deactivate
       subscription.reload

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -441,36 +441,6 @@ describe User do
     end
   end
 
-  describe '#has_access_to_shows?' do
-    context 'when the user has an active subscription' do
-      it 'returns true' do
-        subscription = build_stubbed(:subscription)
-        subscription.stubs(:active?).returns(true)
-        user = build_stubbed(:user, subscription: subscription)
-
-        expect(user).to have_access_to_shows
-      end
-    end
-
-    context 'when the user has an inactive subscription' do
-      it 'returns true' do
-        subscription = build_stubbed(:subscription)
-        subscription.stubs(:active?).returns(false)
-        user = build_stubbed(:user, subscription: subscription)
-
-        expect(user).not_to have_access_to_shows
-      end
-    end
-
-    context 'when the user does not have a subscription' do
-      it 'returns false' do
-        user = build_stubbed(:user)
-
-        expect(user).not_to have_access_to_shows
-      end
-    end
-  end
-
   describe '#has_access_to?' do
     context 'when the user does not have a subscription' do
       it 'returns false' do

--- a/spec/modules/teams/team_plan_spec.rb
+++ b/spec/modules/teams/team_plan_spec.rb
@@ -110,6 +110,23 @@ module Teams
       end
     end
 
+    describe "#has_feature?" do
+      it "returns true if the plan has the feature" do
+        plan = build_stubbed(:team_plan, :includes_mentor)
+        expect(plan.has_feature?(:mentor)).to be_true
+      end
+
+      it "returns false if the plan does not have the feature" do
+        plan = build_stubbed(:team_plan, :no_mentor)
+        expect(plan.has_feature?(:mentor)).to be_false
+      end
+
+      it "raises an exception with an invalid feature name" do
+        plan = build_stubbed(:team_plan)
+        expect{ plan.has_feature?(:foo) }.to raise_error
+      end
+    end
+
     def team_plan
       build(:team_plan)
     end


### PR DESCRIPTION
- https://trello.com/c/cWPrkqwy
- This will make it easier to migrate a user between plans (give/revoke
  access to Learn repo, assign a mentor, etc.). See https://trello.com/c/1glIjCSB for an example
- New classes for each feature that a plan can have access to. Implement
  #fulfill or #unfulfill methods on these feature classes as necessary
  to give/revoke access to resources related to the feature.  For features without custom fulfilling behavior, Features::GenericFeature class is used.
- These are now the standard ways to ask for access to a feature:
  - User#has_access_to?
  - Subscription#has_access_to?
  - IndividualPlan#has_feature?
  - Teams::TeamPlan#has_feature?
