### PR TITLE
Fix ./bin/setup error

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -358,6 +358,18 @@ FactoryGirl.define do
       after :create do |instance, attributes|
         instance.purchased_subscription = create(
           :subscription,
+          plan: attributes.plan,
+          user: instance
+        )
+      end
+    end
+
+    trait :with_subscription_purchase do
+      with_subscription
+
+      after :create do |instance, attributes|
+        instance.purchased_subscription = create(
+          :subscription,
           :purchased,
           plan: attributes.plan,
           user: instance

--- a/spec/requests/stripe_webhooks_spec.rb
+++ b/spec/requests/stripe_webhooks_spec.rb
@@ -53,7 +53,11 @@ describe 'Stripe webhooks' do
 
   describe 'customer.subscription.deleted' do
     it 'deactivates the subscription' do
-      user = create(:subscriber, stripe_customer_id: FakeStripe::CUSTOMER_ID)
+      user = create(
+        :subscriber,
+        :with_subscription_purchase,
+        stripe_customer_id: FakeStripe::CUSTOMER_ID
+      )
 
       simulate_stripe_webhook_firing(
         FakeStripe::EVENT_ID_FOR_SUBSCRIPTION_DELETION
@@ -63,7 +67,11 @@ describe 'Stripe webhooks' do
     end
 
     it 'responds with 200 OK' do
-      create(:subscriber, stripe_customer_id: FakeStripe::CUSTOMER_ID)
+      create(
+        :subscriber,
+        :with_subscription_purchase,
+        stripe_customer_id: FakeStripe::CUSTOMER_ID
+      )
 
       simulate_stripe_webhook_firing(
         FakeStripe::EVENT_ID_FOR_SUBSCRIPTION_DELETION


### PR DESCRIPTION
- Creating a Purchase associated with a subscription was causing
  bin/setup to raise ActiveRecord::RecordNotSaved because the
  Purchase#place_payment create callback was failing.
- Now, in order to create an actual Purchase record associated with a
  subscription, use the :with_subscription_purchase factory.
- For now, this is only necessary to set up for specs that cancel
  subscriptions.
