### PR TITLE
Reduce minimum TeamPlan members to 3

### DIFF
--- a/app/modules/teams/team_plan.rb
+++ b/app/modules/teams/team_plan.rb
@@ -36,7 +36,7 @@ module Teams
     end
 
     def minimum_quantity
-      5
+      3
     end
 
     def fulfill(purchase, user)

--- a/spec/modules/teams/team_plan_spec.rb
+++ b/spec/modules/teams/team_plan_spec.rb
@@ -65,10 +65,10 @@ module Teams
     end
 
     context '#minimum_quantity' do
-      it 'is 5' do
+      it "is 3" do
         team_plan = TeamPlan.new
 
-        expect(team_plan.minimum_quantity).to eq 5
+        expect(team_plan.minimum_quantity).to eq 3
       end
     end
 

--- a/spec/modules/teams/user_manages_team_subscription_spec.rb
+++ b/spec/modules/teams/user_manages_team_subscription_spec.rb
@@ -33,7 +33,7 @@ feature 'User creates a team subscription' do
 
     visit_team_plan_purchase_page
 
-    expect_submit_button_to_contain("$445 per month")
+    expect_submit_button_to_contain_default_text
 
     select requested_quantity, from: 'Number of team members'
 
@@ -50,11 +50,11 @@ feature 'User creates a team subscription' do
 
     visit_team_plan_purchase_page
 
-    expect_submit_button_to_contain("$445 per month")
+    expect_submit_button_to_contain_default_text
 
     apply_coupon_with_code('5OFF')
 
-    expect_submit_button_to_contain discount_text('440.00', '445.00')
+    expect_submit_button_to_contain discount_text("262.00", "267.00")
 
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
@@ -95,11 +95,11 @@ feature 'User creates a team subscription' do
 
     visit_team_plan_purchase_page
 
-    expect_submit_button_to_contain("$445 per month")
+    expect_submit_button_to_contain_default_text
 
     apply_coupon_with_code('5OFF')
 
-    expect_submit_button_to_contain discount_text('440.00', '445.00')
+    expect_submit_button_to_contain discount_text("262.00", "267.00")
 
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
@@ -111,7 +111,7 @@ feature 'User creates a team subscription' do
   scenario 'tries to subscribe with an invalid coupon', :js => true do
     visit_team_plan_purchase_page
 
-    expect_submit_button_to_contain('$445 per month')
+    expect_submit_button_to_contain_default_text
 
     apply_coupon_with_code('5OFF')
 
@@ -156,5 +156,9 @@ feature 'User creates a team subscription' do
       '.subscription p strong',
       text: plan.name
     )
+  end
+
+  def expect_submit_button_to_contain_default_text
+    expect_submit_button_to_contain("$267 per month")
   end
 end


### PR DESCRIPTION
I'd much rather give a team of 3 a discounted rate and have them on one
corporate card/subscription than tell them to get their own accounts
which might never happen, might lapse, etc.
