### PR TITLE
Fix errors from already deactivated subscriptions

### DIFF
--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -16,9 +16,11 @@ class Cancellation
   end
 
   def process
-    @subscription.deactivate
-    deliver_unsubscription_survey
-    unsubscribe_from_analytics
+    if @subscription.active?
+      @subscription.deactivate
+      deliver_unsubscription_survey
+      unsubscribe_from_analytics
+    end
   end
 
   def can_downgrade_instead?

--- a/config/initializers/stripe_event.rb
+++ b/config/initializers/stripe_event.rb
@@ -9,7 +9,7 @@ StripeEvent.setup do
     stripe_customer_id = event.data.object.customer
 
     if user = User.find_by_stripe_customer_id(stripe_customer_id)
-      cancellation = Cancellation.new(user.subscription)
+      cancellation = Cancellation.new(user.purchased_subscription)
       cancellation.process
     end
   end

--- a/spec/requests/stripe_webhooks_spec.rb
+++ b/spec/requests/stripe_webhooks_spec.rb
@@ -52,7 +52,7 @@ describe 'Stripe webhooks' do
   end
 
   describe 'customer.subscription.deleted' do
-    it 'deactivates the subscription' do
+    it "deactivates an active subscription" do
       user = create(
         :subscriber,
         :with_subscription_purchase,
@@ -64,14 +64,16 @@ describe 'Stripe webhooks' do
       )
 
       expect(user.reload).not_to have_active_subscription
+      expect(response).to be_success
     end
 
-    it 'responds with 200 OK' do
-      create(
+    it "accepts an inactive subscription without error" do
+      user = create(
         :subscriber,
         :with_subscription_purchase,
         stripe_customer_id: FakeStripe::CUSTOMER_ID
       )
+      user.subscription.deactivate
 
       simulate_stripe_webhook_firing(
         FakeStripe::EVENT_ID_FOR_SUBSCRIPTION_DELETION


### PR DESCRIPTION
- Stripe is sending events for users which have already deactivated
- These events caused errors because `User#subscription` was `nil`
- Also ensure that emails are only delievered once

https://trello.com/c/YBIYvRGn/67-errors-while-deactivating-subscriptions
