### PR TITLE
Fix errors from subscriptions without Stripe customer

### DIFF
--- a/app/models/subscription_upcoming_invoice_updater.rb
+++ b/app/models/subscription_upcoming_invoice_updater.rb
@@ -5,8 +5,10 @@ class SubscriptionUpcomingInvoiceUpdater
 
   def process
     @subscriptions.each do |subscription|
-      upcoming_invoice = upcoming_invoice_for(subscription.stripe_customer_id)
-      update_next_payment_information(subscription, upcoming_invoice)
+      if subscription.stripe_customer_id
+        upcoming_invoice = upcoming_invoice_for(subscription.stripe_customer_id)
+        update_next_payment_information(subscription, upcoming_invoice)
+      end
     end
   end
 

--- a/spec/models/subscription_upcoming_invoice_updater_spec.rb
+++ b/spec/models/subscription_upcoming_invoice_updater_spec.rb
@@ -31,6 +31,15 @@ describe SubscriptionUpcomingInvoiceUpdater do
     expect(subscription.next_payment_on).to be_nil
   end
 
+  it "doesn't raise errors for subscriptions without customer IDs" do
+    subscription = build_stubbed(:subscription)
+    subscription.stubs(:stripe_customer_id).returns(nil)
+    subscriptions = [subscription]
+
+    expect { SubscriptionUpcomingInvoiceUpdater.new(subscriptions).process }.
+      not_to raise_error
+  end
+
   it "sends the error to Airbrake if it isn't 404" do
     Airbrake.stubs(:notify)
     error = Stripe::InvalidRequestError.new('Server error', '', 500)


### PR DESCRIPTION
- We have subscriptions for users without a Stripe customer ID
- We attempt to find the Stripe invoice for every subscription
- This skips updating subscriptions without a Stripe customer ID
- Note: most of these users were thoughtbot employees

https://trello.com/c/F2g9e1IP/68-errors-while-updating-subscriptions
