### PR TITLE
Serve entypo via HTTPs

### DIFF
--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -114,7 +114,7 @@ hr {
   height: 2px;
 }
 
-@include font-face(entypo, '/assets/entypo/entypo');
+@include font-face(entypo, 'entypo/entypo', $asset-pipeline: true);
 .icon {
   font-family: "entypo";
   font-size: 25px;


### PR DESCRIPTION
See https://trello.com/c/gTE3OfPk/65-https-mixed-content-warning

Tested on staging and seems to be loading via cloud front properly.

![thoughtbot learn learn mapping 2014-07-16 10-31-26 2014-07-16 10-31-46](https://cloud.githubusercontent.com/assets/3948/3596349/a04a9ccc-0cc3-11e4-8b7e-43766a9dbf57.jpg)
