### PR TITLE
Extract references to Prime and Prime with Teams to translations

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -6,7 +6,7 @@ class SubscriptionMailer < BaseMailer
     mail(
       to: @user.email,
       bcc: @mentor.email,
-      subject: "Welcome to Prime! I'm your new mentor",
+      subject: t("mailers.subscription.welcome_from_mentor.subject"),
       from: mentor_email(@mentor),
       reply_to: mentor_email(@mentor)
     )
@@ -17,7 +17,7 @@ class SubscriptionMailer < BaseMailer
 
     mail(
       to: user.email,
-      subject: 'Suggestions for improving Prime'
+      subject: t("mailers.subscription.cancellation_survey.subject"),
     )
   end
 
@@ -27,7 +27,7 @@ class SubscriptionMailer < BaseMailer
 
     mail(
       to: email,
-      subject: '[Learn] Your receipt and some tips'
+      subject: t("mailers.subscription.subscription_receipt.subject"),
     )
   end
 
@@ -37,7 +37,8 @@ class SubscriptionMailer < BaseMailer
 
     mail(
       to: @user.email,
-      subject: '[Learn] thoughtbot is about to charge for your Learn Prime subscription'
+      subject:
+        t("mailers.subscription.upcoming_payment_notification.subject"),
     )
   end
 

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -32,9 +32,12 @@ class LineItem
 
   def subscription_description
     if canceled?
-      '(Canceled) Subscription to Prime'
+      I18n.t("line_item.canceled_description")
     else
-      "Subscription to #{stripe_line_item.plan.name}"
+      I18n.t(
+        "line_item.plan_description",
+        plan_name: stripe_line_item.plan.name
+      )
     end
   end
 

--- a/app/modules/teams/team_plan.rb
+++ b/app/modules/teams/team_plan.rb
@@ -15,7 +15,11 @@ module Teams
       if first
         first
       else
-        create!(sku: 'primeteam', name: 'Prime for Teams', individual_price: 0)
+        create!(
+          sku: 'primeteam',
+          name: I18n.t("shared.team_plan_name"),
+          individual_price: 0,
+        )
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,8 @@ en:
     subscriptions:
       icon: ✶
       user_required: ✶ Sign in or sign up to subscribe to Prime.
+    team_plan_name:
+      Prime for Teams
 
   topics:
     workshop:
@@ -211,3 +213,18 @@ en:
     thoughtbot_resources: Use these thoughtbot resources first
     other_resources: Use these resources for reference and additional practice
     validations: "%{name} developers should be able to"
+
+  mailers:
+    subscription:
+      cancellation_survey:
+        subject: Suggestions for improving Prime
+      subscription_receipt:
+        subject: "[Learn] Your receipt and some tips"
+      upcoming_payment_notification:
+        subject: "[Learn] thoughtbot is about to charge for your Learn Prime subscription"
+      welcome_from_mentor:
+        subject: Welcome to Prime! I'm your new mentor
+
+  line_item:
+    canceled_description: (Canceled) Subscription to Prime
+    plan_description: Subscription to %{plan_name}

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe HomesController do
-  it 'redirects to Prime if the visitor is not logged in' do
+  it 'redirects to the landing page if the visitor is not logged in' do
     get :show
 
     expect(response).to redirect_to prime_path

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -122,7 +122,7 @@ FactoryGirl.define do
   end
 
   factory :individual_plan, aliases: [:plan] do
-    name 'Prime'
+    name I18n.t("shared.subscription.name")
     individual_price 99
     sku "prime-99"
     short_description 'A great Subscription'

--- a/spec/features/subscriber_views_monthly_receipt_spec.rb
+++ b/spec/features/subscriber_views_monthly_receipt_spec.rb
@@ -36,7 +36,10 @@ feature 'Subscriber views subscription invoices' do
 
     expect(page).to have_content('Invoice 130521')
     expect(page).to have_content('Date 05/21/13')
-    expect(page).to have_css('.line-item', text: 'Subscription to Prime')
+    expect(page).to have_css(
+      '.line-item',
+      text: I18n.t("shared.subscription.name")
+    )
     expect(page).to have_css('.line-item', text: '$99.00 USD')
     expect(page).to have_css('.subtotal', text: '$99.00 USD')
     expect(page).to have_css('.discount', text: 'Discount: railsconf')

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -47,6 +47,15 @@ describe SubscriptionMailer do
       expect(email.body).to include(user.mentor.github_username)
     end
 
+    it "specifies the subject" do
+      user = user_with_mentor
+      email = welcome_email_for(user)
+
+      expect(email.subject).to eq(
+        I18n.t("mailers.subscription.welcome_from_mentor.subject")
+      )
+    end
+
     def user_with_mentor
       build_stubbed(:user, :with_mentor)
     end
@@ -63,6 +72,15 @@ describe SubscriptionMailer do
 
       expect(email.to).to include(user.email)
       expect(email).to have_body_text(/just canceled/)
+    end
+
+    it "specifies the subject" do
+      user = build_stubbed(:user)
+      email = SubscriptionMailer.cancellation_survey(user)
+
+      expect(email.subject).to eq(
+        I18n.t("mailers.subscription.cancellation_survey.subject")
+      )
     end
   end
 
@@ -83,6 +101,12 @@ describe SubscriptionMailer do
 
     it 'is sent from learn' do
       expect(subscription_receipt_email.from).to eq(%w(learn@thoughtbot.com))
+    end
+
+    it "specifies the subject" do
+      expect(subscription_receipt_email.subject).to eq(
+        I18n.t("mailers.subscription.subscription_receipt.subject")
+      )
     end
 
     def subscription_receipt_email
@@ -124,6 +148,12 @@ describe SubscriptionMailer do
       result = upcoming_payment_notification_email(subscription)
 
       expect(result).to have_body_text("$19.99")
+    end
+
+    it "specifies the subject" do
+      expect(upcoming_payment_notification_email.subject).to eq(
+        I18n.t("mailers.subscription.upcoming_payment_notification.subject")
+      )
     end
 
     def upcoming_payment_notification_email(subscription = nil)

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -48,7 +48,12 @@ describe LineItem do
           )
           line_item = LineItem.new(stripe_line_item)
 
-          expect(line_item.description).to eq('Subscription to Plan')
+          expect(line_item.description).to eq(
+            I18n.t(
+              "line_item.plan_description",
+              plan_name: stripe_line_item.plan.name
+            )
+          )
         end
       end
 
@@ -62,8 +67,9 @@ describe LineItem do
           )
           line_item = LineItem.new(stripe_line_item)
 
-          expect(line_item.description).
-            to eq('(Canceled) Subscription to Prime')
+          expect(line_item.description).to eq(
+            I18n.t("line_item.canceled_description")
+          )
         end
       end
     end

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -309,7 +309,7 @@ class FakeStripe < Sinatra::Base
             quantity: 1,
             plan: {
               interval: "month",
-              name: "Prime",
+              name: I18n.t("shared.subscription.name"),
               amount: 9900,
               currency: "usd",
               id: "prime",


### PR DESCRIPTION
This will make our upcoming rebranding to upcase.com easier.

A future pull will DRY our translations so that "Prime"/"Learn" only appear once.
