### PR TITLE
Page for viewing sent invitations and their status

### DIFF
--- a/app/assets/stylesheets/_teams-invitations-index.scss
+++ b/app/assets/stylesheets/_teams-invitations-index.scss
@@ -1,0 +1,5 @@
+body.teams-invitations-index {
+  table {
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -37,5 +37,6 @@
 @import "design-for-developers";
 @import "invoices";
 @import "cancellation";
+@import "teams-invitations-index";
 
 @import "prettify";

--- a/app/modules/teams/invitation.rb
+++ b/app/modules/teams/invitation.rb
@@ -11,6 +11,8 @@ module Teams
     belongs_to :sender, class_name: 'User'
     belongs_to :team
 
+    delegate :name, to: :recipient, prefix: true, allow_nil: true
+
     before_create :generate_code
 
     friendly_id :code, use: [:finders]

--- a/app/modules/teams/invitations_controller.rb
+++ b/app/modules/teams/invitations_controller.rb
@@ -2,6 +2,10 @@ module Teams
   class InvitationsController < ApplicationController
     before_filter :must_be_team_member
 
+    def index
+      @team = current_user.team
+    end
+
     def create
       if deliver_invitation
         redirect_with_notice

--- a/app/modules/teams/team.rb
+++ b/app/modules/teams/team.rb
@@ -5,6 +5,7 @@ module Teams
     belongs_to :team_plan
 
     has_many :users, dependent: :nullify
+    has_many :invitations
 
     validates :name, presence: true
 
@@ -22,6 +23,10 @@ module Teams
 
     def has_users_remaining?
       users.count < max_users
+    end
+
+    def has_invited_users?
+      invitations.any?
     end
 
     private

--- a/app/modules/teams/views/teams/invitations/_invitation_table_row.html.erb
+++ b/app/modules/teams/views/teams/invitations/_invitation_table_row.html.erb
@@ -1,0 +1,11 @@
+<% if invitation.accepted? %>
+  <tr class="accepted">
+    <td class="email"><%= invitation.email %></td>
+    <td class="status">Accepted by <%= invitation.recipient_name %></td>
+  </tr>
+<% else %>
+  <tr class="pending">
+    <td class="email"><%= invitation.email %></td>
+    <td class="status">Pending</td>
+  </tr>
+<% end %>

--- a/app/modules/teams/views/teams/invitations/_no_invitations.html.erb
+++ b/app/modules/teams/views/teams/invitations/_no_invitations.html.erb
@@ -1,0 +1,4 @@
+<div class="no-invitations">
+  <p>You haven't invited anyone yet.</p>
+  <p><%= link_to "Invite your first team member", edit_teams_team_path %></p>
+</div>

--- a/app/modules/teams/views/teams/invitations/index.html.erb
+++ b/app/modules/teams/views/teams/invitations/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, 'Invitations' %>
+<% content_for :subject_block do %>
+  <h1>Invitations</h1>
+<% end %>
+
+<div class="text-box-wrapper">
+  <div class="text-box">
+    <% if @team.has_invited_users? %>
+      <table>
+        <tr>
+          <th>Email</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+        <%= render partial: "teams/invitations/invitation_table_row",
+          collection: @team.invitations, as: :invitation %>
+      </table>
+    <% else %>
+      <%= render "no_invitations" %>
+    <% end %>
+  </div>
+</div>

--- a/app/modules/teams/views/teams/teams/edit.html.erb
+++ b/app/modules/teams/views/teams/teams/edit.html.erb
@@ -12,4 +12,6 @@
       <%= render 'teams/invitations/form', invitation: Teams::Invitation.new %>
     </div>
   </div>
+
+  <%= link_to 'View existing invitations', teams_invitations_path %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Workshops::Application.routes.draw do
   end
 
   namespace :teams do
-    resources :invitations, only: [:create] do
+    resources :invitations, only: [:index, :create] do
       resources :acceptances, only: [:new, :create]
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -168,6 +168,11 @@ FactoryGirl.define do
     after :stub do |invitation|
       invitation.code = 'abc'
     end
+
+    trait :accepted do
+      recipient factory: :user
+      accepted_at { Time.now }
+    end
   end
 
   factory :acceptance, class: 'Teams::Acceptance' do

--- a/spec/modules/teams/team_spec.rb
+++ b/spec/modules/teams/team_spec.rb
@@ -55,6 +55,20 @@ module Teams
       end
     end
 
+    describe "#has_invited_users?" do
+      it "returns false when the team has no invitations" do
+        team = build(:team, invitations: [])
+
+        expect(team).not_to have_invited_users
+      end
+
+      it "returns true when the team has invitations" do
+        team = build(:team, invitations: build_list(:invitation, 3))
+
+        expect(team).to have_invited_users
+      end
+    end
+
     def stub_team_fulfillment(team, user)
       checkout = build_stubbed(:checkout, subscribeable: team.subscription.plan)
       stub_subscription_fulfillment(checkout, user)

--- a/spec/modules/teams/teams_invitations_index.html.erb_spec.rb
+++ b/spec/modules/teams/teams_invitations_index.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe "teams/invitations/index", type: :view do
+  it "renders no invitations" do
+    assign(:team, build(:team))
+
+    render
+
+    expect(rendered).to have_content "You haven't invited anyone"
+  end
+
+  it "renders pending invitations" do
+    email = "pat@thoughtbot.com"
+    invitation = build(:invitation, email: email)
+    assign(:team, build(:team, invitations: [invitation]))
+
+    render
+
+    expect(rendered).to have_content email
+    expect(rendered).to have_content "Pending"
+  end
+
+  it "renders accepted invitations" do
+    email = "pat@thoughtbot.com"
+    invitation = build(:invitation, :accepted, email: email)
+    assign(:team, build(:team, invitations: [invitation]))
+
+    render
+
+    expect(rendered).to have_content email
+    expect(rendered).to have_content "Accepted"
+    expect(rendered).to have_content invitation.recipient_name
+  end
+end

--- a/spec/modules/teams/user_views_team_invitations_spec.rb
+++ b/spec/modules/teams/user_views_team_invitations_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+feature "View team invitations" do
+  scenario "when some have been accepted" do
+    using_session :team_member do
+      sign_in
+      team = create(:team)
+      add_user_to_team(current_user, team)
+      create_list(:invitation, 2, team: team)
+      create_list(:invitation, 2, :accepted, team: team)
+
+      visit teams_invitations_path
+
+      expect(page).to have_css(".accepted", count: 2)
+      expect(page).to have_css(".pending", count: 2)
+    end
+  end
+
+  def add_user_to_team(user, team)
+    user.team = team
+    user.save!
+  end
+end


### PR DESCRIPTION
https://trello.com/c/dHDDdjnQ/78-as-a-subscriber-mananging-a-team-plan-i-want-to-be-able-to-see-all-the-users-i-ve-invited-and-their-status-signed-up-or-not-so-t

From the teams/team/edit page, there is a link to View existing invitations.
This page presents a simple table of email/statue ("Pending" or "Accepted by
<Name>").

Design and copy are not my forte, so suggestions welcome.

It would make sense (to me) to eventually either move this table over to the
teams/team/edit page, or bring that send-invitation form onto this one (and do
away with teams/team/edit entirely).
