### PR TITLE
Fixes to invitations page feature

### DIFF
--- a/app/modules/teams/views/teams/invitations/index.html.erb
+++ b/app/modules/teams/views/teams/invitations/index.html.erb
@@ -3,7 +3,7 @@
   <h1>Invitations</h1>
 <% end %>
 
-<div class="text-box-wrapper">
+<div class="text-box-wrapper solo">
   <div class="text-box">
     <% if @team.has_invited_users? %>
       <table>

--- a/spec/modules/teams/teams_invitations_index.html.erb_spec.rb
+++ b/spec/modules/teams/teams_invitations_index.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "teams/invitations/index", type: :view do
   it "renders no invitations" do
-    assign(:team, build(:team))
+    assign(:team, build_stubbed(:team))
 
     render
 
@@ -11,8 +11,8 @@ describe "teams/invitations/index", type: :view do
 
   it "renders pending invitations" do
     email = "pat@thoughtbot.com"
-    invitation = build(:invitation, email: email)
-    assign(:team, build(:team, invitations: [invitation]))
+    invitation = build_stubbed(:invitation, email: email)
+    assign(:team, build_stubbed(:team, invitations: [invitation]))
 
     render
 
@@ -22,8 +22,8 @@ describe "teams/invitations/index", type: :view do
 
   it "renders accepted invitations" do
     email = "pat@thoughtbot.com"
-    invitation = build(:invitation, :accepted, email: email)
-    assign(:team, build(:team, invitations: [invitation]))
+    invitation = build_stubbed(:invitation, :accepted, email: email)
+    assign(:team, build_stubbed(:team, invitations: [invitation]))
 
     render
 


### PR DESCRIPTION
https://trello.com/c/dHDDdjnQ/78-as-a-subscriber-mananging-a-team-plan-i-want-to-be-able-to-see-all-the-users-i-ve-invited-and-their-status-signed-up-or-not-so-t
- Use build_stubbed so the test runs faster
- Use the proper css class to ensure correct width
