### PR TITLE
Display number of invitations left along with invite form

### DIFF
--- a/app/modules/teams/team.rb
+++ b/app/modules/teams/team.rb
@@ -22,17 +22,25 @@ module Teams
     end
 
     def has_users_remaining?
-      users.count < max_users
+      users_count < max_users
     end
 
     def has_invited_users?
       invitations.any?
     end
 
+    def invitations_remaining
+      [0, max_users - users_count].max
+    end
+
     private
 
     def fulfillment_for(user)
       SubscriptionFulfillment.new(user, subscription.plan)
+    end
+
+    def users_count
+      users.count
     end
   end
 end

--- a/app/modules/teams/views/teams/teams/edit.html.erb
+++ b/app/modules/teams/views/teams/teams/edit.html.erb
@@ -7,11 +7,18 @@
   <div class="text-box">
     <ul class="members">
     </ul>
-    <div class="invite-members">
-      <p>Invite a member</p>
-      <%= render 'teams/invitations/form', invitation: Teams::Invitation.new %>
-    </div>
-  </div>
 
-  <%= link_to 'View existing invitations', teams_invitations_path %>
+    <% if @team.has_users_remaining? %>
+      <div class="invite-members">
+        <p>Invite a member - You have <%= pluralize(@team.invitations_remaining, 'invitation') %> left</p>
+        <%= render 'teams/invitations/form', invitation: Teams::Invitation.new %>
+      </div>
+    <% else %>
+      <p>You're out of invitations right now, but that's easy to fix. <%= mail_to ENV["SUPPORT_EMAIL"], "Send us a short email" %> and we'll take care of you.</p>
+    <% end %>
+
+    <% if @team.has_invited_users? %>
+      <p><%= link_to "View existing invitations", teams_invitations_path %></p>
+    <% end %>
+  </div>
 </div>

--- a/spec/modules/teams/team_spec.rb
+++ b/spec/modules/teams/team_spec.rb
@@ -69,6 +69,22 @@ module Teams
       end
     end
 
+    describe "#invitations_remaining" do
+      it "returns the difference between users and max users" do
+        team = create(:team, max_users: 5)
+        create_list(:user, 3, team: team)
+
+        expect(team.invitations_remaining).to eq 2
+      end
+
+      it "never returns negative" do
+        team = create(:team, max_users: 2)
+        create_list(:user, 4, team: team)
+
+        expect(team.invitations_remaining).to eq 0
+      end
+    end
+
     def stub_team_fulfillment(team, user)
       checkout = build_stubbed(:checkout, subscribeable: team.subscription.plan)
       stub_subscription_fulfillment(checkout, user)


### PR DESCRIPTION
https://trello.com/c/Vcsfb0Yr/79-as-a-subscriber-managing-a-team-plan-i-want-to-see-how-many-invites-i-have-left-at-my-current-subscription-level

Minor additional improvements:
- Don't show the form at all if they're out of invites. Show a link to change
  their subscription (is this the correct link?)
- Move the "View invitations" link into the text-wrapper to be consistent with
  the next view
- Make the "View invitations" link conditional, only show it if there actually
  are existing invitations

The Trello card has screenshots.
