### PR TITLE
Look for namespaced s3 files on Book product page

### DIFF
--- a/lib/hosted_book_url.rb
+++ b/lib/hosted_book_url.rb
@@ -24,7 +24,9 @@ class HostedBookUrl
   private
 
   def url_for_format(format)
-    s3_files["#{book.filename}.#{format}"].url_for(:read, expires: 10.minutes).to_s
+    s3_files["#{book.filename}/#{book.filename}.#{format}"].
+      url_for(:read, expires: 10.minutes).
+      to_s
   end
 
   def s3_bucket_name


### PR DESCRIPTION
- Paperback's `release` command puts files in s3 underneath a dir of the
  book title
- Upcase book product pages look for an s3 file in the main dir
- This change makes Upcase consistent with Paperback
- https://github.com/thoughtbot/paperback/issues/74#issuecomment-42035965
