### PR TITLE
remove reference to one-time purchases

### DIFF
--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -53,9 +53,6 @@
     the site. This can be an individual product, workshop, or
     subscription.</li>
 
-    <li>&#8220;One-time Purchaser&#8221; refers to a Customer who one or more
-    individual books, screencasts, or workshops.</li>
-
     <li>&#8220;Single-User Subscriber&#8221; refers to a Subscriber who
     purchases a subscription to Upcase <%= t('shared.subscription.name')
     %>&#174; for one (1) User.</li>
@@ -110,14 +107,6 @@
   responsible for management of the User accounts.</p>
 
   <h2>5. Fees; Renewal; Refund Policies</h2>
-  <h3>One-time Purchasers</h3>
-  <ul>
-    <li>Access to the specific product or workshop that was purchased.</li>
-    <li>Purchase price is refundable up to thirty (30) days after the date of purchase.</li>
-    <li>Discounts, rebates or other special offers only valid for initial purchase</li>
-    <li>Right of Access to the purchased Upcase Content granted under these
-    Terms is effective only upon payment of the purchase fees.</li>
-  </ul>
   <h3>Single-User Subscribers</h3>
   <ul>
     <li>Access to all upcase.com Content</li>
@@ -475,6 +464,6 @@
   related to or arising from these Terms. Each party shall bear his/her/its own expenses
   and attorneys&#8217; fees related to any arbitration, claim or action.</p>
 
-  <p>EFFECTIVE DATE: APRIL 24, 2013</p>
+  <p>EFFECTIVE DATE: AUGUST 5, 2014</p>
 </div>
 </div>


### PR DESCRIPTION
We no longer support one-off purchases, so this removes reference to them in
our terms of service.
