### PR TITLE
Fix pending test

### DIFF
--- a/spec/jobs/send_checkout_receipt_email_job_spec.rb
+++ b/spec/jobs/send_checkout_receipt_email_job_spec.rb
@@ -4,11 +4,15 @@ describe SendCheckoutReceiptEmailJob do
   it_behaves_like 'a Delayed Job that notifies Airbrake about errors'
 
   describe '.enqueue' do
-    xit "enqueues a job" do # https://github.com/thoughtbot/learn/pull/692#issuecomment-47453421
+    it "enqueues a job" do
       checkout = create(:checkout)
+      Delayed::Job.stubs(:enqueue)
 
-      expect(SendCheckoutReceiptEmailJob.enqueue(checkout.id)).to
-        enqueue_delayed_job(SendCheckoutReceiptEmailJob)
+      SendCheckoutReceiptEmailJob.enqueue(checkout.id)
+
+      expect(Delayed::Job).to have_received(:enqueue).with(
+        kind_of(SendCheckoutReceiptEmailJob)
+      )
     end
   end
 


### PR DESCRIPTION
- Old test was giving error:
  "expect syntax does not support operator matchers"
- Changing L45 of `spec/suport/enqueue_delayed_job.rb` did not fix issue
- Root of problem unclear, so just changed to be consistent with other
  job specs in the repo
