### PR TITLE
Create static page for Drip opt-in

### DIFF
--- a/app/assets/stylesheets/_land-your-dream-rails-job.scss
+++ b/app/assets/stylesheets/_land-your-dream-rails-job.scss
@@ -1,0 +1,17 @@
+.land-dream-rails-job {
+  @include span-columns(10);
+  @include shift(1);
+
+  h3 {
+    margin-top: em(16*0.5);
+  }
+
+  ol {
+    margin-top: em(16*2);
+    margin-bottom: em(16*1);
+  }
+
+  form {
+    margin-bottom: em(16*0.5);
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -38,5 +38,6 @@
 @import "invoices";
 @import "cancellation";
 @import "teams-invitations-index";
+@import "land-your-dream-rails-job";
 
 @import "prettify";

--- a/app/views/pages/land-your-dream-rails-job.html.erb
+++ b/app/views/pages/land-your-dream-rails-job.html.erb
@@ -1,0 +1,35 @@
+<div class="text-box land-dream-rails-job">
+  <form action="https://www.getdrip.com/forms/9512924/submissions"
+    method="post" target="_blank" data-drip-embedded-form="1744">
+
+    <fieldset>
+      <h3 data-drip-attribute="headline">
+        Land Your Dream Rails Job (A Free, 5-Day Crash Course)
+      </h3>
+
+      <p data-drip-attribute="description">
+        In this course, we'll teach you the skills you need to get hired at top
+        Rails shops like thoughtbot. Each email is packed with actionable advice
+        on becoming the kind of candidate that companies fight over.
+      </p>
+
+      <h5>Course outline</h5>
+      <ul>
+        <li>Day 1: Assessing your skills and filling in the gaps</li>
+        <li>Day 2: Standing out and getting in the door</li>
+        <li>Day 3: Nailing the interview</li>
+        <li>Day 4: Two questions worth a lot of money</li>
+        <li>Day 5: Course wrap-up</li>
+      </ul>
+      <ol>
+        <li>
+          <label for="fields[email]">Email</label>
+          <input type="email" name="fields[email]" value="" />
+        </li>
+      </ol>
+
+      <input type="submit" name="submit" value="Get the first lesson now"
+             data-drip-attribute="sign-up-button" />
+    </fieldset>
+  </form>
+</div>


### PR DESCRIPTION
Lets us link to a page that we know will have the form, rather than relying on
the javascript version appearing.
