### PR TITLE
Maintain the test schema when running tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,8 @@ Capybara.configure do |config|
   config.ignore_hidden_elements = false
 end
 
+ActiveRecord::Migration.maintain_test_schema!
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.use_instantiated_fixtures  = false


### PR DESCRIPTION
Rails 4.1 doesn't use db:test:prepare, but instead expects you to call
`maintain_test_schema` before each test run.
