### PR TITLE
Only show yearly upgrade link to subscribers

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,16 +23,17 @@
     <nav>
       <ul>
         <% if signed_in? %>
-          <% if !current_user_has_active_subscription? %>
+          <% if current_user_has_active_subscription? %>
+            <li class="account">
+              <%= render "shared/annual_billing" %>
+            </li>
+          <% else %>
             <li class="subscription">
               <%= link_to subscribe_path do %>
                 <span><%= t('shared.subscriptions.icon') %></span> <%= t('shared.subscription.name') %> Membership
               <% end %>
             </li>
           <% end %>
-          <li class="account">
-            <%= render 'shared/annual_billing' %>
-          </li>
           <li class="account"><%= link_to 'Settings', my_account_path %></li>
         <% else %>
           <li class="account"><%= link_to 'Sign in', sign_in_path %></li>

--- a/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
+++ b/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
@@ -14,7 +14,23 @@ feature "Subscriber upgrades to annual billing" do
     expect(last_email.to).to include(ENV["SUPPORT_EMAIL"])
   end
 
+  scenario "user with no subscription doesn't see link" do
+    sign_in
+
+    expect_to_not_see_upgrade_link
+  end
+
+  scenario "visitor doesn't see link" do
+    visit products_url
+
+    expect_to_not_see_upgrade_link
+  end
+
   def last_email
     ActionMailer::Base.deliveries.last
+  end
+
+  def expect_to_not_see_upgrade_link
+    expect(page).to_not have_content "Get two months free"
   end
 end


### PR DESCRIPTION
We're currently showing this link to all users, but if someone clicks it
who doesn't actually have a subscription, they get a 500.

https://trello.com/c/xp8l7pf9/105-only-show-the-annual-billing-upgrade-link-to-users-with-active-subscriptions
