### PR TITLE
Set show_exceptions to false in tests

### DIFF
--- a/app/views/subscriber/cancellations/new.html.erb
+++ b/app/views/subscriber/cancellations/new.html.erb
@@ -18,7 +18,7 @@
         <%= link_to(
           "Change to #{individual_price_per_month(@cancellation.downgrade_plan)} &rarr;".html_safe,
           [:subscriber, :downgrade],
-          method: :create
+          method: :post
         ) %>
       </p>
     <% else %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@ Upcase::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = true
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false

--- a/spec/features/user_downgrades_subscription_spec.rb
+++ b/spec/features/user_downgrades_subscription_spec.rb
@@ -1,44 +1,44 @@
 require "rails_helper"
 
-feature 'User downgrades subscription', js: true do
-  scenario 'successfully downgrades and then cancels' do
-    create(:plan, sku: 'upcase', name: 'Upcase')
+feature "User downgrades subscription" do
+  scenario "successfully downgrades and then cancels" do
+    create(:plan, sku: "upcase", name: "Upcase")
     basic_plan = create(:basic_plan)
     workshop = create(:workshop)
 
     sign_in_as_user_with_subscription
     expect(@current_user).to have_active_subscription
     visit products_path
-    expect(find('.header-container')).not_to have_content('Upcase Membership')
-    expect(page).not_to have_link('Subscribe to Upcase')
+    expect(find(".header-container")).not_to have_content("Upcase Membership")
+    expect(page).not_to have_link("Subscribe to Upcase")
 
     ActionMailer::Base.deliveries.clear
 
     visit my_account_path
-    click_link I18n.t('subscriptions.cancel')
-    click_link 'Change to'
+    click_link I18n.t("subscriptions.cancel")
+    click_link "Change to"
 
-    expect(page).to have_link I18n.t('subscriptions.cancel')
+    expect(page).to have_link I18n.t("subscriptions.cancel")
     expect(page).to have_no_content "Scheduled for cancellation"
     @current_user.reload
     expect(@current_user.subscription.plan).to eq basic_plan
 
     visit workshop_path(workshop)
 
-    expect(page).not_to have_css('.free-with-upcase')
+    expect(page).not_to have_css(".free-with-upcase")
 
     visit products_path
 
-    expect(page).not_to have_css('section.mentor h3', text: 'Your Mentor')
+    expect(page).not_to have_css("section.mentor h3", text: "Your Mentor")
 
     visit my_account_path
-    click_link I18n.t('subscriptions.cancel')
+    click_link I18n.t("subscriptions.cancel")
 
-    expect(page).not_to have_content 'deal'
-    expect(page).not_to have_content 'Change to'
+    expect(page).not_to have_content "deal"
+    expect(page).not_to have_content "Change to"
 
-    click_button I18n.t('subscriptions.confirm_cancel')
+    click_button I18n.t("subscriptions.confirm_cancel")
 
-    expect(page).to have_content I18n.t('subscriptions.flashes.cancel.success')
+    expect(page).to have_content I18n.t("subscriptions.flashes.cancel.success")
   end
 end


### PR DESCRIPTION
- When set to true, integration tests see the 500 page
- This masks possible failures
- This hides backtraces

https://trello.com/c/fcFm6dD9/10-set-show-exceptions-to-false
