### PR TITLE
Introduce quiet_assets for cleaner logs in dev.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   gem 'hirb', '0.6.2'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'quiet_assets'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
+    quiet_assets (1.0.3)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -444,6 +446,7 @@ DEPENDENCIES
   paypal-express (= 0.4.6)
   pg (= 0.13.2)
   pry-rails
+  quiet_assets
   rack-cache (= 1.2)
   rack-rewrite (= 1.2.1)
   rack-ssl-enforcer (= 0.2.4)


### PR DESCRIPTION
I find asset requests in logs useless, and it's hard to find params/log data while debugging when they are many like in Upcase.
