### PR TITLE
Addresses OAuth redirection bug

### DIFF
--- a/app/controllers/auth_callbacks_controller.rb
+++ b/app/controllers/auth_callbacks_controller.rb
@@ -3,6 +3,7 @@ class AuthCallbacksController < ApplicationController
     @user = AuthHashService.new(auth_hash).find_or_create_user_from_auth_hash
     sign_in @user
     redirect_to url_after_auth
+    clear_return_to
   end
 
   private
@@ -29,5 +30,9 @@ class AuthCallbacksController < ApplicationController
 
   def auth_origin
     session[:return_to] || request.env['omniauth.origin'] || dashboard_url
+  end
+
+  def clear_return_to
+    session[:return_to] = nil
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -5,11 +5,12 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    session[:return_to] = request.fullpath
-    request.env[:clearance].current_user or redirect_to(sign_in_url)
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
+    if request.env[:clearance].current_user
+      request.env[:clearance].current_user
+    else
+      session[:return_to] = request.fullpath
+      redirect_to(sign_in_url)
+    end
   end
 
   resource_owner_from_credentials do |routes|

--- a/spec/features/oauth_client_authenticates_spec.rb
+++ b/spec/features/oauth_client_authenticates_spec.rb
@@ -22,6 +22,13 @@ feature 'An OAuth client authenticates', js: true do
 
     expect(current_path).not_to eq dashboard_path
     verify_signed_in_user_details_from_page(user)
+
+    visit my_account_path
+    click_link "Sign out"
+
+    visit sign_in_path
+    click_link "with GitHub"
+    expect(current_path).to eq dashboard_path
   end
 
   scenario 'via password' do


### PR DESCRIPTION
When upcase (as provider) authenticates a user, it redirects back to
`session[:return_to]`, set to the authorize path that the client application
triggered.

Chad suggested to clear the session variable upon successful authentication, but
for some reason it wasn't being cleaned.

Problem was that we set that session value always on
`resource_owner_authenticator` -which is akin to a doorkeeper `before_filter`-
when we only want to remember where to redirect when an unauthenticated user
gets to the sign in form in Upcase (ant not when it's already authenticated).

The flow before was:
1. client asks upcase for authorization. Doorkeeper sets the session variable.
2. In upcase, user clicks on "sign in with Github", triggering a successful
   OAuth flow. As of Chad's change, session is cleared after next step.
3. Redirect back to `return_to`, which was the authorize link. Complete a
   successful OAuth flow between client and Upcase as provider.
4. Strategy in client asks for current_user information (`api/v1/me.json`), this
   code runs on Upcase, and before this changeset it was setting
   `session[:return_to]` _again_. So any future authentication in upcase would
   again trigger this same OAuth flow between client and upcase.

Now, doorkeeper only sets `session[:return_to]` only when unauthenticated, and
the `clear_return_to` then works.

Related Trello cards:
- https://trello.com/c/9fxt1Cz8/53-bug-return-to-not-cleared-if-signing-in-with-oauth
- https://trello.com/c/BRU74Q6K/83-bug-github-oauth-is-broken
