### PR TITLE
.resources doesn't extend .topic CSS

### DIFF
--- a/app/assets/stylesheets/_product-card.scss.erb
+++ b/app/assets/stylesheets/_product-card.scss.erb
@@ -158,8 +158,6 @@
 }
 
 .resources {
-  @extend .topic;
-
   &:hover {
     background-color: white;
   }


### PR DESCRIPTION
On wide monitors footer is shown at the right of the list of resources. See for
example http://staging.upcase.com/ios/resources. This change eliminates that
CSS, and shows the columns as expected.
