### PR TITLE
Show only user-facing flash messages

### DIFF
--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,6 +1,6 @@
 <% if flash.any? %>
   <div class="flashes">
-    <% flash.each do |key, value| -%>
+    <% flash.to_hash.slice("notice", "error").each do |key, value| -%>
       <div class="flash <%= key %>">
         <%= value %>
       </div>

--- a/spec/views/shared/_flashes.html.erb_spec.rb
+++ b/spec/views/shared/_flashes.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "shared/_flashes.html.erb" do
+  context "when signed out" do
+    before do
+      view_stubs(flash: {
+                  "notice" => "Thank you",
+                  "purchase_amount" => 29,
+                  "purchase_name" => "30 Minutes a Week"
+                })
+    end
+
+    it "loads the Segment.io JavaScript library" do
+      render
+
+      expect(rendered).to include("Thank you")
+      expect(rendered).not_to include("29")
+      expect(rendered).not_to include("30 Minutes a Week")
+    end
+  end
+end


### PR DESCRIPTION
Was showing to users keys like `purchase_amount` and `purchase_name`.

Trello card:
https://trello.com/c/tl8xwoSL/96-bug-purchased-item-and-amount-are-appearing-in-the-user-visible-flash
