### PR TITLE
Hide annual upsell from subscribers through a team

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
     current_user_has_active_subscription? &&
       current_user.subscription.owner?(current_user)
   end
+  helper_method :current_user_is_subscription_owner?
 
   def current_user_has_active_subscription?
     current_user && current_user.has_active_subscription?

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,7 +23,7 @@
     <nav>
       <ul>
         <% if signed_in? %>
-          <% if current_user_has_active_subscription? %>
+          <% if current_user_is_subscription_owner? %>
             <li class="account">
               <%= render "shared/annual_billing" %>
             </li>

--- a/spec/views/promoted_catalogs/show.html.erb_spec.rb
+++ b/spec/views/promoted_catalogs/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe 'promoted_catalogs/show.html.erb' do
     before do
       view_stubs(signed_in?: true)
       view_stubs(current_user_has_active_subscription?: false)
+      view_stubs(current_user_is_subscription_owner?: false)
       assign_catalog
       render
     end
@@ -26,6 +27,7 @@ describe 'promoted_catalogs/show.html.erb' do
     before do
       view_stubs(signed_in?: true)
       view_stubs(current_user_has_active_subscription?: true)
+      view_stubs(current_user_is_subscription_owner?: true)
       assign_catalog
       render
     end

--- a/spec/views/shared/_header.html.erb_spec.rb
+++ b/spec/views/shared/_header.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "shared/_header.html.erb" do
+  include AnalyticsHelper
+
+  let(:call_to_action_label) { "Get two months free" }
+
+  context "when user is the subscription owner" do
+    it "shows an annual upsell link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user_has_active_subscription?: true)
+      view_stubs(current_user_is_subscription_owner?: true)
+
+      render
+
+      expect(rendered).to have_content(call_to_action_label)
+    end
+  end
+
+  context "when user is not the subscription owner" do
+    it "does not show an annual upsell link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user_has_active_subscription?: true)
+      view_stubs(current_user_is_subscription_owner?: false)
+
+      render
+
+      expect(rendered).not_to have_content(call_to_action_label)
+    end
+  end
+end


### PR DESCRIPTION
A team subscriber is not the owner, and doesn't need to be upsold. Condition "has active subscription" was too loose.

Progress for Trello card:
https://trello.com/c/RyQ7nY3D/100-as-a-subscriber-who-is-on-annual-billing-or-a-team-plan-i-don-t-want-to-see-a-cta-to-upgrade-to-annual-billing
