### PR TITLE
Fixes subscribe CTA link

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -29,11 +29,11 @@ module DashboardsHelper
     locked_features.to_sentence.capitalize
   end
 
-  def subscribe_or_upgrade
+  def subscribe_or_upgrade_link
     if current_user_has_active_subscription?
-      t(".locked_features.upgrade_link")
+      link_to t(".locked_features.upgrade_link"), edit_subscription_path
     else
-      t(".locked_features.subscribe_link")
+      link_to t(".locked_features.subscribe_link"), new_subscription_path
     end
   end
 

--- a/app/views/dashboards/_locked_features.html.erb
+++ b/app/views/dashboards/_locked_features.html.erb
@@ -4,9 +4,9 @@
       <%= t(
         '.locked_features.title_html',
         features: locked_features_text,
-        link: link_to(subscribe_or_upgrade, edit_subscription_path)
+        link: subscribe_or_upgrade_link
       ) %>
     </h2>
-  <%= link_to "See what you're missing", products_path %>
+    <%= link_to "See what you're missing", products_path %>
   </div>
 </section>

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe DashboardsHelper, "#subscribe_or_upgrade_link" do
+  before do
+    @virtual_path = "dashboards.show"
+    helper.instance_variable_set(:@virtual_path, @virtual_path)
+  end
+
+  context "when the user has no active subscription" do
+    it "shows a 'subscribe' link" do
+      helper.stubs(:current_user_has_active_subscription?).returns(false)
+
+      result = helper.subscribe_or_upgrade_link
+
+      expect(result).to match(t(".locked_features.subscribe_link"))
+      expect(result).to match(new_subscription_path)
+    end
+  end
+
+  context "when the user has an active subscription" do
+    it "shows an 'upgrade' link" do
+      helper.stubs(:current_user_has_active_subscription?).returns(true)
+
+      result = helper.subscribe_or_upgrade_link
+
+      expect(result).to match(t(".locked_features.upgrade_link"))
+      expect(result).to match(edit_subscription_path)
+    end
+  end
+end


### PR DESCRIPTION
Users with no subscription where seeing the message 'You must be the owner of
the subscription' while trying to sign up. Yikes!

Trello card:
https://trello.com/c/CzAPDGA2/137-after-signing-up-without-a-subscription-i-can-t-create-a-subscription
