### PR TITLE
Hides annual upsell if already subscribed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user_has_active_subscription?
 
+  def current_user_has_monthly_subscription?
+    current_user_has_active_subscription? &&
+      current_user.has_monthly_subscription?
+  end
+  helper_method :current_user_has_monthly_subscription?
+
   def current_user_has_access_to_video_tutorials?
     current_user && current_user.has_access_to?(:video_tutorials)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,9 @@ module ApplicationHelper
   def current_user_has_access_to?(feature)
     current_user && current_user.has_access_to?(feature)
   end
+
+  def show_upgrade_to_annual_cta?
+    current_user_is_subscription_owner? &&
+      current_user_has_monthly_subscription?
+  end
 end

--- a/app/helpers/auth_callbacks_helper.rb
+++ b/app/helpers/auth_callbacks_helper.rb
@@ -1,2 +1,0 @@
-module AuthCallbacksHelper
-end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -69,6 +69,10 @@ class Plan < ActiveRecord::Base
     false
   end
 
+  def monthly?
+    !annual?
+  end
+
   def has_feature?(feature)
     public_send("includes_#{feature}?")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,10 @@ class User < ActiveRecord::Base
     [purchased_subscription, team_subscription].compact.detect(&:active?)
   end
 
+  def has_monthly_subscription?
+    plan.present? && plan.monthly?
+  end
+
   def annualized_payment
     plan.annualized_payment
   end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,7 +23,7 @@
     <nav>
       <ul>
         <% if signed_in? %>
-          <% if current_user_is_subscription_owner? %>
+          <% if show_upgrade_to_annual_cta? %>
             <li class="account">
               <%= render "shared/annual_billing" %>
             </li>

--- a/db/migrate/20140911184704_add_is_annual_to_plans.rb
+++ b/db/migrate/20140911184704_add_is_annual_to_plans.rb
@@ -1,0 +1,5 @@
+class AddIsAnnualToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :annual, :boolean, nil: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140910213739) do
+ActiveRecord::Schema.define(version: 20140911184704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 20140910213739) do
     t.boolean  "includes_office_hours",    default: true,  null: false
     t.boolean  "includes_shows",           default: true,  null: false
     t.boolean  "includes_team",            default: false, null: false
+    t.boolean  "annual",                   default: false
   end
 
   create_table "products", force: true do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,8 +14,8 @@ describe User do
     it { should validate_presence_of(:name) }
   end
 
-  context 'with a subscription that includes a mentor' do
-    it 'is invalid without a mentor' do
+  context "with a subscription that includes a mentor" do
+    it "is invalid without a mentor" do
       plan = create(:plan, includes_mentor: true)
       subscription = create(:subscription, plan: plan)
       user = create(:user, :with_mentor, subscription: subscription)
@@ -31,13 +31,13 @@ describe User do
     end
   end
 
-  context '#last_name' do
-    it 'returns everything except the first name' do
-      user = User.new(name: 'First Last')
-      expect(user.last_name).to eq 'Last'
+  context "#last_name" do
+    it "returns everything except the first name" do
+      user = User.new(name: "First Last")
+      expect(user.last_name).to eq "Last"
 
-      user_with_multi_part_last_name = User.new(name: 'First van der Last')
-      expect(user_with_multi_part_last_name.last_name).to eq 'van der Last'
+      user_with_multi_part_last_name = User.new(name: "First van der Last")
+      expect(user_with_multi_part_last_name.last_name).to eq "van der Last"
     end
   end
 
@@ -57,7 +57,7 @@ describe User do
     end
   end
 
-  context '#inactive_subscription' do
+  context "#inactive_subscription" do
     it "returns the user's associated subscription if it is inactive" do
       user = User.new
       subscription = build_stubbed(:inactive_subscription)
@@ -117,7 +117,7 @@ describe User do
     end
   end
 
-  context '#has_active_subscription?' do
+  context "#has_active_subscription?" do
     it "returns true if the user's associated subscription is active" do
       user = User.new
       user.purchased_subscription = build_stubbed(:active_subscription)
@@ -188,22 +188,22 @@ describe User do
     end
   end
 
-  describe '#subscribed_at' do
-    it 'returns the date the user subscribed if the user has a subscription' do
+  describe "#subscribed_at" do
+    it "returns the date the user subscribed if the user has a subscription" do
       user = create(:subscriber)
 
       expect(user.subscribed_at).to eq user.subscription.created_at
     end
 
-    it 'returns nil when the user does not have a subscription' do
+    it "returns nil when the user does not have a subscription" do
       user = create(:user)
 
       expect(user.subscribed_at).to be_nil
     end
   end
 
-  context 'password validations' do
-    it 'allows non-oauth users to update attributes without the password' do
+  context "password validations" do
+    it "allows non-oauth users to update attributes without the password" do
       user = create_user_without_cached_password(admin: false)
 
       user.admin = true
@@ -218,23 +218,23 @@ describe User do
     end
   end
 
-  describe '#credit_card' do
-    it 'returns nil if there is no stripe_customer_id' do
+  describe "#credit_card" do
+    it "returns nil if there is no stripe_customer_id" do
       user = create(:user, stripe_customer_id: nil)
 
       expect(user.credit_card).to be_nil
     end
 
-    it 'returns the active card for the stripe customer' do
+    it "returns the active card for the stripe customer" do
       user = create(:user, stripe_customer_id: FakeStripe::CUSTOMER_ID)
 
       expect(user.credit_card).not_to be_nil
-      expect(user.credit_card['last4']).to eq '1234'
+      expect(user.credit_card["last4"]).to eq "1234"
     end
   end
 
-  describe '#assign_mentor' do
-    it 'sets the given user as the mentor' do
+  describe "#assign_mentor" do
+    it "sets the given user as the mentor" do
       mentee = create(:user)
       mentor = create(:mentor)
 
@@ -244,8 +244,8 @@ describe User do
     end
   end
 
-  describe '#has_subscription_with_mentor?' do
-    it 'returns true when the subscription includes mentoring' do
+  describe "#has_subscription_with_mentor?" do
+    it "returns true when the subscription includes mentoring" do
       plan = build(:plan, includes_mentor: true)
       subscription = build(:subscription, plan: plan)
       user = build(:user, :with_mentor, subscription: subscription)
@@ -253,7 +253,7 @@ describe User do
       expect(user).to have_subscription_with_mentor
     end
 
-    it 'returns false when the subscription does not include mentoring' do
+    it "returns false when the subscription does not include mentoring" do
       plan = build(:plan, includes_mentor: false)
       subscription = build(:subscription, plan: plan)
       user = build(:user, subscription: subscription)
@@ -261,7 +261,7 @@ describe User do
       expect(user).to_not have_subscription_with_mentor
     end
 
-    it 'returns false when the subscription is inactive' do
+    it "returns false when the subscription is inactive" do
       plan = build(:plan, includes_mentor: true)
       subscription = build(:inactive_subscription, plan: plan)
       user = build(:user, :with_mentor, subscription: subscription)
@@ -269,7 +269,7 @@ describe User do
       expect(user).to_not have_subscription_with_mentor
     end
 
-    it 'returns false when there is no subscription' do
+    it "returns false when there is no subscription" do
       user = build(:user)
       expect(user).to_not have_subscription_with_mentor
     end
@@ -298,27 +298,27 @@ describe User do
     end
   end
 
-  describe '#plan_name' do
-    it 'delegates to Subscription for the Plan name' do
+  describe "#plan_name" do
+    it "delegates to Subscription for the Plan name" do
       user = create(:subscriber)
       expect(user.plan_name).to eq user.subscription.plan.name
     end
 
-    it 'returns nil when there is no Subscription' do
+    it "returns nil when there is no Subscription" do
       user = create(:user)
       expect(user.plan_name).to be_nil
     end
   end
 
-  describe '#has_logged_in_to_forum?' do
-    it 'returns true when the user has logged in to the forum' do
+  describe "#has_logged_in_to_forum?" do
+    it "returns true when the user has logged in to the forum" do
       user = User.new
       OauthAccessToken.stubs(:for_user).with(user).returns(true)
 
       expect(user).to have_logged_in_to_forum
     end
 
-    it 'returns false when the user has never logged in to the forum' do
+    it "returns false when the user has never logged in to the forum" do
       user = User.new
       OauthAccessToken.stubs(:for_user).with(user).returns(nil)
 
@@ -326,71 +326,71 @@ describe User do
     end
   end
 
-  describe '#mentor_name' do
-    it 'returns the mentor name' do
+  describe "#mentor_name" do
+    it "returns the mentor name" do
       mentee = build_stubbed(:user, :with_mentor)
       mentor = mentee.mentor
 
       expect(mentee.mentor_name).to eq mentor.name
     end
 
-    it 'returns nil if the user has no mentor' do
+    it "returns nil if the user has no mentor" do
       user = build_stubbed(:user)
 
       expect(user.mentor_name).to be_nil
     end
   end
 
-  describe '#mentor_email' do
+  describe "#mentor_email" do
     it "delegates to the user's mentor" do
       user = create(:user, :with_mentor)
       expect(user.mentor_email).to eq user.mentor.email
     end
 
-    it 'returns nil if the user has no mentor' do
+    it "returns nil if the user has no mentor" do
       user = build_stubbed(:user)
 
       expect(user.mentor_email).to be_nil
     end
   end
 
-  describe '#mentor_first_name' do
+  describe "#mentor_first_name" do
     it "delegates to the user's mentor" do
       user = create(:user, :with_mentor)
       expect(user.mentor_first_name).to eq user.mentor.first_name
     end
 
-    it 'returns nil if the user has no mentor' do
+    it "returns nil if the user has no mentor" do
       user = build_stubbed(:user)
 
       expect(user.mentor_first_name).to be_nil
     end
   end
 
-  describe '#has_access_to?' do
-    context 'when the user does not have a subscription' do
-      it 'returns false' do
+  describe "#has_access_to?" do
+    context "when the user does not have a subscription" do
+      it "returns false" do
         user = build_stubbed(:user)
 
-        expect(user.has_access_to?('video_tutorials')).to_not be
+        expect(user.has_access_to?("video_tutorials")).to_not be
       end
     end
 
-    context 'when the user has an inactive subscription' do
-      it 'returns false' do
+    context "when the user has an inactive subscription" do
+      it "returns false" do
         user = create(:subscriber)
         user.subscription.stubs(:active?).returns(false)
 
-        expect(user.has_access_to?('video_tutorials')).to_not be
+        expect(user.has_access_to?("video_tutorials")).to_not be
       end
     end
 
-    context 'when the user has an active subscription' do
+    context "when the user has an active subscription" do
       it "delegates to the subscription's has_access_to? method" do
         user = create(:subscriber)
-        user.subscription.stubs(:has_access_to?).returns('expected')
+        user.subscription.stubs(:has_access_to?).returns("expected")
 
-        expect(user.has_access_to?('video_tutorials')).to eq('expected')
+        expect(user.has_access_to?("video_tutorials")).to eq("expected")
       end
     end
 
@@ -409,8 +409,8 @@ describe User do
     end
   end
 
-  describe '#subscription' do
-    it 'returns a purchased subscription' do
+  describe "#subscription" do
+    it "returns a purchased subscription" do
       subscription = build_stubbed(:subscription)
       user = User.new
       user.purchased_subscription = subscription
@@ -418,7 +418,7 @@ describe User do
       expect(user.subscription).to eq(subscription)
     end
 
-    it 'returns a team subscription' do
+    it "returns a team subscription" do
       team = Team.new
       team.subscription = build_stubbed(:subscription)
       user = User.new
@@ -427,7 +427,7 @@ describe User do
       expect(user.subscription).to eq(team.subscription)
     end
 
-    it 'returns nil without a subscription' do
+    it "returns nil without a subscription" do
       user = User.new
 
       expect(user.subscription).to be_nil
@@ -449,11 +449,29 @@ describe User do
     end
   end
 
-  describe '.with_active_subscription' do
-    it 'returns users with active subscriptions' do
-      with_active_subscription = create(:user, name: 'active')
-      with_inactive_subscription = create(:user, name: 'inactive')
-      create(:user, name: 'without subscription')
+  describe "#has_monthly_subscription?" do
+    it "with inactive subscription" do
+      user = User.new
+      subscription = build_stubbed(:inactive_subscription)
+      user.purchased_subscription = subscription
+
+      expect(user.has_monthly_subscription?).to be false
+    end
+
+    it "with active subscription" do
+      user = User.new
+      subscription = build_stubbed(:subscription)
+      user.purchased_subscription = subscription
+
+      expect(user.has_monthly_subscription?).to be true
+    end
+  end
+
+  describe ".with_active_subscription" do
+    it "returns users with active subscriptions" do
+      with_active_subscription = create(:user, name: "active")
+      with_inactive_subscription = create(:user, name: "inactive")
+      create(:user, name: "without subscription")
       create(:active_subscription, user: with_active_subscription)
       create(:inactive_subscription, user: with_inactive_subscription)
 
@@ -462,12 +480,12 @@ describe User do
       expect(result.map(&:name)).to eq(%w(active))
     end
 
-    it 'eager loads individual subscriptions' do
+    it "eager loads individual subscriptions" do
       expect { User.with_active_subscription.map(&:plan_name) }.
         to eager_load { create(:active_subscription) }
     end
 
-    it 'eager loads team subscriptions' do
+    it "eager loads team subscriptions" do
       expect { User.with_active_subscription.map(&:plan_name) }.
         to eager_load { create_user_with_team }
     end

--- a/spec/views/promoted_catalogs/show.html.erb_spec.rb
+++ b/spec/views/promoted_catalogs/show.html.erb_spec.rb
@@ -28,6 +28,7 @@ describe 'promoted_catalogs/show.html.erb' do
       view_stubs(signed_in?: true)
       view_stubs(current_user_has_active_subscription?: true)
       view_stubs(current_user_is_subscription_owner?: true)
+      view_stubs(current_user_has_monthly_subscription?: true)
       assign_catalog
       render
     end

--- a/spec/views/shared/_header.html.erb_spec.rb
+++ b/spec/views/shared/_header.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe "shared/_header.html.erb" do
       view_stubs(signed_in?: true)
       view_stubs(current_user_has_active_subscription?: true)
       view_stubs(current_user_is_subscription_owner?: true)
+      view_stubs(current_user_has_monthly_subscription?: true)
 
       render
 
@@ -22,6 +23,19 @@ describe "shared/_header.html.erb" do
       view_stubs(signed_in?: true)
       view_stubs(current_user_has_active_subscription?: true)
       view_stubs(current_user_is_subscription_owner?: false)
+
+      render
+
+      expect(rendered).not_to have_content(call_to_action_label)
+    end
+  end
+
+  context "when user is the subscription owner of an annual plan" do
+    it "does not show an annual upsell link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user_has_active_subscription?: true)
+      view_stubs(current_user_is_subscription_owner?: true)
+      view_stubs(current_user_has_monthly_subscription?: false)
 
       render
 


### PR DESCRIPTION
- Refactor show CTA button logic into a Helper
- Adds IndividualPlan#is_annual flag
- Remove empty helper

Trello card:
https://trello.com/c/RyQ7nY3D/100-as-a-subscriber-who-is-on-annual-billing-or-a-team-plan-i-don-t-want-to-see-a-cta-to-upgrade-to-annual-billing

Related PR: https://github.com/thoughtbot/upcase/pull/859
