### PR TITLE
Fixes markup for edit password view

### DIFF
--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,15 +1,16 @@
-<section id="container">
-  <h2>Change your password</h2>
+<section id="auth-form-container">
+  <section class="thoughtbot-signin">
+    <%= semantic_form_for(:password_reset, url: user_password_path(@user, token: @user.confirmation_token), html: { method: :put }) do |form| %>
+      <p class="flash_success">Your password has been reset. Choose a new
+      password below.</p>
 
-  <p class="flash_success">Your password has been reset. Choose a new password below.</p>
-
-  <%= semantic_form_for(:password_reset, url: user_password_path(@user, token: @user.confirmation_token), html: { method: :put }) do |form| %>
-    <%= form.error_messages %>
-    <%= form.inputs do -%>
-      <%= form.input :password, as: :password, label: "Choose password" %>
-    <% end -%>
-    <%= form.actions do -%>
-      <%= form.action :submit, label: "Save this password" %>
-    <% end -%>
-  <% end %>
+      <%= form.error_messages %>
+      <%= form.inputs do -%>
+        <%= form.input :password, as: :password, label: "Choose password" %>
+      <% end -%>
+      <%= form.actions do -%>
+        <%= form.action :submit, label: "Save this password" %>
+      <% end -%>
+    <% end %>
+  </section>
 </section>


### PR DESCRIPTION
Copies markup from correct password/new view.

![screen shot 2014-09-05 at 11 21 31 am](https://cloud.githubusercontent.com/assets/54260/4167179/4ae8daa2-3511-11e4-9618-1e67cf7add4a.png)

Trello card:
https://trello.com/c/o5Psl2dZ/115-bug-styles-on-password-reset-page-appear-a-bit-broken
