### PR TITLE
Display 'video tutorials' in locked features text

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -26,7 +26,7 @@ module DashboardsHelper
   end
 
   def locked_features_text
-    locked_features.to_sentence.capitalize
+    locked_features.to_sentence.humanize
   end
 
   def subscribe_or_upgrade_link

--- a/spec/views/dashboards/show.html.erb_spec.rb
+++ b/spec/views/dashboards/show.html.erb_spec.rb
@@ -53,7 +53,7 @@ describe "dashboards/show.html" do
     end
   end
 
-  context "when a user has access to shows and video_tutorials" do
+  context "when a user has access to shows and video tutorials" do
     it "renders locked features partial with exercises and books" do
       render_show shows: true, video_tutorials: true, screencasts: true
 
@@ -65,7 +65,7 @@ describe "dashboards/show.html" do
     it "renders locked features partial with correct features" do
       render_show shows: true
 
-      text = "Books, exercises, screencasts, and video_tutorials are locked"
+      text = "Books, exercises, screencasts, and video tutorials are locked"
       expect(rendered).to have_content(text)
     end
   end
@@ -74,7 +74,7 @@ describe "dashboards/show.html" do
     it "renders locked features partial with all features" do
       render_show
 
-      text = "Books, exercises, screencasts, shows, and video_tutorials are locked"
+      text = "Books, exercises, screencasts, shows, and video tutorials are locked"
       expect(rendered).to have_content(text)
     end
   end
@@ -101,25 +101,5 @@ describe "dashboards/show.html" do
       exercises: false,
       books: false
     }
-  end
-
-  def include_exercises
-    have_content("Hone your skills")
-  end
-
-  def include_video_tutorials
-    have_content("Enroll in our online video_tutorials")
-  end
-
-  def include_screencasts_and_shows
-    have_content("Watch our web shows and screencasts")
-  end
-
-  def include_shows
-    have_content("Watch The Weekly Iteration")
-  end
-
-  def include_books
-    have_content("Read our eBooks")
   end
 end


### PR DESCRIPTION
- It was previously displaying with an underscore ('video_tutorials')
- Also remove unused helper methods in tests
