### PR TITLE
Update Airbrake notifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.1.2'
 gem 'RedCloth', '4.2.9', require: 'redcloth'
 gem 'active_model_serializers', '~> 0.7.0'
 gem 'acts_as_list', '0.2.0'
-gem 'airbrake', '3.1.14'
+gem 'airbrake', '~> 4.0.0'
 gem 'aws-sdk', '= 1.6.2' # Bug https://github.com/thoughtbot/paperclip/issues/751
 gem 'analytics-ruby'
 gem 'bluecloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,9 +71,9 @@ GEM
     acts_as_list (0.2.0)
       activerecord (>= 3.0)
     addressable (2.3.6)
-    airbrake (3.1.14)
+    airbrake (4.0.0)
       builder
-      json
+      multi_json
     analytics-ruby (0.5.4)
       faraday (>= 0.8, < 0.10)
       faraday_middleware (>= 0.8, < 0.10)
@@ -401,7 +401,7 @@ DEPENDENCIES
   RedCloth (= 4.2.9)
   active_model_serializers (~> 0.7.0)
   acts_as_list (= 0.2.0)
-  airbrake (= 3.1.14)
+  airbrake (~> 4.0.0)
   analytics-ruby
   aws-sdk (= 1.6.2)
   bluecloth


### PR DESCRIPTION
We're getting warnings from Airbrake about using an outdated notifier.

https://trello.com/c/lwo2f1kt/163-update-airbrake-notifier
