### PR TITLE
Remove dash from welcome's email signature

### DIFF
--- a/app/views/subscription_mailer/welcome_to_upcase_from_mentor.text.erb
+++ b/app/views/subscription_mailer/welcome_to_upcase_from_mentor.text.erb
@@ -16,4 +16,4 @@ Before our first call, please do the following:
 
 Talk soon!
 
-- <%= @mentor.first_name %>
+<%= @mentor.first_name %>


### PR DESCRIPTION
Renders as a bullet in Gmail. Makes it look less personal? See attachment:

![screen shot 2014-09-10 at 10 04 39 am](https://cloud.githubusercontent.com/assets/54260/4218657/6e767a84-38f3-11e4-83f0-b125f31eb9cd.png)

Trello card: https://trello.com/c/u4yV4N2L/164-welcome-email-signature-adjustment
