### PR TITLE
Display branch/commit/env only in development

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
   </head>
 
   <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
-    <%= render 'shared/environment' unless Rails.env.production? %>
     <%= render 'shared/header' %>
 
     <%= render 'shared/flashes' %>

--- a/app/views/shared/_environment.html.erb
+++ b/app/views/shared/_environment.html.erb
@@ -1,5 +1,0 @@
-<div id="rails_env">
-  <%= [Rails.env,
-       `git rev-parse --abbrev-ref HEAD`,
-       `git rev-parse --short HEAD`].compact.join(' - ') %>
-</div>


### PR DESCRIPTION
Wanted to show in staging deploy information, but in Heroku the app doesn't have
access to the repository. Something to investigate on a Friday.

Leaving only in development for now.

Trello card: https://trello.com/c/sQdI7ppU/139-put-deploy-information-in-the-header-environment-branch-last-commit-sha-in-non-production-environments
