### PR TITLE
Removes pointer cursor, as element is not a link

### DIFF
--- a/app/assets/stylesheets/_product-card.scss.erb
+++ b/app/assets/stylesheets/_product-card.scss.erb
@@ -9,7 +9,6 @@
 
   &:hover {
     background: darken(white, 3);
-    cursor: pointer;
   }
 
   header {


### PR DESCRIPTION
Confuses users, as it looks like a link but it's not.

Can't make it a link because it contains child links, and that's disallowed by
the spec.

Trello card: https://trello.com/c/YQkfRzd3/148-link-background-of-topics-to-their-index
