### PR TITLE
CSS for "Locked - Get access by upgrading" link

### DIFF
--- a/app/assets/stylesheets/_product-card.scss.erb
+++ b/app/assets/stylesheets/_product-card.scss.erb
@@ -100,7 +100,7 @@
 
   &.dashboard-resource {
     border-top: 5px solid $green;
-    height: 165px;
+    height: 185px;
 
     h4 {
       color: $darkwarmgray;
@@ -115,9 +115,24 @@
       margin-top: 0;
     }
 
+    &.card > a {
+      height: 82%;
+    }
+
     &.trails {
       background: url(<%= asset_path 'upcase/trails-graphic.svg' %>) white no-repeat 3rem .8rem;
       background-size: 75%;
+    }
+
+    .product-card-locked {
+      text-align: center;
+
+      a.upgrade-link {
+        color: $darkwarmgray;
+        font-size: .75rem;
+        font-weight: bold;
+        text-transform: uppercase;
+      }
     }
   }
 

--- a/app/views/dashboards/_locked.html.erb
+++ b/app/views/dashboards/_locked.html.erb
@@ -2,7 +2,7 @@
   <span class="icon">
     <%= image_tag("icons/lock.svg", size: "11x15") %>
   </span>
-  <%= link_to edit_subscription_path do %>
-    <h5>Get access by upgrading</h5>
-  <% end %>
+  <%= link_to 'Get access by upgrading',
+              edit_subscription_path,
+              class: 'upgrade-link' %>
 </div>


### PR DESCRIPTION
I couldn't find any related CSS, but I find it hard to believe that it was never there. Anyhow, now it appears, see screenshot:
![screen shot 2014-09-10 at 2 26 08 pm](https://cloud.githubusercontent.com/assets/54260/4222988/0e2bbcdc-3918-11e4-9d5d-aad4a10d9bdc.png)

Trello card:
https://trello.com/c/DzjfRoMl/149-locked-info-doesn-t-show-up-in-product-cards-at-the-top-of-dashboard
