### PR TITLE
Add a .pryrc and .irbrc

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,3 @@
+def find_user(email)
+  User.find_by_email(email)
+end

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,1 @@
+eval(File.open(".irbrc").read)


### PR DESCRIPTION
Both files are needed because in development we use pry-rails, which
looks for a .pryrc. Staging and production on heroku will use the
.irbrc.
