### PR TITLE
Notify existing users accepting invitations they need to email us

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -9,7 +9,6 @@
 @import "base-typography";
 @import "base-forms";
 
-@import "environment";
 @import "product-card";
 
 @import "layout/layout";

--- a/app/assets/stylesheets/environment.scss
+++ b/app/assets/stylesheets/environment.scss
@@ -1,6 +1,0 @@
-#rails_env {
-  background: $upcase-red;
-  color: white;
-  font-size: .8em;
-  text-align: center;
-}

--- a/app/controllers/acceptances_controller.rb
+++ b/app/controllers/acceptances_controller.rb
@@ -1,5 +1,6 @@
 class AcceptancesController < ApplicationController
   def new
+    @existing_user = User.exists?(email: find_invitation.email)
     @acceptance = build_acceptance
   end
 

--- a/app/views/acceptances/_existing_user.html.erb
+++ b/app/views/acceptances/_existing_user.html.erb
@@ -1,0 +1,6 @@
+<section style="text-align: center">
+  <p>You have been invited to join a team, but you already have an account.</p>
+
+  <p>Please email <%= mail_to 'help@upcase.com' %> and we'll add you to your
+  team.</p>
+</section>

--- a/app/views/acceptances/_form.html.erb
+++ b/app/views/acceptances/_form.html.erb
@@ -1,0 +1,12 @@
+<%= semantic_form_for(
+  acceptance,
+  url: invitation_acceptances_path(acceptance.invitation)
+) do |form| %>
+  <%= form.semantic_errors :invitation %>
+  <%= form.inputs do %>
+    <%= form.input :name %>
+    <%= form.input :github_username %>
+    <%= form.input :password %>
+    <%= form.submit 'Create an account' %>
+  <% end %>
+<% end %>

--- a/app/views/acceptances/new.html.erb
+++ b/app/views/acceptances/new.html.erb
@@ -1,16 +1,9 @@
 <section id="auth-form-container">
   <div class="thoughtbot-signin">
-    <%= semantic_form_for(
-      @acceptance,
-      url: invitation_acceptances_path(@acceptance.invitation)
-    ) do |form| %>
-      <%= form.semantic_errors :invitation %>
-      <%= form.inputs do %>
-        <%= form.input :name %>
-        <%= form.input :github_username %>
-        <%= form.input :password %>
-        <%= form.submit 'Create an account' %>
-      <% end %>
+    <% if @existing_user %>
+      <%= render 'existing_user' %>
+    <% else %>
+      <%= render 'form', acceptance: @acceptance %>
     <% end %>
   </div>
 </section>

--- a/spec/features/user_accepts_team_invitation_spec.rb
+++ b/spec/features/user_accepts_team_invitation_spec.rb
@@ -49,4 +49,23 @@ feature "Accept team invitations" do
       expect(page).to have_content("Dashboard")
     end
   end
+
+  scenario "has existing account" do
+    create(:user, email: "invited-member@example.com")
+
+    visit_team_plan_checkout_page
+    fill_out_account_creation_form email: "owner@somedomain.com"
+    fill_out_credit_card_form_with_valid_credit_card
+
+    fill_in "Email", with: "invited-member@example.com"
+    click_on "Send"
+
+    using_session :team_member do
+      open_email "invited-member@example.com"
+      click_first_link_in_email
+
+      expect(page).to have_content("you already have an account")
+      expect(page).to have_content("Please email help@upcase.com")
+    end
+  end
 end


### PR DESCRIPTION
Redirects to sign in form, telling them they don't need to reclaim an
invitation.

Trello card:
https://trello.com/c/0CVnICbR/140-page-re-renders-without-error-when-accepting-an-invitation
