### PR TITLE
Makes `VideoTutorial` a type of `Product`

### DIFF
--- a/app/models/catalog.rb
+++ b/app/models/catalog.rb
@@ -6,7 +6,7 @@ class Catalog
   end
 
   def video_tutorials
-    VideoTutorial.only_active.by_position
+    VideoTutorial.active
   end
 
   def screencasts

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,9 +1,9 @@
 class Product < ActiveRecord::Base
   extend FriendlyId
 
-  has_many :classifications, as: :classifiable
-  has_many :downloads, as: :purchaseable
-  has_many :licenses, as: :licenseable
+  has_many :classifications, as: :classifiable, dependent: :destroy
+  has_many :downloads, as: :purchaseable, dependent: :destroy
+  has_many :licenses, as: :licenseable, dependent: :destroy
   has_many :topics, through: :classifications
   has_many :videos, as: :watchable, dependent: :destroy
 
@@ -73,11 +73,11 @@ class Product < ActiveRecord::Base
   end
 
   def title
-    "#{name}: a #{type.downcase} by thoughtbot"
+    "#{name}: a #{offering_type.humanize.downcase} by thoughtbot"
   end
 
   def offering_type
-    type.downcase
+    type.underscore
   end
 
   def fulfilled_with_github?

--- a/app/models/related.rb
+++ b/app/models/related.rb
@@ -4,7 +4,7 @@ class Related
   end
 
   def video_tutorials
-    @item.video_tutorials.only_active.by_position
+    @item.video_tutorials.active
   end
 
   def products

--- a/app/models/video_tutorial.rb
+++ b/app/models/video_tutorial.rb
@@ -1,15 +1,7 @@
-class VideoTutorial < ActiveRecord::Base
-  extend FriendlyId
-
-  # Associations
-  has_many :classifications, as: :classifiable, dependent: :destroy
-  has_many :downloads, as: :purchaseable
-  has_many :licenses, as: :licenseable, dependent: :restrict_with_exception
+class VideoTutorial < Product
   has_many :questions, -> { order 'created_at ASC' }, dependent: :destroy
   has_many :teachers, dependent: :destroy
-  has_many :topics, through: :classifications
   has_many :users, through: :teachers
-  has_many :videos, as: :watchable
 
   # Nested Attributes
   accepts_nested_attributes_for :questions, reject_if: :all_blank
@@ -17,69 +9,10 @@ class VideoTutorial < ActiveRecord::Base
   # Validations
   validates :description, presence: true
   validates :length_in_days, presence: true
-  validates :name, presence: true
-  validates :short_description, presence: true
-  validates :sku, presence: true
-  validates :slug, presence: true, uniqueness: true
-
-  # Plugins
-  acts_as_list
-  friendly_id :name, use: :slugged
-
-  def self.by_position
-    order 'video_tutorials.position ASC'
-  end
-
-  def self.only_active
-    where active: true
-  end
-
-  def self.promoted
-    where promoted: true
-  end
-
-  def questions_with_blank
-    questions + [questions.new]
-  end
-
-  def to_param
-    slug
-  end
-
-  def license_for(user)
-    licenses.where(user_id: user).first
-  end
-
-  def title
-    "#{name}: a video_tutorial from thoughtbot"
-  end
-
-  def meta_keywords
-    topics.meta_keywords
-  end
-
-  def offering_type
-    'video_tutorial'
-  end
-
-  def tagline
-    short_description
-  end
-
-  def fulfilled_with_github?
-    github_team.present?
-  end
+  validates :tagline, presence: true
 
   def thumbnail_path
     "video_tutorial_thumbs/#{name.parameterize}.png"
-  end
-
-  def subscription?
-    false
-  end
-
-  def fulfill(license, user)
-    GithubFulfillment.new(license).fulfill
   end
 
   def starts_on(license_date = nil)
@@ -92,14 +25,6 @@ class VideoTutorial < ActiveRecord::Base
 
   def collection?
     true
-  end
-
-  def to_aside_partial
-    'video_tutorials/aside'
-  end
-
-  def published_videos
-    videos.published
   end
 
   def included_in_plan?(plan)

--- a/app/services/topic_with_resources_factory.rb
+++ b/app/services/topic_with_resources_factory.rb
@@ -1,7 +1,7 @@
 # Factory which can decorate a Topic with a list of related resources from a
 # Catalog.
 class TopicWithResourcesFactory
-  RESOURCE_TYPES = %i(exercises products videos video_tutorials)
+  RESOURCE_TYPES = %i(exercises products videos)
 
   def initialize(catalog:, limit: nil)
     @catalog = catalog

--- a/app/views/products/video_tutorials/_video_tutorial.html.erb
+++ b/app/views/products/video_tutorials/_video_tutorial.html.erb
@@ -4,6 +4,6 @@
     <%= image_tag(video_tutorial.thumbnail_path) %>
     <h6 class="status"><%= video_tutorial_card_status(video_tutorial) %></h6>
     <h4><%= video_tutorial.name %></h4>
-    <p><%= video_tutorial.short_description %></p>
+    <p><%= video_tutorial.tagline %></p>
   <% end %>
 <% end %>

--- a/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
+++ b/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
@@ -3,6 +3,6 @@
     <h5>Video Tutorial</h5>
     <%= image_tag(video_tutorial.thumbnail_path) %>
     <h4><%= video_tutorial.name %></h4>
-    <p><%= video_tutorial.short_description %></p>
+    <p><%= video_tutorial.tagline %></p>
   <% end %>
 </figure>

--- a/app/views/video_tutorials/_video_tutorial.html.erb
+++ b/app/views/video_tutorials/_video_tutorial.html.erb
@@ -1,6 +1,6 @@
 <li class="product-list">
   <%= link_to video_tutorial do %>
     <h3><%= video_tutorial.name %></h3>
-    <p><%= video_tutorial.short_description %></p>
+    <p><%= video_tutorial.tagline %></p>
   <% end %>
 </li>

--- a/db/migrate/20140916190948_add_video_attributes_to_products.rb
+++ b/db/migrate/20140916190948_add_video_attributes_to_products.rb
@@ -1,0 +1,6 @@
+class AddVideoAttributesToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :length_in_days, :integer
+    add_column :products, :resources, :text, default: "", null: false
+  end
+end

--- a/db/migrate/20140916190949_move_video_tutorials_into_products.rb
+++ b/db/migrate/20140916190949_move_video_tutorials_into_products.rb
@@ -1,0 +1,21 @@
+class MoveVideoTutorialsIntoProducts < ActiveRecord::Migration
+  def up
+    say_with_time "Moving video_tutorials into products" do
+      # Move team_plans data into individual_plans
+      insert(<<-SQL)
+        INSERT INTO products (sku, name, terms, description, short_description,
+          length_in_days, active, github_team, promoted, slug, resources,
+          tagline, type)
+
+        SELECT sku, name, terms, description, short_description,
+          length_in_days, active, github_team, promoted, slug, resources,
+          short_description, 'VideoTutorial'
+          FROM video_tutorials
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20140916190950_drop_table_video_tutorials.rb
+++ b/db/migrate/20140916190950_drop_table_video_tutorials.rb
@@ -1,0 +1,9 @@
+class DropTableVideoTutorials < ActiveRecord::Migration
+  def up
+    drop_table :video_tutorials
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,6 +203,8 @@ ActiveRecord::Schema.define(version: 20140917182800) do
     t.string   "product_image_updated_at"
     t.boolean  "promoted",                   default: false, null: false
     t.string   "slug",                                       null: false
+    t.integer  "length_in_days"
+    t.text     "resources",                  default: "",    null: false
   end
 
   add_index "products", ["slug"], name: "index_products_on_slug", unique: true, using: :btree
@@ -328,25 +330,6 @@ ActiveRecord::Schema.define(version: 20140917182800) do
   add_index "users", ["mentor_id"], name: "index_users_on_mentor_id", using: :btree
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
   add_index "users", ["team_id"], name: "index_users_on_team_id", using: :btree
-
-  create_table "video_tutorials", force: true do |t|
-    t.string   "name",                              null: false
-    t.text     "description"
-    t.boolean  "active",            default: true,  null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "short_description"
-    t.integer  "position"
-    t.text     "terms"
-    t.text     "resources",         default: "",    null: false
-    t.integer  "github_team"
-    t.integer  "length_in_days"
-    t.string   "sku"
-    t.boolean  "promoted",          default: false, null: false
-    t.string   "slug",                              null: false
-  end
-
-  add_index "video_tutorials", ["slug"], name: "index_video_tutorials_on_slug", unique: true, using: :btree
 
   create_table "videos", force: true do |t|
     t.integer  "watchable_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,7 +50,7 @@ FactoryGirl.define do
 
     description 'Solve 8-Queens over and over again'
     name { generate(:name) }
-    short_description 'Solve 8-Queens'
+    tagline 'Solve 8-Queens'
     sku 'EIGHTQUEENS'
     length_in_days 28
 

--- a/spec/models/catalog_spec.rb
+++ b/spec/models/catalog_spec.rb
@@ -20,7 +20,7 @@ describe Catalog do
     it "returns active video_tutorials in order" do
       catalog = Catalog.new
       expect(catalog.video_tutorials).
-        to find_relation(VideoTutorial.only_active.by_position)
+        to find_relation(VideoTutorial.active)
     end
   end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 describe Product do
-  it { should have_many(:licenses) }
+  it { should have_many(:classifications).dependent(:destroy) }
+  it { should have_many(:downloads).dependent(:destroy) }
+  it { should have_many(:licenses).dependent(:destroy) }
+  it { should have_many(:topics).through(:classifications) }
+  it { should have_many(:videos).dependent(:destroy) }
   it { should validate_presence_of(:slug) }
 
   context "uniqueness" do

--- a/spec/models/related_spec.rb
+++ b/spec/models/related_spec.rb
@@ -29,16 +29,14 @@ describe Related do
 
   describe 'video_tutorials' do
     it 'returns the active ordered video_tutorials of the item' do
-      by_position = stub(:by_position)
-      only_active = stub(only_active: by_position)
-      item = stub(video_tutorials: only_active)
+      active = stub(:active)
+      item = stub(video_tutorials: active)
 
       related = Related.new(item)
       related.video_tutorials
 
       expect(item).to have_received(:video_tutorials)
-      expect(only_active).to have_received(:only_active)
-      expect(by_position).to have_received(:by_position)
+      expect(active).to have_received(:active)
     end
   end
 

--- a/spec/models/show_spec.rb
+++ b/spec/models/show_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 describe Show do
   it_behaves_like 'a class inheriting from Product'
 
-  it { should have_many(:videos).dependent(:destroy) }
-
   describe '.the_weekly_iteration' do
     it 'finds the show named The Weekly Iteration' do
       show = create(:show, name: Show::THE_WEEKLY_ITERATION)

--- a/spec/models/video_tutorial_spec.rb
+++ b/spec/models/video_tutorial_spec.rb
@@ -2,62 +2,21 @@ require "rails_helper"
 
 describe VideoTutorial do
   # Associations
-  it { should have_many(:classifications).dependent(:destroy) }
-  it { should have_many(:downloads) }
-  it { should have_many(:licenses).dependent(:restrict_with_exception) }
   it { should have_many(:questions).dependent(:destroy) }
   it { should have_many(:teachers).dependent(:destroy) }
-  it { should have_many(:topics).through(:classifications) }
   it { should have_many(:users).through(:teachers) }
-  it { should have_many(:videos) }
 
   # Validations
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:short_description) }
+  it { should validate_presence_of(:tagline) }
   it { should validate_presence_of(:sku) }
   it { should validate_presence_of(:length_in_days) }
-  it { should validate_presence_of(:slug) }
-
-  context "uniqueness" do
-    before do
-      create :video_tutorial
-    end
-
-    it { should validate_uniqueness_of(:slug) }
-  end
-
-  describe 'self.promoted' do
-    it 'returns promoted video_tutorials' do
-      promoted_video_tutorials = create_list(:video_tutorial, 2, promoted: true)
-      create(:video_tutorial, promoted: false)
-
-      expect(VideoTutorial.promoted).to eq(promoted_video_tutorials)
-    end
-  end
 
   describe "#to_param" do
     it "returns the slug" do
       video_tutorial = create(:video_tutorial)
       expect(video_tutorial.to_param).to eq video_tutorial.slug
-    end
-  end
-
-  context "license_for" do
-    it "returns the license when a user has licensed a section of the video_tutorial" do
-      user = create(:user)
-      video_tutorial = create(:video_tutorial)
-      license = create(:license, licenseable: video_tutorial, user: user)
-
-      expect(video_tutorial.license_for(user)).to eq license
-    end
-
-    it 'returns nil when a user has not licensed a section fo the video_tutorial' do
-      user = create(:user)
-      video_tutorial = create(:video_tutorial)
-      create(:license, licenseable: video_tutorial)
-
-      expect(video_tutorial.license_for(user)).to be_nil
     end
   end
 
@@ -67,7 +26,7 @@ describe VideoTutorial do
 
       result = video_tutorial.title
 
-      expect(result).to eq 'Billy: a video_tutorial from thoughtbot'
+      expect(result).to eq 'Billy: a video tutorial by thoughtbot'
     end
   end
 
@@ -82,16 +41,6 @@ describe VideoTutorial do
       result = video_tutorial.offering_type
 
       expect(result).to eq 'video_tutorial'
-    end
-  end
-
-  describe '#tagline' do
-    it 'returns the short description' do
-      video_tutorial = build_stubbed(:video_tutorial)
-
-      result = video_tutorial.tagline
-
-      expect(result).to eq(video_tutorial.short_description)
     end
   end
 
@@ -120,20 +69,6 @@ describe VideoTutorial do
   describe '#subscription?' do
     it 'returns false' do
       expect(VideoTutorial.new).not_to be_subscription
-    end
-  end
-
-  describe '#fulfill' do
-    it 'fulfills using GitHub with a GitHub team' do
-      license = build_stubbed(:license)
-      user = build_stubbed(:user)
-      fulfillment = stub('fulfillment', :fulfill)
-      video_tutorial = build_stubbed(:video_tutorial, github_team: 'example')
-      GithubFulfillment.stubs(:new).with(license).returns(fulfillment)
-
-      video_tutorial.fulfill(license, user)
-
-      expect(fulfillment).to have_received(:fulfill)
     end
   end
 

--- a/spec/views/promoted_catalogs/show.html.erb_spec.rb
+++ b/spec/views/promoted_catalogs/show.html.erb_spec.rb
@@ -97,7 +97,7 @@ describe 'promoted_catalogs/show.html.erb' do
       render
 
       expect(rendered).to include(video_tutorial.name)
-      expect(rendered).to include(video_tutorial.short_description)
+      expect(rendered).to include(video_tutorial.tagline)
       expect(rendered).to include(image_tag(video_tutorial.thumbnail_path))
       link_title = "The #{video_tutorial.name} online video tutorial details"
       expect(rendered).


### PR DESCRIPTION
- Adds `Product#position` and `Product#resources`.
- Moves `video_tutorials` data into `products`.
- Removes `video_tutorials` table. With it, `VideoTutorial#position` and its `acts_as_list` functionality go.
- Replaces `VideoTutorial#short_description` with `tagline`.

Trello card: https://trello.com/c/TvCPWAGg/160-make-videotutorials-into-another-product-type
