### PR TITLE
Mentor downgrade notification bugfix

### DIFF
--- a/app/mailers/downgrade_mailer.rb
+++ b/app/mailers/downgrade_mailer.rb
@@ -1,6 +1,6 @@
 class DowngradeMailer < BaseMailer
   def notify_mentor(mentor_id:, mentee_id:)
-    @mentor = User.find mentor_id
+    @mentor = Mentor.find(mentor_id).user
     @mentee = User.find mentee_id
 
     mail(

--- a/spec/mailers/downgrade_mailer_spec.rb
+++ b/spec/mailers/downgrade_mailer_spec.rb
@@ -6,7 +6,7 @@ describe DowngradeMailer do
       mentee = build_stubbed(:subscriber)
       mentor = build_stubbed(:mentor)
       User.stubs(:find).with(mentee.id).returns(mentee)
-      User.stubs(:find).with(mentor.id).returns(mentor)
+      Mentor.stubs(:find).with(mentor.id).returns(mentor)
 
       mail = DowngradeMailer.
                notify_mentor(mentor_id: mentor.id, mentee_id: mentee.id).


### PR DESCRIPTION
id being passed belongs to `Mentor`, which `belongs_to` `User`.

Trello card: https://trello.com/c/DUcnfzC6/127-send-email-to-mentor-once-plan-downgraded
