### PR TITLE
Display validation errors for GitHub username

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -43,6 +43,7 @@ class Checkout < ActiveRecord::Base
     errors[:email] = user.errors[:email]
     errors[:name] = user.errors[:name]
     errors[:password] = user.errors[:password]
+    errors[:github_username] = user.errors[:github_username]
     errors
   end
 

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -67,6 +67,17 @@ describe Checkout do
       expect(checkout.errors[:password]).to include "can't be blank"
     end
 
+    it "requires a unique GitHub username if there is no user" do
+      create :user, github_username: "taken"
+      checkout =
+        build(:checkout, user: nil, github_username: "taken", password: "test")
+
+      checkout.save
+
+      expect(checkout.errors.full_messages).
+        to include("Github username has already been taken")
+    end
+
     it "creates a user when saved with a password" do
       checkout = build(:checkout, user: nil, github_username: "cpytel")
       checkout.password = "test"


### PR DESCRIPTION
Because:
- During signup, these errors were added to User but not Checkout.
- Only Checkout errors are displayed on the page.
- The page would be re-rendered without any error.

This commit:
- Copies GitHub username validations from User to Checkout.

Validation errors are now displayed on the checkout page.

https://trello.com/c/YjiYlXZd/176-error-when-attempting-to-subscribe-with-existing-github-name
