### PR TITLE
Enable extention "pg_stat_statements"

### DIFF
--- a/db/migrate/20140924174818_enable_pg_stat_statements.rb
+++ b/db/migrate/20140924174818_enable_pg_stat_statements.rb
@@ -1,0 +1,5 @@
+class EnablePgStatStatements < ActiveRecord::Migration
+  def change
+    enable_extension "pg_stat_statements"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140923180945) do
+ActiveRecord::Schema.define(version: 20140924174818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "checkouts", force: true do |t|
     t.integer  "user_id",                        null: false


### PR DESCRIPTION
- Heroku enables this in production
- This places development in sync with production
- This prevents `db/schema.rb` changes when using a production dump
