### PR TITLE
Check for remote access before redirecting to GitHub

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -4,13 +4,31 @@ class RepositoriesController < ApplicationController
   end
 
   def show
-    repository = Repository.friendly.find(params[:id])
-    @offering = Offering.new(repository, current_user)
+    @repository = Repository.friendly.find(params[:id])
+    @offering = Offering.new(@repository, current_user)
 
+    check_license do
+      check_github_access do
+        redirect_to @repository.github_url
+      end
+    end
+  end
+
+  private
+
+  def check_license
     if @offering.user_has_license?
-      redirect_to repository.github_url
+      yield
     else
       render template: "products/show"
+    end
+  end
+
+  def check_github_access
+    if @repository.has_github_member?(current_user)
+      yield
+    else
+      render :status
     end
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -5,4 +5,14 @@ class Repository < Product
   def included_in_plan?(plan)
     plan.has_feature?(:source_code)
   end
+
+  def has_github_member?(user)
+    github_client.team_member?(github_team, user.github_username)
+  end
+
+  private
+
+  def github_client
+    Octokit::Client.new(login: GITHUB_USER, password: GITHUB_PASSWORD)
+  end
 end

--- a/app/views/repositories/status.html.erb
+++ b/app/views/repositories/status.html.erb
@@ -1,0 +1,17 @@
+<%= render "offerings/meta", offering: @offering %>
+
+<p>
+  We're adding you to the GitHub repository, and we'll redirect you as soon it's
+  ready. You may receive an email from GitHub asking you to confirm your
+  membership, so make sure to take quick look in your inbox.
+</p>
+
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    (function () {
+      setTimeout(function reload() {
+        window.location.reload();
+      }, 5000);
+    })();
+  </script>
+<% end -%>

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe RepositoriesController do
+  describe "#show" do
+    context "with a license and GitHub access" do
+      it "redirects to the repository on GitHub" do
+        repository = build_stubbed(:repository)
+
+        show_repository repository, license: true, github_access: true
+
+        expect(response).to redirect_to(repository.github_url)
+      end
+    end
+
+    context "with a license but no GitHub access" do
+      it "renders status for the repository" do
+        repository = build_stubbed(:repository)
+
+        show_repository repository, license: true, github_access: false
+
+        expect(controller).to render_template("repositories/status")
+      end
+    end
+
+    context "with no license" do
+      it "renders the product template" do
+        repository = build_stubbed(:repository)
+
+        show_repository repository, license: false, github_access: false
+
+        expect(controller).to render_template("products/show")
+      end
+    end
+  end
+
+  def show_repository(repository, license:, github_access:)
+    user = build_stubbed(:user)
+    finder = stub("finder")
+    finder.stubs(:find).with(repository.to_param).returns(repository)
+    Repository.stubs(:friendly).returns(finder)
+    offering = stub("offering", user_has_license?: license)
+    Offering.stubs(:new).with(repository, user).returns(offering)
+    repository.stubs(:has_github_member?).with(user).returns(github_access)
+
+    sign_in_as user
+    get :show, id: repository.to_param
+  end
+end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -18,4 +18,39 @@ describe Repository do
       expect(result).to eq(expected)
     end
   end
+
+  describe "#has_github_member?" do
+    context "with GitHub access" do
+      it "returns true" do
+        user = build_stubbed(:user)
+        repository = build_stubbed(:repository)
+        client = stub_github_client
+        client.
+          stubs(:team_member?).
+          with(repository.github_team, user.github_username).
+          returns(true)
+
+        expect(repository).to have_github_member(user)
+      end
+    end
+
+    context "without GitHub access" do
+      it "returns false" do
+        user = build_stubbed(:user)
+        repository = build_stubbed(:repository)
+        client = stub_github_client
+        client.stubs(:team_member?).returns(false)
+
+        expect(repository).not_to have_github_member(user)
+      end
+    end
+
+    def stub_github_client
+      stub("github_client").tap do |client|
+        Octokit::Client.
+          stubs(:new).
+          with(login: GITHUB_USER, password: GITHUB_PASSWORD).returns(client)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because:
- We add GitHub access in a background job
- Users must accept an invitation before the actually have access
- We don't want to redirect to a 404 page

This commit:
- Checks for access on GitHub before redirecting
- Displays a status page and reloads until access is accepted

https://trello.com/c/pqFl9m2l/166-landing-pages-for-semi-private-github-repositories
