### PR TITLE
Fix wording in fulfillment error email

### DIFF
--- a/app/views/license_mailer/fulfillment_error.text.erb
+++ b/app/views/license_mailer/fulfillment_error.text.erb
@@ -4,4 +4,4 @@ We're really sorry, but there was a problem adding your GitHub account <%= @user
 
 We've been notified and we are working to resolve this issue ASAP. We'll be back in touch as soon as we have it resolved.
 
-Thank you very much for your license, and your patience.
+Thank you very much for subscribing, and your patience.


### PR DESCRIPTION
This looks like a bad find and replace from "purchase" to "license."
