### PR TITLE
Adds new statuses instead of updating only one

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -10,6 +10,6 @@ class Exercise < ActiveRecord::Base
   end
 
   def status_for(user)
-    statuses.where(user: user).first || NotStarted.new
+    statuses.where(user: user).most_recent || NotStarted.new
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -6,5 +6,8 @@ class Status < ActiveRecord::Base
 
   validates :exercise_id, :user_id, presence: true
   validates :state, inclusion: { in: STATES }
-  validates :user_id, uniqueness: { scope: :exercise_id }
+
+  def self.most_recent
+    order(:created_at).last
+  end
 end

--- a/db/migrate/20140930185615_remove_unique_index_from_statuses.rb
+++ b/db/migrate/20140930185615_remove_unique_index_from_statuses.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexFromStatuses < ActiveRecord::Migration
+  def change
+    remove_index :statuses, name: :index_statuses_on_exercise_id_and_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140926183202) do
+ActiveRecord::Schema.define(version: 20140930185615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,8 +248,6 @@ ActiveRecord::Schema.define(version: 20140926183202) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "statuses", ["exercise_id", "user_id"], name: "index_statuses_on_exercise_id_and_user_id", unique: true, using: :btree
 
   create_table "subscriptions", force: true do |t|
     t.integer  "user_id"

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -22,5 +22,16 @@ describe Exercise do
 
       expect(exercise.status_for(user)).to be_a NotStarted
     end
+
+    it "returns the latest status for the user" do
+      exercise = create(:exercise)
+      user = create(:user)
+      status = create(:status, exercise: exercise, user: user)
+      Timecop.travel(1.day.ago) do
+        create(:status, exercise: exercise, user: user)
+      end
+
+      expect(exercise.status_for(user)).to eq status
+    end
   end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -8,12 +8,15 @@ describe Status do
   it { should validate_presence_of(:user_id) }
   it { should ensure_inclusion_of(:state).in_array(Status::STATES) }
 
-  context "uniqueness" do
-    subject do
-      create(:status)
-    end
+  context ".most_recent" do
+    it "returns the latest status" do
+      status = create(:status)
+      Timecop.travel(1.day.ago) do
+        create(:status)
+      end
 
-    it { should validate_uniqueness_of(:user_id).scoped_to(:exercise_id) }
+      expect(Status.most_recent).to eq status
+    end
   end
 
   context "#state" do


### PR DESCRIPTION
We now keep the data of how long does it take for a user or exercise to move
from one state to the next one.

It will also simplify implementation, as we don't need to check if we need to
create or update a status: we always create.
