### PR TITLE
Exercise Status API endpoint. Adds Exercise#uuid.

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::StatusesController < ApiController
+  def create
+    exercise.statuses.create!(user: resource_owner, state: params[:state])
+    render nothing: true
+  end
+
+  private
+
+  def exercise
+    Exercise.find_by!(uuid: params[:exercise_uuid])
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,6 +1,8 @@
 namespace :api do
   namespace :v1 do
     resources :completions, only: [:index, :show, :create, :destroy]
+
+    post "exercises/:exercise_uuid/status" => "statuses#create", as: :status
   end
 end
 

--- a/db/migrate/20140930160731_add_uuid_to_exercises.rb
+++ b/db/migrate/20140930160731_add_uuid_to_exercises.rb
@@ -1,0 +1,5 @@
+class AddUuidToExercises < ActiveRecord::Migration
+  def change
+    add_column :exercises, :uuid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20140930185615) do
     t.text     "summary",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "uuid"
   end
 
   create_table "invitations", force: true do |t|

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe Api::V1::StatusesController do
+  context "#update" do
+    it "updates the status of the given exercise for the authenticated user" do
+      exercise = create(:exercise)
+      user = create(:user)
+      controller.stubs(:resource_owner).returns(user)
+
+      post :create, exercise_uuid: exercise.uuid, state: "Submitted"
+
+      expect(response).to be_success
+      expect(exercise.status_for(user).state).to eq "Submitted"
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
     "name #{n}"
   end
 
+  sequence :uuid do |n|
+    "uuid_#{n}"
+  end
+
   sequence :github_username do |n|
     "github_#{n}"
   end
@@ -408,9 +412,10 @@ FactoryGirl.define do
   end
 
   factory :exercise do
+    summary "Exercise summary"
     title
     url "http://www.example.com"
-    summary "Exercise summary"
+    uuid
   end
 
   factory :oauth_access_token do


### PR DESCRIPTION
To do:
- Make statuses#uuid not null
  Implies filling them withw whatever whetstone generates.
