### PR TITLE
Configure Exercises in admin

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,6 +1,7 @@
 class Exercise < ActiveRecord::Base
   has_many :classifications, as: :classifiable, dependent: :destroy
   has_many :statuses, dependent: :destroy
+  has_many :topics, through: :classifications
 
   validates :title, presence: true
   validates :url, presence: true

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -130,4 +130,15 @@ RailsAdmin.config do |config|
       end
     end
   end
+
+  config.model Exercise do
+    list do
+      field :id
+      field :title
+    end
+    edit do
+      include_all_fields
+      exclude_fields :classifications, :statuses
+    end
+  end
 end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -4,6 +4,7 @@ describe Exercise do
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:url) }
   it { should have_many(:classifications) }
+  it { should have_many(:topics).through(:classifications) }
 
   describe ".ordered" do
     it "returns older exercises first" do


### PR DESCRIPTION
Previously it was not possible to add topics to exercises in the admin.

I took the opportunity to clean up the Exercises in the admin as well, simplifying the listing and removing statuses from the admin.
