### PR TITLE
Fix spec warnings from stubbing non-public methods

### DIFF
--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Api::V1::StatusesController do
-  it 'returns a 401 when users are not authenticated' do
+  it "returns a 401 when users are not authenticated" do
     post :create, exercise_uuid: create(:exercise).uuid
 
     expect(response.code).to eq "401"
@@ -11,8 +11,8 @@ describe Api::V1::StatusesController do
     it "updates the status of the given exercise for the authenticated user" do
       exercise = create(:exercise)
       user = create(:user)
-      controller.stubs(:doorkeeper_token).returns(stub(accessible?: true))
-      controller.stubs(:resource_owner).returns(user)
+      access_token = build_stubbed(:oauth_access_token, user: user)
+      Doorkeeper::OAuth::Token.stubs(:authenticate).returns(access_token)
 
       post :create, exercise_uuid: exercise.uuid, state: Status::SUBMITTED
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -418,7 +418,12 @@ FactoryGirl.define do
     uuid
   end
 
-  factory :oauth_access_token do
+  factory :oauth_access_token, class: "Doorkeeper::AccessToken" do
+    ignore do
+      user nil
+    end
+
+    resource_owner_id { user.try(:id) }
     application_id 1
     token 'abc123'
   end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -8,7 +8,7 @@ describe DashboardsHelper, "#subscribe_or_upgrade_link" do
 
   context "when the user has no active subscription" do
     it "shows a 'subscribe' link" do
-      helper.stubs(:current_user_has_active_subscription?).returns(false)
+      stub_inactive_subscription
 
       result = helper.subscribe_or_upgrade_link
 
@@ -19,12 +19,26 @@ describe DashboardsHelper, "#subscribe_or_upgrade_link" do
 
   context "when the user has an active subscription" do
     it "shows an 'upgrade' link" do
-      helper.stubs(:current_user_has_active_subscription?).returns(true)
+      stub_active_subscription
 
       result = helper.subscribe_or_upgrade_link
 
       expect(result).to match(t(".locked_features.upgrade_link"))
       expect(result).to match(edit_subscription_path)
+    end
+  end
+
+  def stub_active_subscription
+    stub_subscription(true)
+  end
+
+  def stub_inactive_subscription
+    stub_subscription(false)
+  end
+
+  def stub_subscription(result)
+    Mocha::Configuration.allow(:stubbing_non_existent_method) do
+      helper.stubs(:current_user_has_active_subscription?).returns(result)
     end
   end
 end

--- a/spec/models/oauth_access_token_spec.rb
+++ b/spec/models/oauth_access_token_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 describe '.for_user' do
   it 'returns the last access token for a given user' do
     user = create(:user)
-    token = create(:oauth_access_token, resource_owner_id: user.id)
+    token = create(:oauth_access_token, user: user)
 
-    expect(OauthAccessToken.for_user(user)).to eq token
+    expect(OauthAccessToken.for_user(user).token).to eq token.token
   end
 
 end


### PR DESCRIPTION
- Some methods aren't defined on the helper
- Some methods are private controller methods
- Mocha prints warnings about unknown methods
- We can tell Mocha in this case to ignore the method
- We can use actual Doorkeeper OAuth tokens
