### PR TITLE
Nullify empty string for unique github_usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ActiveRecord::Base
   delegate :plan, to: :subscription, allow_nil: true
   delegate :scheduled_for_cancellation_on, to: :subscription, allow_nil: true
 
+  before_save :clean_github_username
+
   def self.with_active_subscription
     includes(purchased_subscription: :plan, team: { subscription: :plan }).
       select(&:has_active_subscription?)
@@ -98,6 +100,12 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def clean_github_username
+    if github_username.blank?
+      self.github_username = nil
+    end
+  end
 
   def team_subscription
     if team.present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,6 +42,16 @@ describe User do
     end
   end
 
+  context "#github_username" do
+    it "doesn't raise DB exception when saving empty strings" do
+      create(:user, github_username: "")
+      user = build(:user, github_username: "")
+
+      expect(user.save).to be true
+      expect(user.github_username).to be nil
+    end
+  end
+
   describe "#has_licensed?" do
     it "returns true if the user has any licenses" do
       user = build_stubbed(:user)


### PR DESCRIPTION
Database has a unique index in `users.github_username`. When they are `NULL` it
is not triggered, but empty strings are considered values, and database raises
exceptions.

This change nullifies the value when it comes as an empty string, allowing
`github_username` to be empty in forms.
