### PR TITLE
Remove PhantomJS requirement from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ your work.
 
         % open http://localhost:5000
 
-### Testing
-
-You'll need to install phantom.js to run some of the specs.
-
-        brew install phantomjs
-
 ### Continuous Integration
 
 CI is hosted with [CircleCI](https://circleci.com/gh/thoughtbot/upcase). The


### PR DESCRIPTION
We're using capybara-webkit in this project.
