### PR TITLE
Fix algorithm for checking if user accessed forum

### DIFF
--- a/app/models/oauth_access_token.rb
+++ b/app/models/oauth_access_token.rb
@@ -2,4 +2,14 @@ class OauthAccessToken < ActiveRecord::Base
   def self.for_user(user)
     where(resource_owner_id: user.id).last
   end
+
+  def self.for_forum
+    where(<<-SQL.squish)
+      application_id IN (
+        SELECT id
+        FROM oauth_applications
+        WHERE redirect_uri LIKE '%forum%'
+      )
+    SQL
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ActiveRecord::Base
   end
 
   def has_logged_in_to_forum?
-    OauthAccessToken.for_user(self).present?
+    OauthAccessToken.for_forum.for_user(self).present?
   end
 
   def has_active_subscription?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -427,6 +427,12 @@ FactoryGirl.define do
     token 'abc123'
   end
 
+  factory :oauth_application, class: "Doorkeeper::Application" do
+    sequence(:name) { |n| "Application #{n}" }
+    sequence(:uid) { |n| n }
+    redirect_uri "http://www.example.com/callback"
+  end
+
   factory :status do
     user
     exercise

--- a/spec/models/oauth_access_token_spec.rb
+++ b/spec/models/oauth_access_token_spec.rb
@@ -1,11 +1,28 @@
 require "rails_helper"
 
-describe '.for_user' do
-  it 'returns the last access token for a given user' do
+describe ".for_user" do
+  it "returns the last access token for a given user" do
     user = create(:user)
     token = create(:oauth_access_token, user: user)
 
     expect(OauthAccessToken.for_user(user).token).to eq token.token
   end
+end
 
+describe ".for_forum" do
+  it "returns only access tokens that associated with forums" do
+    forum = create(
+      :oauth_application,
+      redirect_uri: "http://forum.upcase.com/auth/upcase/callback"
+    )
+    exercise = create(
+      :oauth_application,
+      redirect_uri: "https://exercises.upcase.com/auth/upcase/callback"
+    )
+    forum_token = create(:oauth_access_token, application_id: forum.id)
+    exercise_token = create(:oauth_access_token, application_id: exercise.id)
+
+    expected_tokens = [forum_token.becomes(OauthAccessToken)]
+    expect(OauthAccessToken.for_forum).to eq expected_tokens
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -324,14 +324,18 @@ describe User do
   describe "#has_logged_in_to_forum?" do
     it "returns true when the user has logged in to the forum" do
       user = User.new
-      OauthAccessToken.stubs(:for_user).with(user).returns(true)
+      forum_scoped = stub(:scope)
+      forum_scoped.stubs(:for_user).with(user).returns(true)
+      OauthAccessToken.stubs(:for_forum).returns forum_scoped
 
       expect(user).to have_logged_in_to_forum
     end
 
     it "returns false when the user has never logged in to the forum" do
       user = User.new
-      OauthAccessToken.stubs(:for_user).with(user).returns(nil)
+      forum_scoped = stub(:scope)
+      forum_scoped.stubs(:for_user).with(user).returns(nil)
+      OauthAccessToken.stubs(:for_forum).returns forum_scoped
 
       expect(user).to_not have_logged_in_to_forum
     end


### PR DESCRIPTION
We were only checking if they have any access token, which is incorrect. This fix adds another check to ensure that the token is tied to an application that its name starts with "Discourse" or its name equals "forum.upcase.com".

https://trello.com/c/NyFRO5ca
