### PR TITLE
Prevent exception when pressing return on checkout

### DIFF
--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -1,13 +1,17 @@
-$(".coupon input[type=submit]").click(function(e) {
-  $.ajax({
-    url: $(".coupon").data('url'),
-    data: {
-      'checkout[quantity]': $('#checkout_quantity').val(),
-      'coupon[code]': $('#coupon_code').val()
-    },
-    dataType: 'script',
-    type: 'GET'
-  });
+$(".coupon input[type=button]").click(function(e) {
+  var coupon_code = $.trim($('#coupon_code').val());
+
+  if(coupon_code.length > 0) {
+    $.ajax({
+      url: $(".coupon").data('url'),
+      data: {
+        'checkout[quantity]': $('#checkout_quantity').val(),
+        'coupon[code]': coupon_code
+      },
+      dataType: 'script',
+      type: 'GET'
+    });
+  }
 
   return false;
 });

--- a/app/assets/stylesheets/_base-forms.css.scss
+++ b/app/assets/stylesheets/_base-forms.css.scss
@@ -1,4 +1,4 @@
-input[type="submit"] {
+input[type="submit"], input[type="button"] {
   border-bottom-width: none;
   border-image: initial;
   border-left-color: none;
@@ -14,7 +14,7 @@ input[type="submit"] {
   padding: 13px 30px 0 30px;
 }
 
-.button, input[type="submit"] {
+.button, input[type="submit"], input[type="button"] {
   background-color: $upcase-red;
   border-bottom: 3px solid $upcase-darkred;
   border-radius: 3px;

--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -120,7 +120,7 @@ body.checkouts-new, body.checkouts-create {
       margin: 1.5rem 0 1.25rem;
     }
 
-    input[type='submit'] {
+    input[type='button'] {
       border-bottom: 0;
       height: 39px;
       @include position(absolute, 27px 3px 0px 0);

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -15,7 +15,7 @@ class Coupon
 
   def stripe_coupon
     @stripe_coupon ||= Stripe::Coupon.retrieve(@stripe_coupon_id)
-  rescue Stripe::APIError
+  rescue Stripe::InvalidRequestError
     @stripe_coupon = nil
   end
 

--- a/app/views/redemptions/_form.html.erb
+++ b/app/views/redemptions/_form.html.erb
@@ -11,7 +11,7 @@
   <fieldset class="actions">
     <ol>
       <li class="action input_action" id="coupon_submit_action">
-        <input name="commit" type="submit" value="Apply Coupon">
+        <input name="commit" type="button" value="Apply Coupon">
       </li>
     </ol>
   </fieldset>

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -28,7 +28,7 @@ describe Coupon do
   end
 
   it 'is not valid if the coupon code does not exist' do
-    exception = Stripe::APIError.new("No such coupon", "NONE")
+    exception = Stripe::InvalidRequestError.new("No such coupon", "NONE")
     Stripe::Coupon.stubs(:retrieve).raises(exception)
     coupon = Coupon.new('NONE')
 

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -215,6 +215,13 @@ class FakeStripe < Sinatra::Base
       @@coupons[params[:id]].to_json
     else
       status 404
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "No such coupon: #{params[:id]}",
+          param: "id"
+        }
+      }.to_json
     end
   end
 


### PR DESCRIPTION
When user presses [Return] key on the form, it triggers `click` event on the nearest submit button, which in this case is the "Apply coupon" submit button. We also bind the `click` event on that button to check the validity of the coupon code. However, it turned out that we did not check if the coupon code is there first before trying to making a request, resulting in sending a request to non-existence endpoint.

This commit includes the changes that:
- Trim the coupon code that user enters.
- Prevent coupon code validation if the coupon code is empty.
- Change the rescue class on Coupon model, as Stripe now raises
  `InvalidRequestError` instead of `APIError` on non-existence coupon.

https://trello.com/c/j95ImHDc
https://thoughtbot.airbrake.io/projects/6325/groups/1251484741652927019
https://thoughtbot.airbrake.io/projects/6325/groups/1240487883421998395
