### PR TITLE
Clear next_payment_on when cancelling Subscription

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -375,6 +375,7 @@ FactoryGirl.define do
   factory :subscription, aliases: [:active_subscription] do
     association :plan
     association :user, :with_stripe, :with_mentor, :with_github
+    next_payment_on { 3.weeks.from_now }
 
     factory :inactive_subscription do
       deactivated_on { Time.zone.today }

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -58,6 +58,7 @@ describe Cancellation do
         with(at_period_end: true)
       expect(subscription.scheduled_for_cancellation_on).
         to eq Time.zone.at(1361234235).to_date
+      expect(subscription.next_payment_on).to be_nil
       expect(analytics_updater).to have_received(:track_cancelled)
     end
 


### PR DESCRIPTION
Until now we were scheduling subscriptions for cancellation, without clearing
the next_payment_on field. Users who cancelled would get email reminders for
next payments that should not (and did not) occur.

This changeset fixes the issue by clearing that date when a subscription is
cancelled.

Trello card: https://trello.com/c/wMeD3iwe/191-inaccurate-billing-notifications
