### PR TITLE
Allow access to exercises in order

### DIFF
--- a/app/assets/stylesheets/_dashboards-trails.scss
+++ b/app/assets/stylesheets/_dashboards-trails.scss
@@ -110,7 +110,6 @@
       $arrow-size: 20px;
       padding: $step-padding;
       position: relative;
-      cursor: pointer;
 
       &:last-of-type {
         &.reviewed .dot {

--- a/app/models/trail_with_progress.rb
+++ b/app/models/trail_with_progress.rb
@@ -31,6 +31,10 @@ class TrailWithProgress < SimpleDelegator
       end
     end
 
+    def can_be_accessed?
+      state != Status::NOT_STARTED
+    end
+
     private
 
     def next_up?

--- a/app/views/trails/_exercise.html.erb
+++ b/app/views/trails/_exercise.html.erb
@@ -1,7 +1,6 @@
 <div class="step <%= exercise.state.parameterize %>">
-  <%= exercise_link exercise.url, title: exercise.title do %>
-    <div class="dot"></div>
-  <% end %>
+  <%= render "trails/exercise_dot", exercise: exercise %>
+
   <div class="tooltip">
     <%= render "products/exercises/exercise", exercise: exercise %>
   </div>

--- a/app/views/trails/_exercise_dot.html.erb
+++ b/app/views/trails/_exercise_dot.html.erb
@@ -1,0 +1,7 @@
+<% if exercise.can_be_accessed? %>
+  <%= exercise_link exercise.url, title: exercise.title do %>
+    <div class="dot"></div>
+  <% end %>
+<% else %>
+  <div class="dot"></div>
+<% end %>

--- a/spec/models/trail_with_progress_spec.rb
+++ b/spec/models/trail_with_progress_spec.rb
@@ -43,5 +43,22 @@ describe TrailWithProgress do
         expect(result.third.state).to eq(Status::NOT_STARTED)
       end
     end
+
+    describe "#can_be_accessed?" do
+      it "can access if its state is Next Up, or already had access" do
+        exercises = create_list(:exercise, 4)
+        trail = create(:trail, exercises: exercises)
+        user = create(:user)
+        exercises.first.statuses.create!(user: user, state: Status::REVIEWED)
+        trail_with_progress = TrailWithProgress.new(trail, user: user)
+
+        result = trail_with_progress.exercises
+
+        expect(result.first.can_be_accessed?).to be_truthy
+        expect(result.second.can_be_accessed?).to be_truthy
+        expect(result.third.can_be_accessed?).to be_falsy
+        expect(result.fourth.can_be_accessed?).to be_falsy
+      end
+    end
   end
 end

--- a/spec/views/trails/_exercise.html.erb_spec.rb
+++ b/spec/views/trails/_exercise.html.erb_spec.rb
@@ -20,6 +20,7 @@ describe "trails/_exercise.html" do
   def stub_exercise(state: "Imaginary")
     Mocha::Configuration.allow(:stubbing_non_existent_method) do
       build_stubbed(:exercise). tap do |exercise|
+        exercise.stubs(:can_be_accessed?)
         exercise.stubs(:state).returns(state)
       end
     end


### PR DESCRIPTION
Not Started (grayed out) is not clickable. Next up, Started, Finished, etc are
all clickable.

https://trello.com/c/CVktmKBG/199-only-make-the-next-exercise-in-a-trail-clickable
