### PR TITLE
Fix cards hovering behind dots from other trails

### DIFF
--- a/app/assets/stylesheets/_dashboards-trails.scss
+++ b/app/assets/stylesheets/_dashboards-trails.scss
@@ -169,6 +169,7 @@
         pointer-events: none;
         position: absolute;
         top: 40px;
+        z-index: 1;
 
         &:before, &:after {
           @include calc(left, "50% - #{$arrow-size / 2}");
@@ -191,7 +192,6 @@
 
 
         .card {
-          z-index: 0;
           height: auto;
 
           figure {


### PR DESCRIPTION
With more than one trail, the dots would appear above the tooltips.

https://trello.com/c/kPa5VZlg/222-with-more-than-one-trail-tooltips-appear-behind-dots-from-other-trails
