### PR TITLE
Only display published trails to users

### DIFF
--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -10,7 +10,7 @@ class Trail < ActiveRecord::Base
       count { |exercise| exercise.status_for(user).state != Status::REVIEWED }
   end
 
-  def self.most_recent
-    order(created_at: :desc)
+  def self.most_recent_published
+    order(created_at: :desc).where(published: true)
   end
 end

--- a/app/services/dashboard.rb
+++ b/app/services/dashboard.rb
@@ -18,7 +18,7 @@ class Dashboard
   end
 
   def trails
-    Trail.most_recent.map do |trail|
+    Trail.most_recent_published.map do |trail|
       TrailWithProgress.new(trail, user: @user)
     end
   end

--- a/db/migrate/20141007211055_add_published_to_trails.rb
+++ b/db/migrate/20141007211055_add_published_to_trails.rb
@@ -1,0 +1,11 @@
+class AddPublishedToTrails < ActiveRecord::Migration
+  def up
+    add_column :trails, :published, :boolean, default: false, null: false
+    update("UPDATE trails SET published = true")
+    add_index :trails, :published
+  end
+
+  def down
+    remove_column :trails, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007191034) do
+ActiveRecord::Schema.define(version: 20141007211055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -319,11 +319,14 @@ ActiveRecord::Schema.define(version: 20141007191034) do
   add_index "topics", ["slug"], name: "index_topics_on_slug", unique: true, using: :btree
 
   create_table "trails", force: true do |t|
-    t.string   "name",          null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.string   "complete_text", null: false
+    t.string   "name",                          null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.string   "complete_text",                 null: false
+    t.boolean  "published",     default: false, null: false
   end
+
+  add_index "trails", ["published"], name: "index_trails_on_published", using: :btree
 
   create_table "users", force: true do |t|
     t.string   "email"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -435,6 +435,10 @@ FactoryGirl.define do
   factory :trail do
     name "Trail name"
     complete_text "Way to go!"
+
+    trait :published do
+      published true
+    end
   end
 
   factory :step do

--- a/spec/features/subscriber_follows_trail_spec.rb
+++ b/spec/features/subscriber_follows_trail_spec.rb
@@ -6,7 +6,7 @@ feature "subscriber follows trail" do
       create(:exercise, title: "First Exercise"),
       create(:exercise, title: "Second Exercise")
     ]
-    create(:trail, name: "Baby Exercises", exercises: exercises)
+    create(:trail, :published, name: "Baby Exercises", exercises: exercises)
 
     sign_in_as_user_with_subscription
     click_on "First Exercise"
@@ -19,7 +19,7 @@ feature "subscriber follows trail" do
       create(:exercise, title: "First Exercise"),
       create(:exercise, title: "Second Exercise")
     ]
-    create(:trail, name: "Baby Exercises", exercises: exercises)
+    create(:trail, :published, name: "Baby Exercises", exercises: exercises)
     user = create(:subscriber)
     exercises.first.statuses.create!(user: user, state: Status::REVIEWED)
 

--- a/spec/models/trail_spec.rb
+++ b/spec/models/trail_spec.rb
@@ -6,15 +6,25 @@ describe Trail do
   it { should have_many(:steps).dependent(:destroy) }
   it { should have_many(:exercises).through(:steps) }
 
-  describe ".most_recent" do
+  describe ".most_recent_published" do
     it "returns more recent trails first" do
-      create :trail, created_at: 2.day.ago, name: "two"
-      create :trail, created_at: 1.days.ago, name: "one"
-      create :trail, created_at: 3.days.ago, name: "three"
+      create :trail, published: true, created_at: 2.day.ago, name: "two"
+      create :trail, published: true, created_at: 1.days.ago, name: "one"
+      create :trail, published: true, created_at: 3.days.ago, name: "three"
 
-      result = Trail.most_recent
+      result = Trail.most_recent_published
 
       expect(result.map(&:name)).to eq(%w(one two three))
+    end
+
+    it "only returns published trails" do
+      create :trail, published: true, name: "two"
+      create :trail, published: true, name: "one"
+      create :trail, published: false, name: "unpublished"
+
+      result = Trail.most_recent_published
+
+      expect(result.map(&:name)).to match_array(%w(one two))
     end
   end
 

--- a/spec/services/dashboard_spec.rb
+++ b/spec/services/dashboard_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 describe Dashboard do
   describe "#trails" do
-    it "decorates the most recent trails" do
+    it "decorates the most recent, published trails" do
       user = stub(:user)
       undecorated = stub(:undecorated)
       trails = [undecorated]
       trail_with_progress = stub(:trail_with_progress)
-      Trail.stubs(:most_recent).returns(trails)
+      Trail.stubs(:most_recent_published).returns(trails)
       TrailWithProgress.
         stubs(:new).
         with(undecorated, user: user).


### PR DESCRIPTION
Because:
- We want to proofread trails before displaying them to users
- We want to try out some trails internally

This commit:
- Adds a "published" flag to trails
- Only displayed published trails on the dashboard

https://trello.com/c/FUclDz0R/217-add-a-published-flag-to-trails-so-we-can-test-them-before-users-see-them
