### PR TITLE
Fix HTTPS warnings from HTTP resources

### DIFF
--- a/app/assets/stylesheets/_product-card.scss.erb
+++ b/app/assets/stylesheets/_product-card.scss.erb
@@ -246,7 +246,7 @@
     }
 
     .illustration {
-      background: url('trail-step-complete.svg') center /58px no-repeat;
+      background: image-url('trail-step-complete.svg') center /58px no-repeat;
 
       &:after {
         display: none;
@@ -260,7 +260,7 @@
     }
 
     .illustration {
-      background: url('trail-step-in-progress.svg') center /60px no-repeat;
+      background: image-url('trail-step-in-progress.svg') center /60px no-repeat;
 
       &:after {
         display: none;


### PR DESCRIPTION
The new trail status background images used `url` instead of
`image-url`.
