### PR TITLE
Update foreman to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ end
 
 group :development, :test do
   gem 'dotenv-rails'
-  gem 'foreman', '0.46.0'
+  gem "foreman"
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,8 @@ GEM
     flutie (2.0.0)
     font-awesome-rails (4.1.0.0)
       railties (>= 3.2, < 5.0)
-    foreman (0.46.0)
+    foreman (0.63.0)
+      dotenv (>= 0.7)
       thor (>= 0.13.6)
     formtastic (2.2.0)
       actionpack (>= 3.0)
@@ -417,7 +418,7 @@ DEPENDENCIES
   escape_utils (= 0.2.4)
   factory_girl_rails
   flutie (= 2.0.0)
-  foreman (= 0.46.0)
+  foreman
   formtastic (= 2.2.0)
   friendly_id (= 5.0.4)
   gravatarify (~> 3.1.0)


### PR DESCRIPTION
When I try to kill the app using Ctrl+C, I kept getting this error on the current version of Foreman:

```
^C/Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:164:in `synchronize': can't be called from trap context (ThreadError)
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:164:in `puts'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:38:in `block in start'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:141:in `call'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:141:in `wait2'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:141:in `watch_for_termination'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/engine.rb:43:in `start'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/lib/foreman/cli.rb:33:in `start'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/sikachu/.rvm/gems/ruby-2.1.3/gems/foreman-0.46.0/bin/foreman:7:in `<top (required)>'
    from /Users/sikachu/Projects/upcase/bin/foreman:16:in `load'
    from /Users/sikachu/Projects/upcase/bin/foreman:16:in `<main>'
```

Upgrade to the latest version seems to fix this problem.
