### PR TITLE
"Next Up" should be shown as "Exercise"

### DIFF
--- a/app/services/exercise_with_progress_query.rb
+++ b/app/services/exercise_with_progress_query.rb
@@ -8,7 +8,7 @@ class ExerciseWithProgressQuery
   end
 
   def each(&block)
-    previous_exercise_state = nil
+    previous_exercise_state = Status::REVIEWED
     @exercises.all.map do |exercise|
       state = status_for(exercise.id).state
       ExerciseWithProgress.new(exercise, state, previous_exercise_state).tap do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
 
   exercises:
     statuses:
-      next-up: "Next Up"
+      next-up: "Exercise"
       not-started: "Exercise"
       started: "In Progress"
       pushed: "In Progress"

--- a/spec/services/exercise_with_progress_query_spec.rb
+++ b/spec/services/exercise_with_progress_query_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe ExerciseWithProgressQuery do
   describe "#each" do
-    it "decorates an exercise with progress" do
-      create(:exercise)
+    it "decorates exercises with progress" do
       exercise = create(:exercise)
+      create(:exercise)
       user = create(:user)
-      create(:status, exercise: exercise, user: user, state: "Pushed")
       query = ExerciseWithProgressQuery.new(user: user, exercises: Exercise.all)
 
-      exercises_array = query.to_a
+      exercises = query.to_a
 
-      expect(exercises_array.last.title).to eq(exercise.title)
-      expect(exercises_array.last.state).to eq("Pushed")
+      expect(exercises[0].title).to eq(exercise.title)
+      expect(exercises[0].state).to eq(Status::NEXT_UP)
+      expect(exercises[1].state).to eq(Status::NOT_STARTED)
     end
   end
 


### PR DESCRIPTION
First exercise of an unstarted trail should have the `NEXT_UP` state. But in other views (like topics) we want to show the proper title, "Exercise", instead of "Next Up". This changeset marks the first exercise as next, but changes the label to be "exercise".

It is funky because we are reusing the query object to cache statuses not only in trails, but also in topics.

https://trello.com/c/MgPjT8Dp/218-optimize-status-for-exercises-within-trails
