### PR TITLE
Improve "open Intercom new message" experience

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -44,8 +44,9 @@
 
         <% content_for :javascript do %>
           <script type="text/javascript">
-            $(".trail-hint" ).click(function() {
-              $('#intercom-launcher').click()
+            $(".trail-hint" ).click(function(event) {
+              Intercom('show');
+              event.preventDefault();
             });
           </script>
         <% end %>


### PR DESCRIPTION
Previously:
- It jumps back to the top of the page after clicking if you've scrolled down.
  Not terrible, but a little jarring.
- It opens the Intercom sidebar, but it doesn't start a new message right
  away.

Now:
- Prevent default to stop "jump".
- Use Intercom's JavaScript API to open the new message window.
  http://docs.intercom.io/install-on-your-web-product/intercom-javascript-api

https://trello.com/c/H5pVx7lS
