### PR TITLE
Track named pages in Segment

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -33,10 +33,13 @@ module AnalyticsHelper
   end
 
   def purchased_hash
+    campaign_hash.merge(revenue: flash[:purchase_amount])
+  end
+
+  def campaign_hash
     {
-      revenue: flash[:purchase_amount],
       context: {
-        campaign: session[:campaign_params].to_json,
+        campaign: session[:campaign_params]
       }
     }
   end

--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -1,5 +1,5 @@
 <meta charset="utf-8" />
-<title><%= page_title(app_name: t('layouts.app_name')) %></title>
+<title><%= [content_for(:page_title), t("layouts.app_name")].compact.uniq.join(" | ") %></title>
 <%= render 'layouts/stylesheets' %>
 <link rel="icon" href="/favicon.ico" type="image/x-icon">
 <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence || t('layouts.meta_description') %>" />

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <% content_for :additional_body_classes, @checkout.subscribeable_name %>
+<% content_for :page_title, "Subscribe to #{@checkout.subscribeable_name}" %>
 
 <div class="text-box-wrapper">
   <div class="text-box">

--- a/app/views/landing_pages/watch-one-do-one-teach-one.html.erb
+++ b/app/views/landing_pages/watch-one-do-one-teach-one.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Watch One, Do One, Teach One" %>
+
 <div class="landing-page-wrapper">
   <header class="landing-hero">
     <h1>

--- a/app/views/promoted_catalogs/show.html.erb
+++ b/app/views/promoted_catalogs/show.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :additional_body_classes, 'marketing' %>
+<% content_for :additional_body_classes, "marketing" %>
+<% content_for :page_title, "Upcase" %>
 
 <%= render "shared/header" %>
 

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,7 +1,7 @@
 <script type="text/javascript">
   window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
   window.analytics.load('<%= ENV['SEGMENT_KEY']%>');
-  window.analytics.page();
+  window.analytics.page('<%= yield :page_title %>', <%= raw campaign_hash.to_json %>);
 </script>
 
 <% if flash[:purchase_amount] %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Plans and Pricing" %>
+
 <% if signed_in? %>
   <%= link_to 'account', my_account_path, class: 'signin' %>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
 
   layouts:
     meta_description: 'Video Tutorials, and videos to help you learn web design and development.'
-    app_name: 'Upcase from thoughtbot'
+    app_name: 'Upcase'
 
   dashboards:
     locked_features:

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -3,23 +3,23 @@ require "rails_helper"
 describe AnalyticsHelper do
   describe '#analytics?' do
     it "is true when ENV['ANALYTICS'] is present" do
-      ENV['ANALYTICS'] = 'anything'
+      ENV["ANALYTICS"] = "anything"
 
       expect(helper).to be_analytics
 
-      ENV['ANALYTICS'] = nil
+      ENV["ANALYTICS"] = nil
     end
 
     it "is false when ENV['ANALYTICS'] is not present" do
-      ENV['ANALYTICS'] = nil
+      ENV["ANALYTICS"] = nil
 
       expect(helper).to_not be_analytics
     end
   end
 
-  describe '#analytics_hash' do
-    it 'returns a hash of data to be sent to analytics' do
-      user = build_stubbed(:user, stripe_customer_id: 'something')
+  describe "#analytics_hash" do
+    it "returns a hash of data to be sent to analytics" do
+      user = build_stubbed(:user, stripe_customer_id: "something")
 
       expect(analytics_hash(user)).to eq(
         created: user.created_at,
@@ -48,7 +48,7 @@ describe AnalyticsHelper do
 
     context "without campaign params" do
       it "tracks nil" do
-        expect(purchased_hash[:context]).to eq({ campaign: "null" })
+        expect(purchased_hash[:context]).to eq(campaign: nil)
       end
     end
 
@@ -61,9 +61,7 @@ describe AnalyticsHelper do
         }
         session[:campaign_params] = campaign_params
 
-        expect(purchased_hash[:context]).to eq(
-          { campaign: campaign_params.to_json }
-        )
+        expect(purchased_hash[:context]).to eq(campaign: campaign_params)
       end
     end
   end

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
-describe 'shared/_analytics.html.erb' do
+describe "shared/_analytics.html.erb" do
   include AnalyticsHelper
 
-  context 'when signed out' do
+  context "when signed out" do
     before do
       view_stubs(signed_in?: false)
     end
 
-    it 'loads the Segment.io JavaScript library' do
+    it "loads the Segment JavaScript library" do
       segment_load_line = "window.analytics.load('#{ENV['SEGMENT_KEY']}');"
 
       render
@@ -17,7 +17,7 @@ describe 'shared/_analytics.html.erb' do
     end
 
     it 'records a pageview' do
-      record_pageview_line = 'window.analytics.page();'
+      record_pageview_line = %{window.analytics.page('', {"context":{"campaign":null}});}
 
       render
 


### PR DESCRIPTION
- Mixpanel does not track unnamed pages but does track named pages.
  https://segment.com/docs/api/tracking/page/
- Include `utm_` properties on all `page` events.
- Re-use existing `page_title` partial-rendering name.
- Improve SEO of page titles using "Page Name | Brand" format.
  http://moz.com/learn/seo/title-tag
- Fix double-JSON formatting on campaign key-value pairs.

https://trello.com/c/6wF6wxh1
