### PR TITLE
Change button, form and flash notice styles

### DIFF
--- a/app/assets/stylesheets/_base-forms.css.scss
+++ b/app/assets/stylesheets/_base-forms.css.scss
@@ -15,8 +15,8 @@ input[type="submit"], input[type="button"] {
 }
 
 .button, input[type="submit"], input[type="button"] {
-  background-color: $upcase-red;
-  border-bottom: 3px solid $upcase-darkred;
+  background-color: $upcase-green;
+  border-bottom: 3px solid $upcase-green-4;
   border-radius: 3px;
   color: white;
   display: inline-block;
@@ -29,11 +29,11 @@ input[type="submit"], input[type="button"] {
   -webkit-appearance: none;
 
   &:hover {
-    background-color: #C42107;
+    background-color: $upcase-green-2;
   }
 
   &:active {
-    background-color: $upcase-darkred;
+    background-color: $upcase-green-3
   }
 
   &[disabled] {
@@ -58,7 +58,7 @@ input[type="submit"], input[type="button"] {
 
 .button-mini {
   @extend .button;
-  border-bottom: 2px solid $upcase-darkred;
+  border-bottom: 2px solid $upcase-green;
   height: auto;
   margin-bottom: 10px;
   margin-top: 10px;
@@ -75,7 +75,7 @@ form {
   }
 
   .errors, .errors li {
-    color: $upcase-red;
+    color: $upcase-blue;
     font-size: 18px;
     font-style: bold;
     margin-top: 20px;
@@ -85,7 +85,7 @@ form {
     list-style-type: none;
 
     &.payment-errors, &.subscription-errors {
-      color: $upcase-red;
+      color: $upcase-blue;
       font-style: bold;
 
       &:empty {
@@ -125,7 +125,7 @@ form {
       width: 100%;
 
       &:focus {
-        border: 1px solid $upcase-red;
+        border: 1px solid $upcase-blue;
         outline: none;
         outline-color: none;
       }
@@ -144,7 +144,7 @@ form {
         }
 
         p.inline-errors {
-          color: $red;
+          color: $upcase-blue;
           font-size: 16px;
         }
 
@@ -154,7 +154,7 @@ form {
           }
 
           p.inline-hints {
-            color: $red;
+            color: $upcase-blue;
           }
 
           input[type=text],

--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -7,7 +7,7 @@ $off-white: darken(white, 1.5);
 $lightwarmgray: #F5F5F0;
 $warmgray: #D9D4CC;
 $darkwarmgray: #555;
-$upcase-red: #B22115;
+$upcase-red: #FF4856;
 $upcase-darkred: #660000;
 $green: #83d4b7;
 $green-trail: #1dbe76;
@@ -22,8 +22,19 @@ $upcase-blue: #2387E0;
 $upcase-blue-1: #487BF6;
 $upcase-blue-2: #0093CB;
 $upcase-blue-3: #3FBCFF;
-$upcase-blue-4: #A2F6F9;
+$upcase-blue-4: #3FBCFF;
+$upcase-blue-5: #A2F6F9;
+$upcase-blue-6: #04659B;
+$upcase-blue-7: #3D9FF7;
 
+$upcase-green: #57C75C;
+$upcase-green-2: #3CBD41;
+$upcase-green-3: #73E179;
+$upcase-green-4: #36AC3A;
+
+$light-yellow: #FFF5C2;
+$light-brown: #EDDAA5;
+$dark-brown: #5C4A33;
 
 $gray-1: #333;
 $gray-2: #666;

--- a/app/assets/stylesheets/_upcase-marketing.scss
+++ b/app/assets/stylesheets/_upcase-marketing.scss
@@ -87,8 +87,8 @@ body.promoted_catalogs {
 
 .upcase-journey-cta {
   @include appearance(none);
-  background: $upcase-red;
-  border-bottom: .2rem solid darken($upcase-red, 10%);
+  background: $upcase-green;
+  border-bottom: .2rem solid $upcase-green-4;
   border-radius: 3px;
   color: #fff;
   display: block;
@@ -99,11 +99,11 @@ body.promoted_catalogs {
   z-index: 5;
 
   &:hover {
-    background: lighten($upcase-red, 3%);
+    background: $upcase-green-2;
   }
 
   &:active {
-    background: darken($upcase-red, 3%);
+    background: $upcase-green-3;
   }
 
   @include marketing-mobile {

--- a/app/assets/stylesheets/layout/_flashes.scss
+++ b/app/assets/stylesheets/layout/_flashes.scss
@@ -6,20 +6,36 @@
   text-align: center;
 
   .flash {
-    @extend %main-content-box;
-    border-width: 0;
+    background: $light-yellow;
+    border: 1px solid $light-brown;
+    border-radius: 3px;
     display: inline-block;
     margin-bottom: 0;
     overflow-y: auto;
     padding: 1rem 2rem;
 
-    &.failure {
-      background: #f8bcba;
+    a {
+      font-family: $sans-serif;
+      font-weight: 600;
     }
+  }
 
-    &.notice {
-      color: $upcase-red;
-      font: 400 1.2rem/1.2em $sans-serif;
+  .failure {
+    background: #f8bcba;
+    border: 1px solid $red;
+    color: $red;
+
+    a {
+      color: $red;
+    }
+  }
+
+  .notice {
+    color: $dark-brown;
+    font: 400 1.2rem/1.2em $sans-serif;
+
+    a {
+      color: $upcase-blue-6;
     }
   }
 }


### PR DESCRIPTION
I started out making the button blue, but in the interest of adding more than just one color, and staying consistent with exercises, I went with green. I think this the green complements the header blue well, and keeps us from making everything blue, just as everything was red in the original Learn design.

![screen shot 2014-10-28 at 12 26 34 pm](https://cloud.githubusercontent.com/assets/2343392/4812327/beb8b90c-5ebf-11e4-99ae-d5e0e76a6fc4.png)

Links are blue, as are form outlines.
![screen shot 2014-10-28 at 12 27 35 pm](https://cloud.githubusercontent.com/assets/2343392/4812337/d14218ac-5ebf-11e4-8cc1-9cdc389fe876.png)

Flashes reflect the Whetstone messaging style:
![screen shot 2014-10-28 at 11 45 33 am](https://cloud.githubusercontent.com/assets/2343392/4812344/e1019bf0-5ebf-11e4-9be5-06e79b14ee05.png)

Errors are red:
![screen shot 2014-10-28 at 11 45 42 am](https://cloud.githubusercontent.com/assets/2343392/4812352/eca1e5aa-5ebf-11e4-880e-da981e26d872.png)

I'm adding a lot of color variables to the repo now ($upcase-green-1, $upcase-green-2...) Several may go away and be named better as we hone in on the essential colors.
