### PR TITLE
Include Discourse comment embed on videos#show

### DIFF
--- a/app/views/videos/_comments.html.erb
+++ b/app/views/videos/_comments.html.erb
@@ -1,0 +1,13 @@
+<% unless Rails.env.test? %>
+  <div id="discourse-comments"></div>
+  <script type="text/javascript">
+    var discourseUrl = "<%= forum_url %>";
+    var discourseEmbedUrl = "<%= video_url(video) %>";
+
+    (function() {
+      var d = document.createElement("script"); d.type = "text/javascript"; d.async = true;
+        d.src = discourseUrl + "javascripts/embed.js";
+      (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(d);
+    })();
+  </script>
+<% end %>

--- a/app/views/videos/_watch_video.html.erb
+++ b/app/views/videos/_watch_video.html.erb
@@ -8,3 +8,5 @@
     </section>
   </div>
 <% end %>
+
+<%= render "comments", video: video %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -13,6 +13,8 @@
   </div>
 </div>
 
+<%= render "comments", video: @video %>
+
 <aside>
   <%= render "products/license", offering: @offering %>
   <%= render 'products/terms', offering: @offering %>

--- a/app/views/videos/show_licensed.html.erb
+++ b/app/views/videos/show_licensed.html.erb
@@ -16,4 +16,4 @@
   </h2>
 <% end %>
 
-<%= render 'watch_video', video: @video %>
+<%= render "watch_video", video: @video %>


### PR DESCRIPTION
This is disabled in the test environment to avoid making external requests.

It is included in other environments, but Discourse does referral checking and
will only allow embeds from a url we set in Discourse. This is currently set to
production.
