### PR TITLE
Add link to Upcase Exercise admin on exercise edit

### DIFF
--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -23,6 +23,6 @@ class Api::V1::ExercisesController < ApiController
   end
 
   def exercise_parameters
-    params.require(:exercise).permit(:title, :url, :summary)
+    params.require(:exercise).permit(:edit_url, :summary, :title, :url)
   end
 end

--- a/app/views/rails_admin/main/_whetstone_edit_url.html.erb
+++ b/app/views/rails_admin/main/_whetstone_edit_url.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Edit title and summary", form.object.edit_url %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -134,8 +134,15 @@ RailsAdmin.config do |config|
     end
 
     edit do
-      include_all_fields
-      exclude_fields :classifications, :statuses, :steps
+      field :whetstone_edit_url do
+        label false
+        help false
+        partial "whetstone_edit_url"
+      end
+
+      field :public
+      field :topics
+      field :trails
     end
   end
 

--- a/db/migrate/20141111095353_add_edit_url_to_exercises.rb
+++ b/db/migrate/20141111095353_add_edit_url_to_exercises.rb
@@ -1,0 +1,18 @@
+class AddEditUrlToExercises < ActiveRecord::Migration
+  def up
+    add_column :exercises, :edit_url, :string
+
+    update <<-SQL.squish
+      UPDATE exercises
+      SET edit_url = regexp_replace(
+        url,
+        '/exercises/(.+)$',
+        '/admin/exercises/\\1/edit'
+      )
+    SQL
+  end
+
+  def down
+    remove_column :exercises, :edit_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20141112201747) do
     t.datetime "updated_at"
     t.string   "uuid",                       null: false
     t.boolean  "public",     default: false, null: false
+    t.string   "edit_url"
   end
 
   add_index "exercises", ["public"], name: "index_exercises_on_public", using: :btree

--- a/spec/requests/exercises_synchronization_spec.rb
+++ b/spec/requests/exercises_synchronization_spec.rb
@@ -12,6 +12,7 @@ describe "PUT /api/v1/exercises/:id" do
       expect(exercise.title).to eq exercise_attributes[:title]
       expect(exercise.uuid).to eq "uuid-1234"
       expect(exercise.url).to eq exercise_attributes[:url]
+      expect(exercise.edit_url).to eq exercise_attributes[:edit_url]
       expect(exercise.summary).to eq exercise_attributes[:summary]
     end
   end
@@ -44,9 +45,11 @@ describe "PUT /api/v1/exercises/:id" do
 
   def exercise_attributes
     {
+      edit_url:
+        "https://exercise.upcase.com/admin/exercises/shakespeare-analyzer/edit",
       title: "Shakespeare Analyzer",
-      url: "https://exercise.upcase.com/exercises/shakespeare-analyzer",
-      summary: "Analyse Shakespeare's literature"
+      summary: "Analyse Shakespeare's literature",
+      url: "https://exercise.upcase.com/exercises/shakespeare-analyzer"
     }
   end
 end


### PR DESCRIPTION
Also, hide those title and summary field, suggesting users that they should go to Upcase Exercise to edit those fields.

![screen shot 2014-11-10 at 4 36 51 pm](https://cloud.githubusercontent.com/assets/4912/4973763/ee5aa304-68f7-11e4-8c22-d6f6e1b9888a.png)

https://trello.com/c/GxksRnxm
