### PR TITLE
Remove unecessary header margin displaying on /products

### DIFF
--- a/app/assets/stylesheets/_products-index.scss.erb
+++ b/app/assets/stylesheets/_products-index.scss.erb
@@ -1,7 +1,4 @@
 body.products-index {
-  .header-container {
-    margin-bottom: $product-card-margin / 2;
-  }
 
   .content > section {
     @include display(flex);


### PR DESCRIPTION
https://trello.com/c/Yc9Tm9li/403-header-in-products-is-too-wide

I thought this was covered here https://github.com/thoughtbot/upcase/commit/8d60360b70c89d2a19d9bcd300a838860e2b1b07, but there was a lingering css rule only affecting the /products page.
