### PR TITLE
Checkouts #subscribeable turns into #plan

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,10 +78,6 @@ class ApplicationController < ActionController::Base
       find(params)
   end
 
-  def requested_subscribeable
-    Plan.where(sku: params[:plan]).first
-  end
-
   def included_in_current_users_plan?(licenseable)
     licenseable.included_in_plan?(current_user.plan)
   end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -11,7 +11,7 @@ class CheckoutsController < ApplicationController
   end
 
   def create
-    @checkout = requested_subscribeable.checkouts.build(checkout_params)
+    @checkout = plan.checkouts.build(checkout_params)
     @checkout.user = current_user
     @checkout.stripe_customer_id = existing_stripe_customer_id
     CheckoutPrepopulator.new(@checkout, current_user).prepopulate_with_user_info
@@ -23,7 +23,7 @@ class CheckoutsController < ApplicationController
         success_url,
         notice: t(
           "checkout.flashes.success",
-          name: @checkout.subscribeable_name
+          name: @checkout.plan_name
         ),
         flash: {
           purchase_amount: @checkout.price
@@ -37,7 +37,7 @@ class CheckoutsController < ApplicationController
   private
 
   def build_checkout_with_defaults
-    checkout = requested_subscribeable.checkouts.build
+    checkout = plan.checkouts.build
     CheckoutPrepopulator.new(checkout, current_user).prepopulate_with_user_info
     checkout
   end
@@ -84,6 +84,10 @@ class CheckoutsController < ApplicationController
     if using_existing_card?
       current_user.stripe_customer_id
     end
+  end
+
+  def plan
+    Plan.where(sku: params[:plan]).first
   end
 
   def using_existing_card?

--- a/app/controllers/redemptions_controller.rb
+++ b/app/controllers/redemptions_controller.rb
@@ -1,10 +1,14 @@
 class RedemptionsController < ApplicationController
   def new
-    @checkout = requested_subscribeable.checkouts.build(checkout_params)
+    @checkout = plan.checkouts.build(checkout_params)
     @coupon = Coupon.new(params[:coupon][:code])
   end
 
   private
+
+  def plan
+    Plan.where(sku: params[:plan]).first
+  end
 
   def checkout_params
     params.require(:checkout).permit(:quantity)

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -16,7 +16,7 @@ module CheckoutsHelper
   end
 
   def subscription_interval(checkout)
-    checkout.subscribeable.subscription_interval
+    checkout.plan.subscription_interval
   end
 
   def choose_plan_link(plan)
@@ -35,8 +35,8 @@ module CheckoutsHelper
     signed_out?
   end
 
-  def checkout_form_partial(subscribeable)
-    if subscribeable.includes_team?
+  def checkout_form_partial(plan)
+    if plan.includes_team?
       "checkouts/team_plan_form"
     else
       "checkouts/individual_plan_form"

--- a/app/mailers/checkout_mailer.rb
+++ b/app/mailers/checkout_mailer.rb
@@ -4,7 +4,7 @@ class CheckoutMailer < BaseMailer
 
     mail(
       to: @checkout.user_email,
-      subject: "Your receipt for #{@checkout.subscribeable_name}"
+      subject: "Your receipt for #{@checkout.plan_name}"
     )
   end
 end

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -1,6 +1,6 @@
 class Checkout < ActiveRecord::Base
   belongs_to :user
-  belongs_to :subscribeable, polymorphic: true
+  belongs_to :plan
 
   validates :github_username, presence: true
   validates :email, presence: true
@@ -13,12 +13,14 @@ class Checkout < ActiveRecord::Base
   delegate :github_username, to: :user, prefix: true
   delegate :last_name, to: :user, prefix: true
   delegate :organization, to: :user, prefix: true
-  delegate :sku, to: :subscribeable, prefix: true
-  delegate :includes_team?, to: :subscribeable
-  delegate :name, to: :subscribeable, prefix: true
-  delegate :terms, to: :subscribeable
+  delegate :sku, to: :plan, prefix: true
+  delegate :includes_team?, to: :plan
+  delegate :name, to: :plan, prefix: true
+  delegate :terms, to: :plan
 
-  attr_accessor :email, :name, :github_username, :password, :stripe_customer_id, :stripe_token, :organization, :address1, :address2, :city, :state, :zip_code, :country
+  attr_accessor :email, :name, :github_username, :password, :stripe_customer_id,
+    :stripe_token, :organization, :address1, :address2, :city, :state,
+    :zip_code, :country
 
   before_validation :create_user, if: :password_required?
   before_create :create_subscription
@@ -27,7 +29,7 @@ class Checkout < ActiveRecord::Base
   after_save :send_receipt
 
   def price
-    subscribeable.individual_price * quantity
+    plan.individual_price * quantity
   end
 
   private
@@ -56,7 +58,7 @@ class Checkout < ActiveRecord::Base
   end
 
   def fulfill
-    subscribeable.fulfill(self, user)
+    plan.fulfill(self, user)
   end
 
   def password_required?

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -4,7 +4,7 @@ class Plan < ActiveRecord::Base
   THE_WEEKLY_ITERATION_SKU = "the-weekly-iteration"
   MINIMUM_TEAM_SIZE = 3
 
-  has_many :checkouts, as: :subscribeable
+  has_many :checkouts
   has_many :subscriptions, as: :plan
 
   validates :description, presence: true

--- a/app/models/stripe_subscription.rb
+++ b/app/models/stripe_subscription.rb
@@ -61,7 +61,7 @@ class StripeSubscription
 
   def base_subscription_attributes
     {
-      plan: @checkout.subscribeable_sku,
+      plan: @checkout.plan_sku,
       quantity: @checkout.quantity
     }
   end

--- a/app/views/checkout_mailer/receipt.text.erb
+++ b/app/views/checkout_mailer/receipt.text.erb
@@ -1,18 +1,18 @@
-Thank you for subscribing to <%= @checkout.subscribeable_name %>!
+Thank you for subscribing to <%= @checkout.plan_name %>!
 
-<%- if @checkout.subscribeable.has_feature?(:mentor) -%>
+<%- if @checkout.plan.has_feature?(:mentor) -%>
 You will receive an email from your mentor soon.
 <%- end -%>
 
 In the meantime, one of the first things you might do is visit our Trail Maps
-<%- if @checkout.subscribeable.has_feature?(:video_tutorials) -%>
+<%- if @checkout.plan.has_feature?(:video_tutorials) -%>
 and check off your skills to determine which video tutorials are right for you:
 <%- else -%>
 and check off your skills to identify new things to learn:
 <%- end -%>
 <%= topics_url %>
 
-<%= @checkout.subscribeable_name %> also includes access to our forum. Get help
+<%= @checkout.plan_name %> also includes access to our forum. Get help
 from thoughtbot and other subscribers here:
 <%= forum_url %>
 

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= semantic_form_for checkout, url: checkouts_path(checkout.subscribeable), html: { method: 'post' } do |form| %>
+<%= semantic_form_for checkout, url: checkouts_path(checkout.plan), html: { method: 'post' } do |form| %>
   <%= form.semantic_errors %>
 
   <%= form.inputs do %>
@@ -23,7 +23,7 @@
       <%= form.input :github_username, required: true, label: "GitHub username",
         hint: "Be sure to enter a valid, unique GitHub username. Organizations are not allowed." %>
     <% end %>
-    <%= render checkout_form_partial(@checkout.subscribeable), form: form, checkout: @checkout %>
+    <%= render checkout_form_partial(@checkout.plan), form: form, checkout: @checkout %>
   <% end %>
 
   <%= link_to 'Need an address on your receipt?', '#', class: 'reveal-address' %>

--- a/app/views/checkouts/_individual_plan_form.html.erb
+++ b/app/views/checkouts/_individual_plan_form.html.erb
@@ -3,5 +3,5 @@
   as: :hidden,
   wrapper_html: {
     "data-individual-price" => @checkout.price,
-    "data-interval" => @checkout.subscribeable.subscription_interval
+    "data-interval" => @checkout.plan.subscription_interval
   }) %>

--- a/app/views/checkouts/_team_plan_form.html.erb
+++ b/app/views/checkouts/_team_plan_form.html.erb
@@ -1,1 +1,1 @@
-<%= team_plan_quantity_select(form, checkout, checkout.subscribeable) %>
+<%= team_plan_quantity_select(form, checkout, checkout.plan) %>

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :subject_block do %>
-  <h1><%= @checkout.subscribeable_name %></h1>
+  <h1><%= @checkout.plan_name %></h1>
 <% end %>
 
-<% content_for :additional_body_classes, @checkout.subscribeable_name %>
-<% content_for :page_title, "Subscribe to #{@checkout.subscribeable_name}" %>
+<% content_for :additional_body_classes, @checkout.plan_name %>
+<% content_for :page_title, "Subscribe to #{@checkout.plan_name}" %>
 
 <div class="text-box-wrapper">
   <div class="text-box">

--- a/app/views/redemptions/_form.html.erb
+++ b/app/views/redemptions/_form.html.erb
@@ -1,5 +1,5 @@
 <%= link_to "Have a coupon code?", "#", class: 'coupon-note' %>
-<div class="coupon" style="display: none;" data-url="<%= new_redemption_url(checkout.subscribeable) %>">
+<div class="coupon" style="display: none;" data-url="<%= new_redemption_url(checkout.plan) %>">
   <fieldset class="inputs">
     <ol>
       <li class="string input optional stringish" id="coupon_code_input">

--- a/db/migrate/20141112201747_checkout_subscribable_is_plan.rb
+++ b/db/migrate/20141112201747_checkout_subscribable_is_plan.rb
@@ -1,0 +1,6 @@
+class CheckoutSubscribableIsPlan < ActiveRecord::Migration
+  def change
+    remove_column :checkouts, :subscribeable_type
+    rename_column :checkouts, :subscribeable_id, :plan_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141030171639) do
+ActiveRecord::Schema.define(version: 20141112201747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
 
   create_table "checkouts", force: true do |t|
-    t.integer  "user_id",                        null: false
-    t.integer  "subscribeable_id",               null: false
-    t.string   "subscribeable_type",             null: false
-    t.integer  "quantity",           default: 1, null: false
+    t.integer  "user_id",                      null: false
+    t.integer  "plan_id",                      null: false
+    t.integer  "quantity",         default: 1, null: false
     t.string   "stripe_coupon_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -26,7 +26,7 @@ describe CheckoutsController do
 
       get :new, plan: desired_plan
 
-      expect(assigns(:checkout).subscribeable).to eq desired_plan
+      expect(assigns(:checkout).plan).to eq desired_plan
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -196,7 +196,7 @@ FactoryGirl.define do
     email
     name
     github_username
-    association :subscribeable, factory: :plan
+    association :plan, factory: :plan
     association :user, :with_stripe, :with_mentor, :with_github
   end
 
@@ -385,7 +385,7 @@ FactoryGirl.define do
       after :create do |subscription|
         create(
           :checkout,
-          subscribeable: subscription.plan,
+          plan: subscription.plan,
           user: subscription.user
         )
       end

--- a/spec/mailers/checkout_mailer_spec.rb
+++ b/spec/mailers/checkout_mailer_spec.rb
@@ -23,7 +23,7 @@ describe CheckoutMailer do
         it 'mentions the mentor email' do
           plan = create(:plan, :includes_mentor)
           user = create(:subscriber, plan: plan)
-          checkout = create(:checkout, user: user, subscribeable: plan)
+          checkout = create(:checkout, user: user, plan: plan)
 
           expect(email_for(checkout)).to have_body_text(/mentor/)
         end
@@ -33,7 +33,7 @@ describe CheckoutMailer do
           checkout = create(
             :checkout,
             user: user,
-            subscribeable: create(:basic_plan)
+            plan: create(:basic_plan)
           )
 
           expect(email_for(checkout)).not_to have_body_text(/mentor/)

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Checkout do
   it { should belong_to(:user) }
-  it { should belong_to(:subscribeable) }
+  it { should belong_to(:plan) }
 
   it { should validate_presence_of(:user_id) }
   it { should validate_presence_of(:quantity) }
@@ -13,9 +13,9 @@ describe Checkout do
   it { should delegate(:user_first_name).to(:user).as(:first_name) }
   it { should delegate(:user_last_name).to(:user).as(:last_name) }
   it { should delegate(:user_github_username).to(:user).as(:github_username) }
-  it { should delegate(:subscribeable_sku).to(:subscribeable).as(:sku) }
-  it { should delegate(:subscribeable_name).to(:subscribeable).as(:name) }
-  it { should delegate(:terms).to(:subscribeable) }
+  it { should delegate(:plan_sku).to(:plan).as(:sku) }
+  it { should delegate(:plan_name).to(:plan).as(:name) }
+  it { should delegate(:terms).to(:plan) }
 
   context "#save" do
     it "fulfills a subscription when purchasing a plan" do
@@ -88,16 +88,16 @@ describe Checkout do
     end
   end
 
-  it "uses the individual_price of the subscribeable as it's price" do
+  it "uses the individual_price of the plan as it's price" do
     plan = build(:plan, individual_price: 50)
-    checkout = build(:checkout, subscribeable: plan)
+    checkout = build(:checkout, plan: plan)
 
     expect(checkout.price).to eq 50
   end
 
-  it "uses the individual_price of the subscribeable and quantity as it's price" do
+  it "uses the individual_price of the plan and quantity as it's price" do
     plan = build(:plan, individual_price: 50)
-    checkout = build(:checkout, subscribeable: plan, quantity: 3)
+    checkout = build(:checkout, plan: plan, quantity: 3)
 
     expect(checkout.price).to eq 150
   end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -61,7 +61,7 @@ describe Plan do
       user = build_stubbed(:user)
       user.stubs(:create_subscription)
       plan = build_stubbed(:plan)
-      checkout = build_stubbed(:checkout, user: user, subscribeable: plan)
+      checkout = build_stubbed(:checkout, user: user, plan: plan)
       fulfillment = stub_subscription_fulfillment(checkout)
 
       plan.fulfill(checkout, user)
@@ -110,7 +110,7 @@ describe Plan do
       user = build_stubbed(:user)
       user.stubs(:create_subscription)
       plan = build_stubbed(:plan, :team)
-      checkout = build_stubbed(:checkout, user: user, subscribeable: plan)
+      checkout = build_stubbed(:checkout, user: user, plan: plan)
       subscription_fulfillment = stub_subscription_fulfillment(checkout)
       team_fulfillment = stub_team_fulfillment(checkout)
 

--- a/spec/models/stripe_subscription_spec.rb
+++ b/spec/models/stripe_subscription_spec.rb
@@ -10,7 +10,7 @@ describe StripeSubscription do
       subscription.create
 
       new_subscription = customer.subscriptions.first
-      expect(new_subscription[:plan]).to eq checkout.subscribeable_sku
+      expect(new_subscription[:plan]).to eq checkout.plan_sku
       expect(new_subscription[:quantity]).to eq 1
     end
 
@@ -23,7 +23,7 @@ describe StripeSubscription do
       subscription.create
 
       new_subscription = customer.subscriptions.first
-      expect(new_subscription[:plan]).to eq checkout.subscribeable_sku
+      expect(new_subscription[:plan]).to eq checkout.plan_sku
       expect(new_subscription[:quantity]).to eq checkout.quantity
     end
 
@@ -37,7 +37,7 @@ describe StripeSubscription do
       subscription.create
 
       new_subscription = customer.subscriptions.first
-      expect(new_subscription[:plan]).to eq checkout.subscribeable_sku
+      expect(new_subscription[:plan]).to eq checkout.plan_sku
       expect(new_subscription[:coupon]).to eq "25OFF"
       expect(new_subscription[:quantity]).to eq 1
     end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -102,7 +102,7 @@ describe Subscription do
       create(
         :checkout,
         user: subscription.user,
-        subscribeable: original_plan
+        plan: original_plan
       )
 
       expect { subscription.deactivate }.not_to raise_error

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -130,7 +130,7 @@ describe Team do
   end
 
   def stub_team_fulfillment(team, user)
-    checkout = build_stubbed(:checkout, subscribeable: team.subscription.plan)
+    checkout = build_stubbed(:checkout, plan: team.subscription.plan)
     stub_subscription_fulfillment(checkout, user)
   end
 end

--- a/spec/support/fulfillment_stubs.rb
+++ b/spec/support/fulfillment_stubs.rb
@@ -3,7 +3,7 @@ module FulfillmentStubs
     stub('fulfillment', fulfill: true, remove: true).tap do |fulfillment|
       SubscriptionFulfillment.
         stubs(:new).
-        with(user, checkout.subscribeable).
+        with(user, checkout.plan).
         returns(fulfillment)
     end
   end


### PR DESCRIPTION
It was polymorphic to accomodate IndividualPlans and TeamPlans. Now they are all
Plans.

https://trello.com/c/K52Duwxl/404-checkout-subscribeable-is-polymorphic-but-now-they-only-hold-plan-objects
