### PR TITLE
Optimize subscriber count

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -5,7 +5,7 @@ class HomesController < ApplicationController
     if signed_in?
       redirect_to dashboard_path
     else
-      @community_size = User.with_active_subscription.count
+      @community_size = User.subscriber_count
       render template: "landing_pages/watch-one-do-one-teach-one"
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,11 @@ class User < ActiveRecord::Base
       select(&:has_active_subscription?)
   end
 
+  def self.subscriber_count
+    Subscription.active.joins(team: :users).count +
+      Subscription.active.includes(:team).where(teams: { id: nil }).count
+  end
+
   def first_name
     name.split(" ").first
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -567,4 +567,33 @@ describe User do
       expect(user.discounted_annual_payment).to eq(1234)
     end
   end
+
+  describe ".subscriber_count" do
+    it "counts users with an active individual subscription" do
+      subscriber("active1", subscriptions: [create(:subscription)])
+      subscriber("active2", subscriptions: [create(:subscription)])
+      subscriber("inactive", subscriptions: [create(:inactive_subscription)])
+
+      result = User.subscriber_count
+
+      expect(result).to eq(2)
+    end
+
+    it "counts users with an active team subscription" do
+      team = create(:team, subscription: create(:subscription))
+      inactive_team =
+        create(:team, subscription: create(:inactive_subscription))
+      subscriber("active1", team: team)
+      subscriber("active2", team: team)
+      subscriber("inactive1", team: inactive_team)
+
+      result = User.subscriber_count
+
+      expect(result).to eq(2)
+    end
+
+    def subscriber(name, subscriptions: [], team: nil)
+      create(:user, name: name, subscriptions: subscriptions, team: team)
+    end
+  end
 end


### PR DESCRIPTION
We display this number on the home page.

Before:
- Loads every user, subscription, team, and plan into memory
- Iterates over every user in Ruby to filter
- Causes memory bloat and swapping on Heroku

After:
- Performs two count queries

https://trello.com/c/Bl7qdAaV/408-memory-bloat-on-new-home-page
