### PR TITLE
Remove exercises links from landing page

### DIFF
--- a/app/views/landing_pages/watch-one-do-one-teach-one.html.erb
+++ b/app/views/landing_pages/watch-one-do-one-teach-one.html.erb
@@ -32,10 +32,8 @@
     </h2>
 
     <p>
-      Exercises include
-      <%= link_to "Refactoring: Explaining Variable", "https://exercises.upcase.com/exercises/explaining-variable" %>
-      and
-      <%= link_to "Regular Expressions: Repeating Patterns", "https://exercises.upcase.com/exercises/regular-expressions-repeating-patterns" %>.
+      Exercises include "Refactoring: Explaining Variable" and
+      "Regular Expressions: Repeating Patterns".
       Clone the exercise's Git repo.
       Solve the problem on your own machine, then submit your solution.
     </p>


### PR DESCRIPTION
They don't work for visitors or users without permission.

For users with no permission they redirect to https://upcase.com/subscribe,
which 404s. For visitors, to sign in.

https://trello.com/c/wavAmdwn/413-landing-page-bugfix
