### PR TITLE
Notify Analytics of subscription changes

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -56,6 +56,7 @@ class Subscription < ActiveRecord::Base
     update_features do
       self.plan = Plan.find_by!(sku: sku)
       save!
+      track_updated
     end
   end
 
@@ -127,6 +128,10 @@ class Subscription < ActiveRecord::Base
     )
     feature_fulfillment.fulfill_gained_features
     feature_fulfillment.unfulfill_lost_features
+  end
+
+  def track_updated
+    Analytics.new(user).track_updated
   end
 
   def stripe_customer

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -12,6 +12,10 @@ class Analytics
     track("Cancelled")
   end
 
+  def track_updated
+    track("Updated")
+  end
+
   private
 
   attr_reader :user


### PR DESCRIPTION
https://trello.com/c/dBfmdc93/422-send-customer-property-updates-to-analytics-whenever-someone-s-subscription-changes
