### PR TITLE
Stripe webhook doesn't trigger a second stripe update

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -48,13 +48,21 @@ class Subscription < ActiveRecord::Base
   end
 
   def change_plan(sku:)
+    write_plan(sku: sku)
+    change_stripe_plan(sku: sku)
+  end
+
+  def write_plan(sku:)
     update_features do
-      subscription = stripe_customer.subscriptions.first
-      subscription.plan = sku
-      subscription.save
       self.plan = Plan.find_by!(sku: sku)
       save!
     end
+  end
+
+  def change_stripe_plan(sku:)
+    subscription = stripe_customer.subscriptions.first
+    subscription.plan = sku
+    subscription.save
   end
 
   def change_quantity(new_quantity)

--- a/app/services/stripe_events.rb
+++ b/app/services/stripe_events.rb
@@ -11,7 +11,7 @@ class StripeEvents
 
   def customer_subscription_updated
     if subscription
-      subscription.change_plan(sku: stripe_subscription.plan.id)
+      subscription.write_plan(sku: stripe_subscription.plan.id)
       SubscriptionUpcomingInvoiceUpdater.new([subscription]).process
     end
   end

--- a/spec/services/stripe_events_spec.rb
+++ b/spec/services/stripe_events_spec.rb
@@ -38,7 +38,7 @@ describe StripeEvents do
 
       StripeEvents.new(event).customer_subscription_updated
 
-      expect(subscription).to have_received(:change_plan).
+      expect(subscription).to have_received(:write_plan).
         with(sku: FakeStripe::PLAN_ID)
       expect(SubscriptionUpcomingInvoiceUpdater).
         to have_received(:new).with([subscription])
@@ -51,7 +51,7 @@ describe StripeEvents do
   def stub_subscription
     subscription = build_stubbed(:subscription)
     Subscription.stubs(:find_by).returns(subscription)
-    subscription.stubs(:change_plan)
+    subscription.stubs(:write_plan)
     subscription
   end
 


### PR DESCRIPTION
Stripe webhook doesn't trigger a second stripe update

StripeEvents was calling `Subscription#change_plan`, which itself tried to
trigger a Stripe update.

This changeset separates upcase and stripe updates into their own methods,
calling the appropriate from StripeEvents, and using a method that calls both
when we want to update both copies.

https://trello.com/c/VpihCMSF/396-listen-for-subscription-updates-in-stripe
