### PR TITLE
Update Intercom data from Ruby

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -3,7 +3,7 @@ module AnalyticsHelper
     ENV["ANALYTICS"].present?
   end
 
-  def analytics_hash(user = current_user)
+  def identify_hash(user = current_user)
     {
       created: user.created_at,
       email: user.email,

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -9,22 +9,22 @@ class Analytics
   end
 
   def track_cancelled
-    track("Cancelled")
+    track(event: "Cancelled", properties: {})
   end
 
   def track_updated
-    track("Updated")
+    backend.identify(user_id: user.id, traits: identify_hash(user))
   end
 
   private
 
   attr_reader :user
 
-  def track(name)
+  def track(event:, properties:)
     backend.track(
-      event: name,
+      event: event,
       user_id: user.id,
-      properties: analytics_hash(user),
+      properties: properties
     )
   end
 end

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -15,7 +15,7 @@
   <script type="text/javascript">
     analytics.identify(
       '<%= current_user.id %>',
-      <%= raw analytics_hash.to_json %>,
+      <%= raw identify_hash.to_json %>,
       <%= raw intercom_hash.to_json %>
     );
   </script>

--- a/spec/features/user_cancels_subscription_spec.rb
+++ b/spec/features/user_cancels_subscription_spec.rb
@@ -18,12 +18,7 @@ feature 'User cancels a subscription' do
     click_button I18n.t('subscriptions.confirm_cancel_reject_deal')
 
     expect(page).to have_content I18n.t('subscriptions.flashes.cancel.success')
-    expect(analytics).to have_tracked("Cancelled").
-      for_user(@current_user).
-      with_properties(
-        has_active_subscription: true,
-        scheduled_for_cancellation_on: @current_user.reload.scheduled_for_cancellation_on
-      )
+    expect(analytics).to have_tracked("Cancelled").for_user(@current_user)
   end
 
   def expect_to_see_alternate_offer

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -17,11 +17,11 @@ describe AnalyticsHelper do
     end
   end
 
-  describe "#analytics_hash" do
+  describe "#identify_hash" do
     it "returns a hash of data to be sent to analytics" do
       user = build_stubbed(:user, stripe_customer_id: "something")
 
-      expect(analytics_hash(user)).to eq(
+      expect(identify_hash(user)).to eq(
         created: user.created_at,
         email: user.email,
         has_active_subscription: user.has_active_subscription?,

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe Analytics do
+  describe "#track_cancelled" do
+    it "sends cancelled event to backend" do
+      user = build(:user)
+      user_analytics = Analytics.new(user)
+
+      user_analytics.track_cancelled
+
+      expect(analytics).to have_tracked("Cancelled").for_user(user)
+    end
+  end
+
+  describe "#track_updated" do
+    it "sends updated identify event to backend" do
+      user = build_stubbed(:user)
+      user_analytics = Analytics.new(user)
+
+      user_analytics.track_updated
+
+      expect(analytics).to have_identified(user).
+        with_properties(user_analytics.identify_hash(user))
+    end
+  end
+end

--- a/spec/support/fake_analytics_ruby.rb
+++ b/spec/support/fake_analytics_ruby.rb
@@ -1,17 +1,24 @@
 class FakeAnalyticsRuby
   def initialize
+    @identified_events = EventsList.new([])
     @tracked_events = EventsList.new([])
+  end
+
+  def identify(options)
+    @identified_events << options
   end
 
   def track(options)
     @tracked_events << options
   end
 
-  delegate :tracked_events_for, to: :tracked_events
+  def identified_events_for(user)
+    @identified_events.events_for(user)
+  end
 
-  private
-
-  attr_reader :tracked_events
+  def tracked_events_for(user)
+    @tracked_events.events_for(user)
+  end
 
   class EventsList
     def initialize(events)
@@ -22,7 +29,7 @@ class FakeAnalyticsRuby
       @events << event
     end
 
-    def tracked_events_for(user)
+    def events_for(user)
       self.class.new(
         events.select do |event|
           event[:user_id] == user.id
@@ -40,7 +47,9 @@ class FakeAnalyticsRuby
 
     def has_properties?(options)
       events.any? do |event|
-        options.all? { |key, value| event[:properties][key] == value }
+        options.all? do |key, value|
+          (event[:properties] || event[:traits])[key] == value
+        end
       end
     end
 

--- a/spec/support/matchers/have_identified.rb
+++ b/spec/support/matchers/have_identified.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :have_identified do |user|
+  match do |backend|
+    @backend = backend
+
+    backend.
+      identified_events_for(user).
+      has_properties?(@properties || {})
+  end
+
+  chain(:with_properties) { |properties| @properties = properties }
+end

--- a/spec/support/matchers/have_tracked.rb
+++ b/spec/support/matchers/have_tracked.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :have_tracked do |event_name|
     backend.
       tracked_events_for(@user).
       named(@event_name).
-      has_properties?(@properties)
+      has_properties?(@properties || {})
   end
 
   chain(:for_user) { |user| @user = user }

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -74,7 +74,7 @@ describe "shared/_analytics.html.erb" do
 
       render
 
-      expect(rendered).to include(analytics_hash(user).to_json)
+      expect(rendered).to include(identify_hash(user).to_json)
     end
 
     it 'uses Intercom secure mode' do


### PR DESCRIPTION
`track` doesn't update information in Itercom, it just enqueues new activity
elements. `identify` updates changed information about the user.

https://trello.com/c/dBfmdc93/422-send-customer-property-updates-to-analytics-whenever-someone-s-subscription-changes
