### PR TITLE
Trap proper exception from Stripe

### DIFF
--- a/app/models/subscription_upcoming_invoice_updater.rb
+++ b/app/models/subscription_upcoming_invoice_updater.rb
@@ -16,7 +16,7 @@ class SubscriptionUpcomingInvoiceUpdater
 
   def upcoming_invoice_for(stripe_customer_id)
     Stripe::Invoice.upcoming(customer: stripe_customer_id)
-  rescue Stripe::APIError => error
+  rescue Stripe::InvalidRequestError => error
     notify_airbrake(error)
     nil
   end

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -77,7 +77,7 @@ describe Cancellation do
       subscription = create(:subscription)
       cancellation = Cancellation.new(subscription)
       stripe_customer.subscriptions.first.stubs(:delete).
-        raises(Stripe::APIError)
+        raises(Stripe::InvalidRequestError)
       Stripe::Customer.stubs(:retrieve).returns(stripe_customer)
 
       expect { cancellation.cancel_now }.to raise_error
@@ -133,7 +133,7 @@ describe Cancellation do
       cancellation = Cancellation.new(subscription)
 
       stripe_customer.subscriptions.first.stubs(:delete).
-        raises(Stripe::APIError)
+        raises(Stripe::InvalidRequestError)
       Stripe::Customer.stubs(:retrieve).returns(stripe_customer)
 
       expect { cancellation.schedule }.to raise_error

--- a/spec/models/subscription_upcoming_invoice_updater_spec.rb
+++ b/spec/models/subscription_upcoming_invoice_updater_spec.rb
@@ -19,7 +19,11 @@ describe SubscriptionUpcomingInvoiceUpdater do
 
   it 'sets the next_payment_amount to 0 when it is 404' do
     Stripe::Invoice.stubs(:upcoming).raises(
-      Stripe::APIError.new("No upcoming invoices for customer", "", 404)
+      Stripe::InvalidRequestError.new(
+        "No upcoming invoices for customer",
+        "",
+        404
+      )
     )
     subscription = create(:subscription)
     subscriptions = [subscription]
@@ -42,7 +46,7 @@ describe SubscriptionUpcomingInvoiceUpdater do
 
   it "sends the error to Airbrake if it isn't 404" do
     Airbrake.stubs(:notify)
-    error = Stripe::APIError.new("Server error", "", 500)
+    error = Stripe::InvalidRequestError.new("Server error", "", 500)
     Stripe::Invoice.stubs(:upcoming).raises(
       error
     )


### PR DESCRIPTION
Stripe raises `InvalidRequestError` instead of `APIError` when there is no
upcoming invoices.

Related commit: https://github.com/thoughtbot/upcase/commit/e65f53aeb65768391af10621c38d033efafa9e47

Trello card: https://trello.com/c/yNGVszrf/426-investigate-stripe-webhook-exception
