### PR TITLE
Don't escape characters in video description

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -1,5 +1,5 @@
 module VideosHelper
   def video_description(video, length: 250)
-    truncate(strip_tags(video.notes_html), length: length)
+    truncate(strip_tags(video.notes_html), escape: false, length: length)
   end
 end

--- a/spec/helpers/videos_helper_spec.rb
+++ b/spec/helpers/videos_helper_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe VideosHelper do
   describe "#video_description" do
     it "returns plain text video notes" do
-      video = stub("video", notes_html: "<h1>Citizen Kane</h1>")
+      video = stub("video", notes_html: "<h1>Vim's Power</h1>")
 
       result = video_description(video)
 
-      expect(result).to eq "Citizen Kane"
+      expect(result).to eq "Vim's Power"
     end
 
     it "truncates the video notes to 250 characters by default" do


### PR DESCRIPTION
The HTML escaping causes the content to go longer than 200 characters, which
causes Twitter's Player Card to not display.
