### PR TITLE
Remove duplicate footer from subscription edit page.

### DIFF
--- a/app/views/subscriptions/_plans.html.erb
+++ b/app/views/subscriptions/_plans.html.erb
@@ -2,5 +2,4 @@
   <%= render 'pricing', plans: catalog.individual_plans %>
   <%= render 'testimonials' %>
   <%= render 'plan_features', catalog: catalog %>
-  <%= render 'shared/footer' %>
 </section>


### PR DESCRIPTION
The footer on [the subscription edit page](https://upcase.com/subscription/edit) is duplicated:

![upcase_-_duplicate_footer](https://cloud.githubusercontent.com/assets/607257/5152731/3b254758-71c6-11e4-8d2b-8d17a5371921.png)

This is because 'shared/footer' template is already rendered by _layouts/application.html.erb_.

This change removes the duplicate footer:

![upcase_single_footer](https://cloud.githubusercontent.com/assets/607257/5152741/b8ce33cc-71c6-11e4-8269-92e36e085c2b.png)
