### PR TITLE
No need to notify of subscription double delete

### DIFF
--- a/app/services/stripe_events.rb
+++ b/app/services/stripe_events.rb
@@ -4,23 +4,15 @@ class StripeEvents
   end
 
   def customer_subscription_deleted
-    if subscription
+    if subscription = find_subscription
       Cancellation.new(subscription).process
     end
   end
 
   def customer_subscription_updated
-    if subscription
+    if subscription = find_subscription
       subscription.write_plan(sku: stripe_subscription.plan.id)
       SubscriptionUpcomingInvoiceUpdater.new([subscription]).process
-    end
-  end
-
-  private
-
-  def subscription
-    if subscription = Subscription.find_by(stripe_id: stripe_subscription.id)
-      subscription
     else
       Airbrake.notify_or_ignore(
         error_message: "No subscription found for #{stripe_subscription.id}",
@@ -29,6 +21,10 @@ class StripeEvents
       )
       nil
     end
+  end
+
+  def find_subscription
+    Subscription.find_by(stripe_id: stripe_subscription.id)
   end
 
   def stripe_subscription

--- a/spec/services/stripe_events_spec.rb
+++ b/spec/services/stripe_events_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 describe StripeEvents do
   describe "#customer_subscription_deleted" do
-    it "sends notifications if no subscription is found" do
+    it "doesn't send notifications on delete if no subscription is found" do
       Airbrake.stubs(:notify_or_ignore)
 
       StripeEvents.new(event).customer_subscription_deleted
 
-      expect(Airbrake).to have_received(:notify_or_ignore).once
+      expect(Airbrake).to have_received(:notify_or_ignore).never
     end
 
     it "cancels plan if subscription found" do


### PR DESCRIPTION
Cancelled subscriptions in Upcase are cancelled in Stripe, and the 
notification raises an exception back in Upcase. If it doesn't exist in 
Upcase, both systems are anyway in sync, and there is nothing to do or fix.

https://trello.com/c/eeAfGC9X/438-cancelled-subscriptions-in-upcase-are-cancelled-in-stripe-and-the-notification-raises-an-exception-back-in-upcase
