### PR TITLE
github_username with errors is still needed

### DIFF
--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -27,8 +27,10 @@ module CheckoutsHelper
     end
   end
 
-  def need_to_collect_github_username?
-    signed_in? && current_user.github_username.blank?
+  def needs_github_username?
+    signed_in? &&
+      (current_user.github_username.blank? ||
+       current_user.errors[:github_username].present?)
   end
 
   def need_to_create_user_account?

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -19,7 +19,7 @@
       <%= form.input :email, as: :email, required: true %>
       <%= form.input :password, required: true %>
     <% end %>
-    <% if need_to_create_user_account? || need_to_collect_github_username? %>
+    <% if need_to_create_user_account? || needs_github_username? %>
       <%= form.input :github_username, required: true, label: "GitHub username",
         hint: "Be sure to enter a valid, unique GitHub username. Organizations are not allowed." %>
     <% end %>

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -155,6 +155,18 @@ feature "User creates a subscription" do
     expect(page).not_to have_link("Subscribe to #{plan.name}")
   end
 
+  scenario "existing user tries to subscribe with duplicate github", js: true do
+    create(:user, github_username: "taken")
+    user = create(:user)
+
+    visit new_checkout_path(@plan, as: user)
+    fill_in "GitHub username", with: "taken"
+    fill_out_subscription_form_with_valid_credit_card
+
+    expect(page).to have_content("has already been taken")
+    expect(page).not_to have_content("Your Billing Info")
+  end
+
   scenario "User subscribes with an existing credit card", js: true do
     user = create(:user, :with_github, stripe_customer_id: "test")
 


### PR DESCRIPTION
This can be tested with the integration test removed as of
https://github.com/thoughtbot/upcase/pull/1057#discussion-diff-20682044 (moved integration test to unit).

Also related with the weird `reload` in a helper, this is a better solution than that one.

https://trello.com/c/Jkg8OlIE/424-sign-up-and-then-checkout-with-an-existing-github-username-raises-an-exception-right-after-you-seed-in-your-cc
