### PR TITLE
Left-align and use .subject for all page headers 

### DIFF
--- a/app/assets/stylesheets/_annual-billing.scss
+++ b/app/assets/stylesheets/_annual-billing.scss
@@ -2,13 +2,6 @@
   margin-bottom: em(100);
 }
 
-.subject {
-  h2 {
-    font-size: em(28);
-    font-weight: 400;
-  }
-}
-
 .subscription-charge {
   color: $upcase-blue;
   font-weight: 800;

--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -162,3 +162,36 @@ hr {
     padding: 0 1em;
   }
 }
+
+.subject {
+  margin-bottom: 3em;
+  text-align: left;
+  width: 85%;
+
+  @include body-mobile {
+    width: 100%;
+  }
+
+  h1 {
+    color: $darkwarmgray;
+    font-weight: 700;
+    margin-bottom: 0.5em;
+
+    @include body-mobile {
+      font-size: 30px;
+    }
+  }
+
+  h2 {
+    font-size: 1em;
+    font-weight: normal;
+    line-height: 1.75em;
+    width: 85%;
+  }
+
+  .tagline, .tagline a {
+    @include body-mobile {
+      font-size: 20px;
+    }
+  }
+}

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -16,26 +16,6 @@ $not-started-dot-color: #D8D8D8;
   }
 }
 
-.section-title {
-  margin: 0 auto 80px;
-  text-align: center;
-  width: 85%;
-
-  h1 {
-    color: $darkwarmgray;
-    font-size: em(41);
-    font-weight: 700;
-    margin-bottom: 0.6em;
-  }
-
-  h2 {
-    font-size: em(27);
-    font-weight: normal;
-    line-height: 1.2;
-  }
-}
-
-
 .trails-progress {
   display: block;
   position: relative;
@@ -53,7 +33,6 @@ $not-started-dot-color: #D8D8D8;
   }
 
   .trail {
-    padding: 0 em(30);
     width: 100%;
 
     header {

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -17,8 +17,9 @@ body.passwords-create {
 }
 
 .header-container {
-  @include outer-container;
   @include user-select(none);
+  @include outer-container;
+  max-width: $max-width;
   position: relative;
 
   .small-logo {

--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -19,56 +19,18 @@ section {
 
 .content {
   @include outer-container;
+  max-width: $max-width;
   flex: 1;
-  max-width: 1100px;
   padding: 0 2em 3em 2em;
   width: 100%;
 
+  @media only screen and (min-width: 800px)  {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   &.fullscreen {
     max-width: 100%;
-  }
-
-  div.subject {
-    margin: 0 auto 2rem;
-    text-align: center;
-    width: 75%;
-
-    @include body-mobile {
-      width: 100%;
-      margin-bottom: 1rem;
-    }
-
-    h1 {
-      color: #6c6a66;
-      font-size: 50px;
-      line-height: 1em;
-      margin: 2rem 0 0;
-
-      @include body-mobile {
-        font-size: 30px;
-      }
-    }
-
-    .tagline, .tagline a {
-      font: 400 30px/40px $sans-serif;
-      margin: .5rem auto 0 auto;
-
-      @include body-mobile {
-        font-size: 20px;
-      }
-    }
-
-    .tagline a {
-      border-bottom: 2px solid $upcase-red;
-      margin: 0 3px;
-    }
-  }
-
-  h1.subject {
-    color: desaturate(darken($warmgray, 22%), 8%);
-    font-size: 50px;
-    line-height: 1.15em;
-    margin: 0 0 .4rem 22px;
   }
 
   ul, ol {

--- a/app/views/annual_billings/new.html.erb
+++ b/app/views/annual_billings/new.html.erb
@@ -1,7 +1,7 @@
-<div id="annual-subscription-subject" class="subject">
+<section id="annual-subscription-subject" class="subject">
   <h1>Get two free months of Upcase</h1>
   <h2>Switch to annual billing and commit to long-term learning</h2>
-</div>
+</section>
 
 <div class="text-box-wrapper left">
   <div class="text-box no-background">

--- a/app/views/explore/show.html.erb
+++ b/app/views/explore/show.html.erb
@@ -7,13 +7,13 @@
 
 <section class="root-library">
   <div class="content">
-    <header class="section-title">
+    <section class="subject">
       <h1>Explore</h1>
       <h2>
         Upcase's exclusive video tutorials and resources on intermediate and
         advanced topics such as Vim mastery, TDD, and object-oriented design.
       </h2>
-    </header>
+    </section>
 
     <section class="topics">
       <span class="divider">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
         <h1 class="subject"><%= yield(:subject) %></h1>
       <% end %>
       <% if content_for?(:subject_block) %>
-        <div class="subject"><%= yield(:subject_block) %></div>
+        <section class="subject"><%= yield(:subject_block) %></section>
       <% end %>
       <%= yield %>
     </div>

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -24,7 +24,7 @@
 
     <section class="content">
       <% if content_for?(:subject_block) %>
-        <div class="subject"><%= yield(:subject_block) %></div>
+        <section class="subject"><%= yield(:subject_block) %></section>
       <% end %>
       <%= yield %>
     </section>

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -8,13 +8,13 @@
 <section class="root-trails">
   <div class="content">
     <section class="trails-progress">
-      <header class="section-title">
+      <section class="subject">
         <h1>New Trails (Beta)</h1>
         <h2>
           These new trails are focused exercises targeting your interests. They
           help you learn by doing and keep your skillset sharp.
         </h2>
-      </header>
+      </section>
 
       <%= render partial: "practice/trail", collection: @practice.trails %>
 


### PR DESCRIPTION
![screen shot 2014-11-24 at 3 44 21 pm](https://cloud.githubusercontent.com/assets/2343392/5172984/92c93f86-73f2-11e4-9aca-2067d1faee5a.png)
![screen shot 2014-11-24 at 3 48 57 pm](https://cloud.githubusercontent.com/assets/2343392/5172985/92ce294c-73f2-11e4-89bf-9d925d265911.png)
![screen shot 2014-11-24 at 3 56 47 pm](https://cloud.githubusercontent.com/assets/2343392/5172987/92d10c48-73f2-11e4-95a7-2a48440cdfc1.png)
![screen shot 2014-11-24 at 3 57 01 pm](https://cloud.githubusercontent.com/assets/2343392/5172986/92cf2bd0-73f2-11e4-8165-2bd2f2c81212.png)
- Extend .section-title class to .subject divs 
- Change paragraph text to sans-serif
- Adjust .content and header padding so that header aligns left with page sections

Question - should we name .section-title and .subject the same in the markup? Right now they are named differently, but are the same style. for example, /repositories has the .subject class, but explore/show has .section-title. I extended the .section-title style to .subject divs, but if they were the same class, I wouldn't have to do so.
