### PR TITLE
Make /products header and call to action consistent with global styles

### DIFF
--- a/app/assets/stylesheets/_products-index.scss
+++ b/app/assets/stylesheets/_products-index.scss
@@ -1,23 +1,14 @@
 body.products-index {
-
-  .content > section {
-    @include display(flex);
-    @include flex-flow(wrap);
-    @include justify-content(space-around);
-    margin-bottom: 3.5rem;
+  h1 {
+    margin-bottom: 1em;
   }
 
-  .content > h2 {
-    margin: 0 0 1.75rem;
-    text-align: center;
-  }
+  .subscription {
+    width: 100%;
 
-  .subscription .button {
-    display: block;
-    font-size: 1.2rem;
-    height: auto;
-    letter-spacing: 1px;
-    margin: $product-card-margin auto 2rem;
-    width: 400px;
+    .button {
+      @extend %button;
+      margin-right: 5px;
+    }
   }
 }

--- a/app/assets/stylesheets/_products-video_tutorials-show.scss
+++ b/app/assets/stylesheets/_products-video_tutorials-show.scss
@@ -8,6 +8,14 @@ body.videos-show aside {
     margin-bottom: 2rem;
   }
 
+  .button {
+    @extend %button;
+    letter-spacing: 1px;
+    line-height: 1.5em;
+    margin-top: 0;
+    text-align: center;
+  }
+
   div {
 
     h2 a {
@@ -29,16 +37,6 @@ body.videos-show aside {
 
     .license {
       margin-top: 0;
-    }
-
-    .button {
-      @extend %button;
-      font-size: 12px;
-      letter-spacing: 1px;
-      line-height: 1.5em;
-      margin-top: 0;
-      padding: 1em;
-      text-align: center;
     }
 
     .location-name {

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,14 +1,13 @@
-<% if !current_user_has_active_subscription? %>
-  <section class="subscription">
-    <%= link_to "Subscribe to #{t('shared.subscription.name')} to access all of these products",
-      new_subscription_path,
-      class: 'button' %>
-  </section>
-<% end %>
-
-<header class="section-title">
+<section class="subject">
   <h1>Video Tutorials</h1>
-</header>
+  <% if !current_user_has_active_subscription? %>
+    <div class="subscription">
+      <%= link_to "Subscribe to #{t('shared.subscription.name')}",
+        new_subscription_path,
+        class: 'button' %> to access all of these products.
+    </div>
+  <% end %>
+</section>
 
 <section class="resources">
   <%= render(


### PR DESCRIPTION
https://trello.com/c/HCkAGWW3/474-products-index-page-looks-broken

![screen shot 2014-12-02 at 12 03 42 pm](https://cloud.githubusercontent.com/assets/2343392/5266967/57ad0390-7a1b-11e4-80f9-ac085367b235.png)
