### PR TITLE
Change layout and add repo details to /repositories index

### DIFF
--- a/app/assets/stylesheets/_base-lists.scss
+++ b/app/assets/stylesheets/_base-lists.scss
@@ -4,3 +4,15 @@ ol {
   padding: 0;
   list-style-type: none;
 }
+
+ul {
+  .list-title {
+    margin-bottom: .5em;
+    font-weight: 700;
+    font-size: em(22);
+  }
+
+  .number {
+    font-weight: 700;
+  }
+}

--- a/app/assets/stylesheets/_repos.scss
+++ b/app/assets/stylesheets/_repos.scss
@@ -1,0 +1,39 @@
+body.repositories-show aside {
+  .button {
+    @extend %button;
+    letter-spacing: 1px;
+    line-height: 1.5em;
+    margin-top: 0;
+    text-align: center;
+  }
+}
+
+
+body.repositories-index {
+  .repos-list a:first-child .repository {
+    padding-top: 1em;
+  }
+
+  .repository {
+    border-bottom: 1px solid $base-border-color-1;
+    display: block;
+    float: left;
+    margin: 0;
+    padding: 3em 0;
+    width: 100%;
+
+    .repo-name {
+      float: left;
+      clear: left;
+    }
+  }
+
+  .repo-info {
+    float: right;
+
+    li {
+      float: left;
+      margin: 0 1em 0 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -44,5 +44,6 @@
 @import "topics";
 @import "tile";
 @import "trail-titles";
+@import "repos";
 
 @import "prettify";

--- a/app/views/products/repositories/_repository.html.erb
+++ b/app/views/products/repositories/_repository.html.erb
@@ -1,10 +1,12 @@
-<figure class="repository card">
-  <%= link_to repository, title: repository.name do %>
-    <h5>GitHub Repository</h5>
-    <figure>
-      <div class="illustration"></div>
-    </figure>
-    <h4><%= repository.name %></h4>
-    <p><%= repository.tagline %></p>
-  <% end %>
-</figure>
+<%= link_to repository, title: repository.name do %>
+  <li class="repository">
+    <div class="repo-name">
+      <h1 class="list-title"><%= repository.name %></h1>
+      <p class="description"><%= repository.tagline %></p>
+    </div>
+
+    <ul class="repo-info">
+      <%= raw repository.alternative_description %>
+    </ul>
+  </li>
+<% end %>

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -4,8 +4,14 @@
 <% end %>
 
 <section class="resources">
-  <%= render(
-    partial: "products/repositories/repository",
-    collection: @catalog.repositories
-  ) %>
+  <span class="divider">
+    <h4 class="text">Github Repos</h4>
+  </span>
+
+  <ul class="repos-list">
+    <%= render(
+      partial: "products/repositories/repository",
+      collection: @catalog.repositories
+    ) %>
+  </ul>
 </section>


### PR DESCRIPTION
https://trello.com/c/Hbga6QLu/445-design-for-repositories

![screen shot 2014-12-03 at 1 35 57 pm](https://cloud.githubusercontent.com/assets/2343392/5286405/240a46c4-7af2-11e4-9540-674c0a92403b.png)

The goal here is to move these repos out of the "card" format and into a list.
I also added placeholders for info about each repo (# contributors, branches, etc..) Is that easy to add?
