### PR TITLE
Display no team subscription message

### DIFF
--- a/app/views/teams/_team.html.erb
+++ b/app/views/teams/_team.html.erb
@@ -2,12 +2,16 @@
   <li class="subscription team">
     <p class="subscription-name"><strong>Team:</strong> <%= team.name %></p>
 
-    <% if team.owner?(current_user) %>
-      <%= link_to 'Manage Users', edit_team_path %>
+    <% if team.subscription %>
+      <% if team.owner?(current_user) %>
+        <%= link_to 'Manage Users', edit_team_path %>
+      <% else %>
+        Your team owner,
+        <%= mail_to team.owner.email, team.owner.name, class: "owner-email" %>,
+        can make changes to your subscription.
+      <% end %>
     <% else %>
-      Your team owner,
-      <%= mail_to team.owner.email, team.owner.name, class: "owner-email" %>,
-      can make changes to your subscription.
+      Your team currently has no subscription.
     <% end %>
   </li>
 </ol>

--- a/spec/views/teams/_team.html.erb_spec.rb
+++ b/spec/views/teams/_team.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "teams/_team.html.erb" do
+  context "when team has a subscription" do
+    it "renders link to manage users" do
+      team = build_stubbed(:team)
+      current_user = team.subscription.user
+
+      render "teams/team", current_user: current_user, team: team
+
+      expect(rendered).to include "Manage Users"
+    end
+  end
+
+  context "when team has no subscription" do
+    it "renders no subscription message" do
+      team = build_stubbed(:team, subscription: nil)
+      current_user = build_stubbed(:user)
+
+      render "teams/team", current_user: current_user, team: team
+
+      expect(rendered).to include "Your team currently has no subscription."
+    end
+  end
+end


### PR DESCRIPTION
User now able to update their account information instead of seeing an error page if their team loses a subscription.

https://thoughtbot.airbrake.io/projects/6325/groups/1296378819750090081
https://trello.com/c/Vd8rCXbk
