### PR TITLE
Fix broken header on non-subscriber user, and remove repetitive "see what you're missing" link

### DIFF
--- a/app/assets/stylesheets/_products-index.scss
+++ b/app/assets/stylesheets/_products-index.scss
@@ -4,8 +4,6 @@ body.products-index {
   }
 
   .subscription {
-    width: 100%;
-
     .button {
       @extend %button;
       margin-right: 5px;

--- a/app/views/products/_locked_features.html.erb
+++ b/app/views/products/_locked_features.html.erb
@@ -9,7 +9,6 @@
             link: subscribe_or_upgrade_link
           ) %>
       </h2>
-        <%= link_to "See what you're missing", products_path %>
       </div>
     </section>
   </div>


### PR DESCRIPTION
https://trello.com/c/kKDfwS7w/476-products-page-breaks-on-non-subscriber-user
1. fixed bug
2. removed "see what you're missing" link. There is already a link to subscribe, and this one took the user to /products, which isn't really a full account of what someone is missing.
   ![screen shot 2014-12-05 at 3 24 24 pm](https://cloud.githubusercontent.com/assets/2343392/5322438/a23f21d4-7c93-11e4-9efa-48c8a957676e.png)
