### PR TITLE
Update analytics tracking for team plan changes

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -131,7 +131,17 @@ class Subscription < ActiveRecord::Base
   end
 
   def track_updated
-    Analytics.new(user).track_updated
+    users_for_analytics_tracking.each do |user|
+      Analytics.new(user).track_updated
+    end
+  end
+
+  def users_for_analytics_tracking
+    if team
+      team.users
+    else
+      [user]
+    end
   end
 
   def stripe_customer


### PR DESCRIPTION
Sends update to analytics service for each of the team members upon changes to the team plan instead of just the team owner.

https://trello.com/c/H8J9Vw10
