### PR TITLE
Fix positioning to show all new trails within a category

### DIFF
--- a/app/assets/stylesheets/_topics-index.scss
+++ b/app/assets/stylesheets/_topics-index.scss
@@ -15,10 +15,11 @@
     height: 100%;
     overflow: auto;
     @include transition(.07s);
+    margin-top: 3em;
   }
 
-  .new-trail .steps-complete {
-    top: 35%;
+  .new-trail .trails-progress > div {
+    margin-top: 2em;
   }
 
   > a {

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -286,7 +286,6 @@ $not-started-dot-color: #D8D8D8;
   ///////////////////////////////////////////////////////////////////////////
   .unstarted {
     @include clearfix;
-    margin-bottom: 3.5em;
 
     header {
       float: left;


### PR DESCRIPTION
https://trello.com/c/gdrZPx7C/505-when-there-is-more-than-one-trail-in-a-category-only-one-trail-progress-bar-displays

Now it should look like:
![screen shot 2014-12-16 at 11 31 04 am](https://cloud.githubusercontent.com/assets/2343392/5457315/99623146-8517-11e4-89d5-5dfddd2af61c.png)
