### PR TITLE
Change video tutorial card style to tile

### DIFF
--- a/app/assets/stylesheets/_resources-index.scss
+++ b/app/assets/stylesheets/_resources-index.scss
@@ -72,6 +72,10 @@ body.resources-index {
     }
   }
 
+  .divider {
+    margin-top: 2em;
+  }
+
   .trails-progress {
     padding: 1px;
     width: 100%;

--- a/app/assets/stylesheets/_tile.scss
+++ b/app/assets/stylesheets/_tile.scss
@@ -1,16 +1,19 @@
-.tiles ul {
+.tiles ul,
+.tiles-container {
   @include display(flex);
   @include flex-direction(row);
   @include flex-wrap(wrap);
   @include justify-content(space-around);
   margin-bottom: 2em;
+  width: 100%;
 
   .tile {
     border-radius: 0 0 3px 3px;
     border-top: 10px solid $gray-5;
     box-shadow: 0 0 0 1px $gray-4;
     height: 280px;
-    margin: 0;
+    margin: 0 0 2em 0;
+    overflow: hidden;
     padding: 40px;
     position: relative;
     text-align: center;
@@ -22,6 +25,7 @@
     }
 
     h1 {
+      font-size: 20px;
       line-height: 26px;
       margin-bottom: em(8);
 
@@ -56,5 +60,13 @@
       position: absolute;
       width: 180px;
     }
+  }
+}
+
+.resources-index .tiles-container .tile {
+  height: 280px;
+
+  h1 {
+    color: $darkwarmgray;
   }
 }

--- a/app/helpers/video_tutorials_helper.rb
+++ b/app/helpers/video_tutorials_helper.rb
@@ -11,7 +11,7 @@ module VideoTutorialsHelper
   end
 
   def video_tutorial_card_classes(video_tutorial)
-    classes = ["video_tutorial", "card"]
+    classes = %w(video_tutorial tile)
     classes << video_tutorial_card_status(video_tutorial)
     classes.join(" ")
   end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 </section>
 
-<section class="resources-container">
+<section class="resources-container tiles-container">
   <%= render(
     partial: "products/video_tutorials/video_tutorial",
     collection: @catalog.video_tutorials

--- a/app/views/products/shows/_show.html.erb
+++ b/app/views/products/shows/_show.html.erb
@@ -1,4 +1,4 @@
-<figure class="card weekly-iteration">
+<figure class="weekly-iteration tile">
   <%= link_to show, title: show.name do %>
     <h5><%= show.name %></h5>
     <%= image_tag(show.product_image.url) %>

--- a/app/views/products/video_tutorials/_video_tutorial.html.erb
+++ b/app/views/products/video_tutorials/_video_tutorial.html.erb
@@ -1,11 +1,7 @@
 <%= content_tag :figure, class: video_tutorial_card_classes(video_tutorial) do %>
   <%= link_to video_tutorial, title: video_tutorial.name, 'data-role' => 'video_tutorial' do %>
-    <h5>Video Tutorial</h5>
-    <div class="illustration">
-      <%= image_tag(video_tutorial.product_image.url) %>
-    </div>
-    <h6 class="status"><%= video_tutorial_card_status(video_tutorial) %></h6>
-    <h4><%= video_tutorial.name %></h4>
-    <p><%= video_tutorial.tagline %></p>
+    <h2>Video Tutorial</h2>
+    <h1><%= video_tutorial.name %></h1>
+    <p class="description"><%= video_tutorial.tagline %></p>
   <% end %>
 <% end %>

--- a/app/views/products/videos/_video.html.erb
+++ b/app/views/products/videos/_video.html.erb
@@ -1,10 +1,7 @@
-<figure class="card weekly-iteration">
+<figure class="tile weekly-iteration">
   <%= link_to video, title: video.title do %>
-    <h5>Weekly Iteration</h5>
-    <div class="illustration">
-      <%= medium_wistia_thumbnail_for(video.clip, video.title) %>
-    </div>
-    <h4><%= video.title %></h4>
-    <p><%= truncate_html video.notes_html %></p>
+    <h2>Weekly Iteration</h2>
+    <h1><%= video.title %></h1>
+    <p class="description"><%= truncate_html video.notes_html %></p>
   <% end %>
 </figure>

--- a/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
+++ b/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
@@ -1,4 +1,4 @@
-<figure class="video_tutorial card">
+<figure class="video_tutorial tile">
   <%= link_to video_tutorial, title: "The #{video_tutorial.name} online video tutorial details" do %>
     <h5>Video Tutorial</h5>
     <%= image_tag(video_tutorial.product_image.url) %>

--- a/app/views/resources/_topic.html.erb
+++ b/app/views/resources/_topic.html.erb
@@ -1,5 +1,5 @@
-<section class="resources-container">
-  <% if topic.trails.present? %>
+<section class="resources-container tiles-container">
+  <% if topic.published_trails.present? %>
     <span class="divider">
       <h4 class="text">All Trails</h4>
     </span>

--- a/spec/features/subscriber_explores_content_spec.rb
+++ b/spec/features/subscriber_explores_content_spec.rb
@@ -8,7 +8,7 @@ feature "Subscriber accesses content" do
   end
 
   scenario "begins a video_tutorial" do
-    video_tutorial = create(:video_tutorial)
+    create(:video_tutorial)
     sign_in_as_user_with_subscription
     visit explore_path
     click_video_tutorial_detail_link
@@ -17,8 +17,6 @@ feature "Subscriber accesses content" do
 
     expect(page).to have_content I18n.t("licenses.flashes.success")
     expect(page).not_to have_content("Receipt")
-
-    expect_products_to_show_video_tutorial_active(video_tutorial)
   end
 
   scenario "subscriber without access to video_tutorials attempts to begin a video_tutorial" do
@@ -42,7 +40,7 @@ feature "Subscriber accesses content" do
     click_link I18n.t("video_tutorial.checkout_cta")
 
     visit products_path
-    expect(page).to have_css(".card.in-progress", text: video_tutorial.name)
+    expect(page).to have_css(".tile.in-progress", text: video_tutorial.name)
   end
 
   scenario "show complete status for past video_tutorial" do
@@ -53,7 +51,7 @@ feature "Subscriber accesses content" do
     end
 
     visit products_path
-    expect(page).to have_css(".card.complete", text: video_tutorial.name)
+    expect(page).to have_css(".tile.complete", text: video_tutorial.name)
   end
 
   scenario "gets added to the GitHub team for a repository" do
@@ -83,14 +81,6 @@ feature "Subscriber accesses content" do
 
   def click_video_tutorial_detail_link
     find(".video-tutorial a:first").click
-  end
-
-  def expect_products_to_show_video_tutorial_active(video_tutorial)
-    visit products_path
-    expect(page).to have_css(
-      ".card a[title='#{video_tutorial.name}'] .status",
-      text: "in-progress"
-    )
   end
 
   def have_added_current_user_to_team_for(product)

--- a/spec/views/resources/_topic.html.erb_spec.rb
+++ b/spec/views/resources/_topic.html.erb_spec.rb
@@ -2,19 +2,46 @@ require "rails_helper"
 
 describe "resources/_topic" do
   it "shows videos and video tutorials" do
-    view_stubs(:current_user)
-
-    render partial: "resources/topic", locals: { topic: topic_with_resources }
+    render_topic
 
     expect(rendered).to include("The Weekly Iteration")
     expect(rendered).to include("Video Tutorials")
   end
 
-  def topic_with_resources
+  context "with published trails" do
+    it "renders the published trails header" do
+      render_topic published_trails: [build_stubbed(:trail)]
+
+      expect(rendered).to have_trails_header
+    end
+  end
+
+  context "with only unpublished trails" do
+    it "doesn't render the published trails header" do
+      render_topic published_trails: []
+
+      expect(rendered).not_to have_trails_header
+    end
+  end
+
+  def render_topic(**topic_attributes)
+    topic = topic_with_resources(**topic_attributes)
+    view_stubs(:current_user)
+    stub_template("practice/_trail.html.erb" => "")
+    render partial: "resources/topic", locals: { topic: topic }
+  end
+
+  def topic_with_resources(published_trails: [])
     build_stubbed(
       :topic,
       videos: [build_stubbed(:video, slug: "a-video")],
       video_tutorials: [build_stubbed(:video_tutorial)]
-    )
+    ).tap do |topic|
+      topic.stubs(:published_trails).returns(published_trails)
+    end
+  end
+
+  def have_trails_header
+    have_text("All Trails")
   end
 end


### PR DESCRIPTION
![upcase-tiles](https://cloud.githubusercontent.com/assets/2343392/5509148/103d9360-8783-11e4-837d-5f941278b064.png)

![screen shot 2014-12-19 at 1 25 41 pm](https://cloud.githubusercontent.com/assets/2343392/5509130/cecba05c-8782-11e4-8626-503bb7e3ea45.png)

We introduced a tile style for videos on /explore, and this PR aims to extend that style to the video cards on topic pages.
I was able to style Weekly Iteration cards, but need help removing the "card" class from video tutorials. 
In products/video_tutorials/_video_tutorial.html.erb, a class of "card" is assigned, but we don't want that to happen.
We want both Weekly Iteration and Video Tutorial videos to have a .tile class.
These seems to have separate markup, but we want them to be the same.

Help!
