### PR TITLE
Link to contact us in footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,29 +2,34 @@
 <div class="footer-content">
     <ul class="sign-out">
       <% if signed_in? %>
-        <li><%= link_to('Sign out', sign_out_path, method: :delete) %></li>
-        <li><%= render partial: 'shared/admin_sign_out' %></li>
+        <li><%= link_to("Sign out", sign_out_path, method: :delete) %></li>
+        <li><%= render partial: "shared/admin_sign_out" %></li>
       <% else %>
-        <li><%= link_to 'Sign in', sign_in_path %></li>
+        <li><%= link_to "Sign in", sign_in_path %></li>
       <% end %>
     </ul>
     <section class="thoughtbot">
       <ul>
-        <li>
-          <%= link_to 'Upcase source code on GitHub', repositories_path %>
-        </li>
+        <% if signed_in? %>
+          <li>
+            <%= link_to "Upcase source code on GitHub", repositories_path %>
+          </li>
+        <% else %>
+          <li>
+            <%= mail_to ENV["SUPPORT_EMAIL"], "Contact us" %>
+          </li>
+        <% end %>
         <li><a href="http://thoughtbot.com">About thoughtbot</a></li>
-        <li><a href="http://apprentice.io">Apprentice.io</a></li>
-        <li><a href="http://thoughtbot.com/podcast">Podcast</a></li>
-        <li><%= link_to 'Blog', 'http://robots.thoughtbot.com' %></li>
-        <li><%= link_to 'Privacy Policy', privacy_path %></li>
-        <li><%= link_to 'Terms & Conditions', terms_path %></li>
+        <li><a href="http://thoughtbot.com/podcast">Podcasts</a></li>
+        <li><%= link_to "Blog", "http://robots.thoughtbot.com" %></li>
+        <li><%= link_to "Privacy Policy", privacy_path %></li>
+        <li><%= link_to "Terms & Conditions", terms_path %></li>
       </ul>
     </section>
   </div>
   <section class="copyright">
     <div>
-      <a href="http://www.thoughtbot.com"><%= image_tag('ralph.svg') %></a>
+      <a href="http://www.thoughtbot.com"><%= image_tag("ralph.svg") %></a>
       <p>© 2012 - <%= Time.zone.today.year %> thoughtbot, inc. The <em>design of a robot</em> and <em>thoughtbot</em> are registered trademarks of thoughtbot,&nbsp;inc.</p>
     </div>
   </section>

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "shared/_footer.html.erb" do
+  context "when not signed in" do
+    it "does not show the repositories link" do
+      view_stubs(signed_in?: false)
+
+      render
+
+      expect(rendered).not_to have_content("Upcase source code")
+    end
+
+    it "does show the contact us link" do
+      view_stubs(signed_in?: false)
+
+      render
+
+      expect(rendered).to have_content("Contact us")
+    end
+
+    it "does show a sign in link" do
+      view_stubs(signed_in?: false)
+
+      render
+
+      expect(rendered).to have_content("Sign in")
+      expect(rendered).not_to have_content("Sign out")
+    end
+  end
+
+  context "when user is signed in" do
+    it "does show the repositories link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user: create(:user))
+
+      render
+
+      expect(rendered).to have_content("Upcase source code")
+    end
+
+    it "does not show the contact us link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user: create(:user))
+
+      render
+
+      expect(rendered).not_to have_content("Contact us")
+    end
+
+    it "does show a sign out link" do
+      view_stubs(signed_in?: true)
+      view_stubs(current_user: create(:user))
+
+      render
+
+      expect(rendered).to have_content("Sign out")
+      expect(rendered).not_to have_content("Sign in")
+    end
+  end
+end


### PR DESCRIPTION
The link is not shown to signed in users, because they can use Intercom.

Also includes some other minor footer cleanups:
- Pluralize "podcast"
- Only show link to repositories for sign in users

https://trello.com/c/lLcKGRcS/500-review-video-tutorial-marketing-copy-and-checkout-process-for-copy-that-no-longer-makes-sense
