### PR TITLE
Correct Wistia videos aspect ratio

### DIFF
--- a/app/helpers/wistia_helper.rb
+++ b/app/helpers/wistia_helper.rb
@@ -7,7 +7,7 @@ module WistiaHelper
       data: {
         wistia_id: clip.wistia_id,
         width: "653",
-        height: "367"
+        height: "391"
       }
     )
   end


### PR DESCRIPTION
Real size in Wistia.com for Vim for Rails developers: 738 / 443 = 1.67

Size was 653 / 367 = 1.78.  New aspect ratio: 1.67.

https://trello.com/c/yfZPhd3x/518-preview-videos-sized-incorrectly
