### PR TITLE
Add topic border color to video tiles

### DIFF
--- a/app/assets/stylesheets/topics.scss.erb
+++ b/app/assets/stylesheets/topics.scss.erb
@@ -17,6 +17,10 @@
     border-top-color: <%= topic.color %>;
   }
 
+  .tiles-container .tile.<%= topic.slug.parameterize %> {
+    border-top-color: <%= topic.color %>;
+  }
+
   .trail-titles li.<%= topic.slug.parameterize %> {
     border-color: <%= topic.color %>;
   }

--- a/app/helpers/video_tutorials_helper.rb
+++ b/app/helpers/video_tutorials_helper.rb
@@ -9,16 +9,4 @@ module VideoTutorialsHelper
     json = "#{callback}(#{json})" if callback
     json.html_safe
   end
-
-  def video_tutorial_card_classes(video_tutorial)
-    classes = %w(video_tutorial tile)
-    classes << video_tutorial_card_status(video_tutorial)
-    classes.join(" ")
-  end
-
-  def video_tutorial_card_status(video_tutorial)
-    if video_tutorial.license_for(current_user) && signed_in?
-      video_tutorial.license_for(current_user).status
-    end
-  end
 end

--- a/app/views/products/shows/_show.html.erb
+++ b/app/views/products/shows/_show.html.erb
@@ -1,4 +1,4 @@
-<figure class="weekly-iteration tile">
+<figure class="weekly-iteration tile <%= topic_slugs(show) %>">
   <%= link_to show, title: show.name do %>
     <h5><%= show.name %></h5>
     <%= image_tag(show.product_image.url) %>

--- a/app/views/products/video_tutorials/_video_tutorial.html.erb
+++ b/app/views/products/video_tutorials/_video_tutorial.html.erb
@@ -1,7 +1,7 @@
-<%= content_tag :figure, class: video_tutorial_card_classes(video_tutorial) do %>
+<figure class="video_tutorial tile <%= topic_slugs(video_tutorial) %>">
   <%= link_to video_tutorial, title: video_tutorial.name, 'data-role' => 'video_tutorial' do %>
     <h2>Video Tutorial</h2>
     <h1><%= video_tutorial.name %></h1>
     <p class="description"><%= video_tutorial.tagline %></p>
   <% end %>
-<% end %>
+</figure>

--- a/app/views/products/videos/_video.html.erb
+++ b/app/views/products/videos/_video.html.erb
@@ -1,4 +1,4 @@
-<figure class="tile weekly-iteration">
+<figure class="tile weekly-iteration <%= topic_slugs(video) %>">
   <%= link_to video, title: video.title do %>
     <h2>Weekly Iteration</h2>
     <h1><%= video.title %></h1>

--- a/spec/features/subscriber_explores_content_spec.rb
+++ b/spec/features/subscriber_explores_content_spec.rb
@@ -31,29 +31,6 @@ feature "Subscriber accesses content" do
     expect(current_path).to eq edit_subscription_path
   end
 
-  scenario "show in-progress status for current video_tutorial" do
-    video_tutorial = create(:video_tutorial, length_in_days: 2)
-
-    sign_in_as_user_with_subscription
-    visit explore_path
-    click_video_tutorial_detail_link
-    click_link I18n.t("video_tutorial.checkout_cta")
-
-    visit products_path
-    expect(page).to have_css(".tile.in-progress", text: video_tutorial.name)
-  end
-
-  scenario "show complete status for past video_tutorial" do
-    video_tutorial = create(:video_tutorial, length_in_days: 2)
-
-    Timecop.travel(3.days.ago) do
-      get_access_to_video_tutorial
-    end
-
-    visit products_path
-    expect(page).to have_css(".tile.complete", text: video_tutorial.name)
-  end
-
   scenario "gets added to the GitHub team for a repository" do
     repository = create(:repository)
     sign_in_as_user_with_subscription


### PR DESCRIPTION
https://trello.com/c/E8bg3rTI/540-add-topic-color-to-video-tiles

We want to add border colors to these:
![screen shot 2015-01-06 at 11 08 11 am](https://cloud.githubusercontent.com/assets/2343392/5631414/5d6249e6-9594-11e4-992c-ebcb2137a9d3.png)

I would expect this to work once a topic class is added to a tile. 

Can a dev help me finish this up?
