### PR TITLE
Add featured people avatars to video tutorials and weekly iteration videos

### DIFF
--- a/app/assets/stylesheets/_tile.scss
+++ b/app/assets/stylesheets/_tile.scss
@@ -49,6 +49,17 @@
       text-transform: uppercase;
     }
 
+    h3 {
+      color: $darkwarmgray;
+      font-size: em(16);
+      text-align: left;
+      margin: 1.2em 0;
+
+      .title {
+        font-weight: 400;
+      }
+    }
+
     h1, h2, p {
       text-align: left;
     }
@@ -68,5 +79,15 @@
 
   h1 {
     color: $darkwarmgray;
+  }
+}
+
+.tile .person {
+  float: left;
+  margin-right: 1em;
+
+  img {
+    @include size(50px);
+    border-radius: 50%;
   }
 }

--- a/app/helpers/teacher_helper.rb
+++ b/app/helpers/teacher_helper.rb
@@ -1,4 +1,8 @@
 module TeacherHelper
+  def teacher_names(teachers)
+    teachers.map(&:name).to_sentence
+  end
+
   def teacher_label
     Proc.new do |teacher|
       teacher_gravatar(teacher)+h(teacher.name)

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,6 +1,6 @@
 class Teacher < ActiveRecord::Base
   belongs_to :user
-  belongs_to :video_tutorial
+  belongs_to :video
 
   delegate :name, :email, :bio, to: :user, allow_nil: true
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,6 +3,7 @@ class Video < ActiveRecord::Base
 
   belongs_to :watchable, polymorphic: true
   has_many :classifications, as: :classifiable
+  has_many :teachers
   has_many :topics, through: :classifications
   has_many :statuses, as: :completeable, dependent: :destroy
 

--- a/app/models/video_tutorial.rb
+++ b/app/models/video_tutorial.rb
@@ -1,10 +1,9 @@
 class VideoTutorial < Product
-  has_many :teachers, dependent: :destroy
-  has_many :users, through: :teachers
+  validates :description, :tagline, presence: true
 
-  # Validations
-  validates :description, presence: true
-  validates :tagline, presence: true
+  def teachers
+    Teacher.joins(:video).merge(videos)
+  end
 
   def collection?
     published_videos.count > 1

--- a/app/views/products/shows/_show.html.erb
+++ b/app/views/products/shows/_show.html.erb
@@ -1,7 +1,6 @@
 <figure class="weekly-iteration tile <%= topic_slugs(show) %>">
   <%= link_to show, title: show.name do %>
     <h5><%= show.name %></h5>
-    <%= image_tag(show.product_image.url) %>
     <h4><%= pluralize show.published_videos.count, 'episode' %></h4>
     <p><%= show.tagline %></p>
   <% end %>

--- a/app/views/products/video_tutorials/_video_tutorial.html.erb
+++ b/app/views/products/video_tutorials/_video_tutorial.html.erb
@@ -1,7 +1,11 @@
 <figure class="video_tutorial tile <%= topic_slugs(video_tutorial) %>">
   <%= link_to video_tutorial, title: video_tutorial.name, 'data-role' => 'video_tutorial' do %>
+    <% video_tutorial.teachers.each do |teacher| %>
+      <div class="person"><%= teacher_gravatar teacher, 92 %></div>
+    <% end %>
     <h2>Video Tutorial</h2>
     <h1><%= video_tutorial.name %></h1>
+    <h3><%= teacher_names(video_tutorial.teachers) %></h3>
     <p class="description"><%= video_tutorial.tagline %></p>
   <% end %>
 </figure>

--- a/app/views/products/videos/_video.html.erb
+++ b/app/views/products/videos/_video.html.erb
@@ -1,7 +1,11 @@
 <figure class="tile weekly-iteration <%= topic_slugs(video) %>">
   <%= link_to video, title: video.title do %>
+    <% video.teachers.each do |teacher| %>
+      <div class="person"><%= teacher_gravatar teacher, 92 %></div>
+    <% end %>
     <h2>Weekly Iteration</h2>
     <h1><%= video.title %></h1>
+    <h3><%= teacher_names(video.teachers) %></h3>
     <p class="description"><%= truncate_html video.notes_html %></p>
   <% end %>
 </figure>

--- a/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
+++ b/app/views/promoted_catalogs/_promoted_video_tutorial.html.erb
@@ -1,7 +1,6 @@
 <figure class="video_tutorial tile">
   <%= link_to video_tutorial, title: "The #{video_tutorial.name} online video tutorial details" do %>
     <h5>Video Tutorial</h5>
-    <%= image_tag(video_tutorial.product_image.url) %>
     <h4><%= video_tutorial.name %></h4>
     <p><%= video_tutorial.tagline %></p>
   <% end %>

--- a/db/migrate/20150108200739_teachers_tied_to_videos_not_video_tutorials.rb
+++ b/db/migrate/20150108200739_teachers_tied_to_videos_not_video_tutorials.rb
@@ -1,0 +1,57 @@
+class TeachersTiedToVideosNotVideoTutorials < ActiveRecord::Migration
+  # Thom informs: joe has been on every episode of WI except #3
+  # (improving-your-workflow-with-chris-toomey) and #35 (landing-a-rails-job)
+  # Ben has been present until episode 47, Rubyisms in Swift
+  BEN_USER_ID = 95
+  RUBYISMS_IN_SWIFT_ID = 179
+
+  JOE_USER_ID = 524
+  IMPROVING_YOUR_WORKFLOW_ID = 86
+  LANDING_A_RAILS_JOB_ID = 167
+
+  def change
+    convert_teachers_video_tutorial_ids_video_ids
+
+    add_ben_to_his_twi_videos
+    add_joe_to_his_twi_videos
+
+    rename_column :teachers, :video_tutorial_id, :video_id
+  end
+
+  private
+
+  def add_ben_to_his_twi_videos
+    connection.insert(<<-SQL)
+      INSERT INTO teachers (user_id, video_tutorial_id)
+        (SELECT #{BEN_USER_ID}, videos.id FROM videos
+          WHERE watchable_id = 23 AND id < #{RUBYISMS_IN_SWIFT_ID})
+    SQL
+  end
+
+  def add_joe_to_his_twi_videos
+    connection.insert(<<-SQL)
+      INSERT INTO teachers (user_id, video_tutorial_id)
+        (SELECT #{JOE_USER_ID}, videos.id FROM videos
+          WHERE watchable_id = 23
+            AND id != #{IMPROVING_YOUR_WORKFLOW_ID}
+            AND id != #{LANDING_A_RAILS_JOB_ID })
+    SQL
+  end
+
+  def convert_teachers_video_tutorial_ids_video_ids
+    connection.insert(<<-SQL)
+      WITH user_id_video_id AS (
+        SELECT
+          teachers.user_id AS user_id,
+          videos.watchable_id AS video_tutorial_id,
+          videos.id AS video_id
+        FROM teachers
+          LEFT JOIN products ON teachers.video_tutorial_id = products.id
+          LEFT JOIN videos ON products.id = videos.watchable_id
+      )
+      -- This is not cleaning up old video_tutorial_id references
+      INSERT INTO teachers (user_id, video_tutorial_id)
+        (SELECT user_id, video_id FROM user_id_video_id)
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -281,10 +281,10 @@ ActiveRecord::Schema.define(version: 20150108220013) do
 
   create_table "teachers", force: true do |t|
     t.integer "user_id"
-    t.integer "video_tutorial_id"
+    t.integer "video_id"
   end
 
-  add_index "teachers", ["user_id", "video_tutorial_id"], name: "index_teachers_on_user_id_and_video_tutorial_id", unique: true, using: :btree
+  add_index "teachers", ["user_id", "video_id"], name: "index_teachers_on_user_id_and_video_id", unique: true, using: :btree
 
   create_table "teams", force: true do |t|
     t.string   "name",            null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -183,7 +183,7 @@ FactoryGirl.define do
 
   factory :teacher do
     user
-    video_tutorial
+    video
   end
 
   factory :topic do

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Teacher do
   it { should belong_to(:user) }
-  it { should belong_to(:video_tutorial) }
+  it { should belong_to(:video) }
 
   [:name, :email, :bio].each do |attribute|
     describe "##{attribute}" do

--- a/spec/models/video_tutorial_spec.rb
+++ b/spec/models/video_tutorial_spec.rb
@@ -1,11 +1,6 @@
 require "rails_helper"
 
 describe VideoTutorial do
-  # Associations
-  it { should have_many(:teachers).dependent(:destroy) }
-  it { should have_many(:users).through(:teachers) }
-
-  # Validations
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:tagline) }
@@ -18,13 +13,13 @@ describe VideoTutorial do
     end
   end
 
-  describe 'title' do
-    it 'describes the video_tutorial name' do
-      video_tutorial = build_stubbed(:video_tutorial, name: 'Billy')
+  describe "title" do
+    it "describes the video_tutorial name" do
+      video_tutorial = build_stubbed(:video_tutorial, name: "Billy")
 
       result = video_tutorial.title
 
-      expect(result).to eq 'Billy: a video tutorial by thoughtbot'
+      expect(result).to eq "Billy: a video tutorial by thoughtbot"
     end
   end
 
@@ -32,13 +27,13 @@ describe VideoTutorial do
     it { should delegate(:meta_keywords).to(:topics) }
   end
 
-  describe 'offering_type' do
-    it 'returns video_tutorial' do
+  describe "offering_type" do
+    it "returns video_tutorial" do
       video_tutorial = VideoTutorial.new
 
       result = video_tutorial.offering_type
 
-      expect(result).to eq 'video_tutorial'
+      expect(result).to eq "video_tutorial"
     end
   end
 
@@ -56,21 +51,21 @@ describe VideoTutorial do
     end
   end
 
-  describe '#subscription?' do
-    it 'returns false' do
+  describe "#subscription?" do
+    it "returns false" do
       expect(VideoTutorial.new).not_to be_subscription
     end
   end
 
-  describe '#collection?' do
-    it 'is a collection if there is more than one published video' do
+  describe "#collection?" do
+    it "is a collection if there is more than one published video" do
       video_tutorial = create(:video_tutorial)
       create_list(:video, 2, :published, watchable: video_tutorial)
 
       expect(video_tutorial).to be_collection
     end
 
-    it 'is not a collection if there is 1 published video or less' do
+    it "is not a collection if there is 1 published video or less" do
       video_tutorial = create(:video_tutorial)
 
       expect(video_tutorial).not_to be_collection
@@ -82,9 +77,32 @@ describe VideoTutorial do
     end
   end
 
-  describe '#to_aside_partial' do
-    it 'returns the path to the aside partial' do
-      expect(VideoTutorial.new.to_aside_partial).to eq 'video_tutorials/aside'
+  describe "#teachers" do
+    it "returns teachers from it's videos" do
+      repeated = Teacher.create(user: create(:user))
+      teacher_1 = Teacher.create(user: create(:user))
+      teacher_2 = Teacher.create(user: create(:user))
+      video_tutorial = create(:video_tutorial)
+      create(
+        :video,
+        watchable: video_tutorial,
+        teachers: [repeated, teacher_1]
+      )
+      create(
+        :video,
+        watchable: video_tutorial,
+        teachers: [repeated, teacher_2]
+      )
+
+      result = video_tutorial.teachers.all
+
+      expect(result).to match_array([repeated, teacher_1, teacher_2])
+    end
+  end
+
+  describe "#to_aside_partial" do
+    it "returns the path to the aside partial" do
+      expect(VideoTutorial.new.to_aside_partial).to eq "video_tutorials/aside"
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/r2IYfIs2/541-add-instructor-featured-people-images-to-video-tutorials-and-weekly-iteration-videos

I've included static html in this PR, with Ralph as placeholder.
![screen shot 2015-01-06 at 11 47 20 am](https://cloud.githubusercontent.com/assets/2343392/5632178/bb5a0f6a-959a-11e4-8d8b-f28a3cff2e4d.png)

For development: We don't currently have the avatars for the instructors/participants in each video, so we need to get those from somewhere.

Also, in the first commit here the two deletions are thumbnail images from two other views (promoted catalogs, weekly iteration) because we have decided not to show these. Make sense?
