### PR TITLE
Send email along with cancellation events

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -9,7 +9,7 @@ class Analytics
   end
 
   def track_cancelled(reason)
-    track(event: "Cancelled", properties: { reason: reason })
+    track(event: "Cancelled", properties: { reason: reason, email: user.email })
   end
 
   def track_updated

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -11,7 +11,7 @@ describe Analytics do
       expect(analytics).to(
         have_tracked("Cancelled").
         for_user(user).
-        with_properties(reason: "reason")
+        with_properties(reason: "reason", email: user.email)
       )
     end
   end


### PR DESCRIPTION
Unfortunately, Segment doesn't send additional identify information via 
webhooks, it just sends the raw information.

The Zapier Intercom integration only can create a message on users by email.

Therefore, we need to send the email along with this so Zapier can use it.

We may want to do something else in the future, but I think this is the best 
solution for now.

https://trello.com/c/FIRl7bI2/539-collect-feedback-upon-cancelation
