### PR TITLE
Only show published videos

### DIFF
--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -9,11 +9,7 @@ class Show < Product
     plan.has_feature?(:shows)
   end
 
-  def latest_videos(take = Explore::LIMIT)
-    videos.recently_published_first.limit(take)
-  end
-
   def latest_video
-    latest_videos(1).first
+    videos.published.recently_published_first.first
   end
 end

--- a/app/views/explore/_latest_show_video.html.erb
+++ b/app/views/explore/_latest_show_video.html.erb
@@ -1,0 +1,6 @@
+<li class="tile show <%= topic_slugs(video) %>">
+  <h2><%= show.name %></h2>
+  <h1><%= link_to video.title, video %></h1>
+  <p class="description"><%= show.tagline %></p>
+  <%= link_to "View All Episodes", show, class: "cta" %>
+</li>

--- a/app/views/explore/_videos.html.erb
+++ b/app/views/explore/_videos.html.erb
@@ -4,17 +4,18 @@
   </span>
 
   <ul>
-    <li class="tile show <%= topic_slugs(show_latest_video) %>">
-      <h2><%= show.name %></h2>
-      <h1><%= link_to show_latest_video.title, show_latest_video %></h1>
-      <p class="description"><%= show.tagline %></p>
-      <%= link_to "View All Episodes", show, class: "cta" %>
-    </li>
+    <% if show.latest_video.present? %>
+      <%= render(
+        "explore/latest_show_video",
+        show: show,
+        video: show.latest_video
+      ) %>
+    <% end %>
 
-    <li class="tile video-tutorial <%= topic_slugs(latest_video_tutorial) %>">
+    <li class="tile video-tutorial <%= topic_slugs(video_tutorial) %>">
       <h2>Video Tutorial</h2>
-      <h1><%= link_to latest_video_tutorial.name, latest_video_tutorial %></h1>
-      <p class="description"><%= latest_video_tutorial.tagline %></p>
+      <h1><%= link_to video_tutorial.name, video_tutorial %></h1>
+      <p class="description"><%= video_tutorial.tagline %></p>
       <%= link_to "View All Videos", products_path, class: "cta" %>
     </li>
   </ul>

--- a/app/views/explore/show.html.erb
+++ b/app/views/explore/show.html.erb
@@ -28,9 +28,10 @@
       </ul>
     </section>
 
-    <%= render "videos",
+    <%= render(
+      "videos",
       show: @explore.show,
-      show_latest_video: @explore.show.latest_video,
-      latest_video_tutorial: @explore.latest_video_tutorial %>
+      video_tutorial: @explore.latest_video_tutorial
+    ) %>
   </div>
 </section>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,10 @@ FactoryGirl.define do
     "github_#{n}"
   end
 
+  sequence :tagline do |n|
+    "tagline #{n}"
+  end
+
   sequence :title do |n|
     "title #{n}"
   end
@@ -72,7 +76,7 @@ FactoryGirl.define do
   factory :product, traits: [:active], class: "VideoTutorial" do
     after(:stub) { |product| product.slug = product.name.parameterize }
     description 'Solve 8-Queens over and over again'
-    tagline 'Solve 8-Queens'
+    tagline
 
     trait :active do
       active true
@@ -404,6 +408,8 @@ FactoryGirl.define do
     trait :with_preview do
       preview_wistia_id '1194804'
     end
+
+    after(:stub) { |video| video.slug = video.id.to_s }
   end
 
   factory :exercise do

--- a/spec/features/subscriber_explores_weekly_iteration_spec.rb
+++ b/spec/features/subscriber_explores_weekly_iteration_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User without a subscription" do
   scenario "Sees latest TWI and Video Tutorial in Explore" do
     show = create(:show, name: Show::THE_WEEKLY_ITERATION)
-    twi_video = create(:video, watchable: show)
+    twi_video = create(:video, :published, watchable: show)
     video_tutorial = create(:video_tutorial)
 
     visit explore_path(as: create(:user))

--- a/spec/models/show_spec.rb
+++ b/spec/models/show_spec.rb
@@ -14,16 +14,24 @@ describe Show do
   end
 
   describe "#latest_video" do
-    it "returns it's latest video" do
+    it "returns its latest, published video" do
       show = create(:show)
-      latest = Timecop.travel(1.days.ago) do
-        create(:video, watchable: show)
-      end
-      Timecop.travel(2.days.ago) do
-        create(:video, watchable: show)
-      end
+      other_show = create(:show)
+      create_video "older_published", show: show, published_on: 2.days.ago
+      create_video "latest_published", show: show, published_on: 1.day.ago
+      create_video "unpublished", show: show, published_on: 1.day.from_now
+      create_video "other_show", show: other_show, published_on: Time.now
 
-      expect(show.latest_video).to eq(latest)
+      expect(show.latest_video.title).to eq("latest_published")
+    end
+
+    def create_video(title, show:, published_on:)
+      create(
+        :video,
+        title: title,
+        watchable: show,
+        published_on: published_on
+      )
     end
   end
 end

--- a/spec/views/explore/_videos.html.erb_spec.rb
+++ b/spec/views/explore/_videos.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "explore/_videos.html" do
+  context "with a published episode" do
+    it "renders the video" do
+      latest_video = build_stubbed(:video)
+      show = build_stubbed(:show)
+      show.stubs(:latest_video).returns(latest_video)
+      video_tutorial = build_stubbed(:video_tutorial)
+
+      render "explore/videos", show: show, video_tutorial: video_tutorial
+
+      expect(rendered).to have_text(show.tagline)
+      expect(rendered).to have_text(latest_video.title)
+    end
+  end
+
+  context "with no published episodes" do
+    it "skips the video" do
+      show = build_stubbed(:show)
+      show.stubs(:latest_video).returns(nil)
+      video_tutorial = build_stubbed(:video_tutorial)
+
+      render "explore/videos", show: show, video_tutorial: video_tutorial
+
+      expect(rendered).not_to have_text(show.tagline)
+    end
+  end
+end


### PR DESCRIPTION
The /explore page was displaying videos which weren't set to published yet.

After this change, only published videos were displayed.

This change caused some unchanged tests to fail, revealing potential 
weaknesses in both the view and tests. These were improved to handle the 
situation where we don't have a video to display.

https://trello.com/c/WsHicbPz/558
