### PR TITLE
Fix Wistia embed for previews

### DIFF
--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -1,25 +1,11 @@
-.videowrapper, .mapwrapper {
-  height: 0;
-  margin: 0 0 2em 0;
-  overflow: hidden;
-  position: relative;
-}
-
-.wistia-holder {
-  width: auto;
-  background-color: #333;
-  border: 1px solid #111;
-  margin: 0 auto;
-  padding: 40px 0 40px 0;
-  text-align: center;
-  position: absolute;
-  left: 0;
-  right: 0;
-
-  .wistia_embed {
-    margin: 0 auto;
-    max-height: 392px;
-  }
+/*
+ * Wistia requires a parent element that does NOT calculate its with based on
+ * the width of its children.
+ *
+ * http://wistia.com/doc/video-foam
+ */
+.wistia-wrapper {
+  width: 100%;
 }
 
 .assets-wrapper {

--- a/app/helpers/wistia_helper.rb
+++ b/app/helpers/wistia_helper.rb
@@ -3,7 +3,7 @@ module WistiaHelper
     content_tag(
       'p',
       nil,
-      class: "videowrapper wistia-video",
+      class: "wistia-video",
       data: {
         wistia_id: clip.wistia_id,
         width: "653",

--- a/app/views/clips/_clip.html.erb
+++ b/app/views/clips/_clip.html.erb
@@ -1,4 +1,6 @@
-<%= large_wistia_iframe_for(clip) %>
+<div class="wistia-wrapper">
+  <%= large_wistia_iframe_for(clip) %>
+</div>
 <section class="assets-wrapper">
   <div class="assets">
     <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
@@ -6,3 +8,7 @@
     <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
   </div>
 </section>
+
+<% content_for :javascript do %>
+  <script src="//fast.wistia.com/assets/external/E-v1.js"></script>
+<% end %>

--- a/app/views/shows/show.html.erb
+++ b/app/views/shows/show.html.erb
@@ -7,9 +7,7 @@
 <div class="text-box-wrapper">
   <%= render "watchables/preview" %>
   <div class="text-box">
-    <p class="videowrapper">
-      <iframe src="//fast.wistia.net/embed/iframe/ol6e0miehm?controlsVisibleOnLoad=true&version=v1&videoHeight=415&videoWidth=738&volumeControl=true" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" width="653" height="367"></iframe>
-    </p>
+    <%= render Clip.new("ol6e0miehm") %>
 
     <section id="videos">
       <% @show.published_videos.recently_published_first.each do |video| %>

--- a/app/views/videos/show_subscribed.html.erb
+++ b/app/views/videos/show_subscribed.html.erb
@@ -1,9 +1,5 @@
 <% content_for :page_title, @video.title.html_safe %>
 
-<% content_for :javascript do %>
-  <script src="//fast.wistia.com/assets/external/E-v1.js"></script>
-<% end %>
-
 <% if @watchable.collection? %>
   <% content_for :additional_header_links do %>
     <li class="all-videos"><%= link_to 'All Videos', @video.watchable %></li>

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe "videos/show" do
     render template: "videos/show"
 
     expect(rendered).
-      to have_css("p.videowrapper[data-wistia-id='#{wistia_id}']")
+      to have_css("p[data-wistia-id='#{wistia_id}']")
   end
 
   it "shows a thumbnail when there is no preview" do


### PR DESCRIPTION
These previews were broken with the tracking introduced in 92a8c329.

The following errors were introduced:
- The Wistia JavaScript was only included on one page
- The Wistia responsive design was fighting our CSS

The commit:
- Introduces the Wistia JavaScript on all pages with embeds
- Removes our CSS hacks to depend on Wistia's "video foam"

https://trello.com/c/cz3T9R6u/559
