### PR TITLE
Fix user JSON

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::UsersController < ApiController
   before_action :doorkeeper_authorize!
 
   def show
-    respond_with user: resource_owner
+    respond_with UserSerializer.new(resource_owner)
   end
 end

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V1::StatusesController do
     end
 
     it "returns a 404 when exercise doesn't exist" do
-      stub_authenticated_user
+      stub_oauth_authenticated_user
 
       expect do
         post :create, exercise_uuid: "exercise-uuid"
@@ -17,7 +17,7 @@ describe Api::V1::StatusesController do
     end
 
     it "updates the status of the given exercise for the authenticated user" do
-      stub_authenticated_user
+      stub_oauth_authenticated_user
       exercise = stub_exercise
 
       post :create, exercise_uuid: exercise.uuid, state: Status::COMPLETE
@@ -32,13 +32,5 @@ describe Api::V1::StatusesController do
     exercise.stubs(:update_trails_state_for)
     Exercise.stubs(:find_by!).returns(exercise)
     exercise
-  end
-
-  def stub_authenticated_user
-    user = build_stubbed(:user)
-    User.stubs(:find).returns(user)
-    access_token = build_stubbed(:oauth_access_token, user: user)
-    Doorkeeper::OAuth::Token.stubs(:authenticate).returns(access_token)
-    user
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,8 +1,26 @@
 require "rails_helper"
 
-describe Api::V1::UsersController, "#show" do
-  it 'returns a 401 when users are not authenticated' do
-    get :show
-    expect(response.code).to eq "401"
+describe Api::V1::UsersController do
+  describe "#show" do
+    context "authenticated" do
+      it "serializes the user" do
+        user = stub_oauth_authenticated_user
+        expected_json = { "expected" => "result" }
+        serializer = stub("serializer", as_json: expected_json)
+        UserSerializer.stubs(:new).with(user).returns(serializer)
+
+        get :show, format: :json
+
+        expect(controller).to respond_with(:success)
+        expect(JSON.parse(response.body)).to eq(expected_json)
+      end
+    end
+
+    context "unauthenticated" do
+      it "returns a 401" do
+        get :show
+        expect(response.code).to eq "401"
+      end
+    end
   end
 end

--- a/spec/support/oauth_support.rb
+++ b/spec/support/oauth_support.rb
@@ -1,0 +1,13 @@
+module OAuthSupport
+  def stub_oauth_authenticated_user
+    build_stubbed(:user).tap do |user|
+      User.stubs(:find).returns(user)
+      access_token = build_stubbed(:oauth_access_token, user: user)
+      Doorkeeper::OAuth::Token.stubs(:authenticate).returns(access_token)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include OAuthSupport, type: :controller
+end


### PR DESCRIPTION
Because:
- We use ActiveModel::Serializer to render User JSON
- Rails 4.2 broke ActiveModel::Serializer

This commit:
- Explicitly uses ActiveModel::Serializer in the controller
- Adds test coverage to prevent this regression

https://trello.com/c/WjCX3djk/577
