### PR TITLE
Update teams design

### DIFF
--- a/app/assets/stylesheets/_subscriptions-new.scss
+++ b/app/assets/stylesheets/_subscriptions-new.scss
@@ -7,28 +7,6 @@ $plan-max-width: 960px;
 $celestial-blue: #4A90E2;
 $yellow: #F3E86B;
 
-//body.subscriptions.subscriptions-new,
-body.teams.teams-index {
-  .signin {
-    color: $darkwarmgray;
-    font-family: $sans-serif;
-    padding: .75rem 1.25rem;
-    @include position(absolute, 0px 0px 0 0);
-    z-index: 3;
-
-    a {
-      color: $darkwarmgray;
-      font-family: $sans-serif;
-      text-transform:lowercase;
-    }
-  }
-
-  h1 img {
-    margin: 80px auto 0;
-    display: block;
-  }
-}
-
 .plans {
   background: $base-background-1;
   padding: 0 $plan-padding;

--- a/app/assets/stylesheets/_teams-index.scss
+++ b/app/assets/stylesheets/_teams-index.scss
@@ -1,85 +1,32 @@
-.teams-index {
-  .logo h2 {
-    margin-bottom: 2em;
-    margin-top: 1em;
-    text-align: center;
-  }
-
-  .plan-features .included-in {
-    display: none;
-  }
-
-  .quotee strong {
-    display: none;
-  }
-
-  .plan {
-    @include outer-container;
-    margin-bottom: 2em;
-
-    .price {
-      display: block;
-      margin-top: 2rem;
-      margin: 2rem auto;
-      width: 200px;
-
-      .amount, .info {
-        height: 3rem;
-      }
-
-      .amount {
-        @include span-columns(6);
-        font-size: 3rem;
-        padding-top: 0.2em;
-        text-align: right;
-        vertical-align: middle;
-      }
-
-      .info {
-        @include span-columns(6);
-        display: block;
-      }
-
-      .interval, .unit {
-        display: block;
-        text-align: left;
-        text-transform: uppercase;
-      }
-    }
-
-    .sign-up {
-      @extend %button;
-      @include shift(3);
-      @include span-columns(6);
-      display: block;
-      margin-bottom: 2rem;
-      margin-top: 2rem;
-      padding: 0.8rem 0;
-      text-align: center;
-    }
-  }
-}
-
-.benefits {
+.teams-index .benefits {
   $icon-bullet-size: 2em;
 
-  margin-left: 2em;
-  margin-right: 2em;
+  padding: 2em;
 
-  .benefit {
-    @include media($large-screen) {
+  ul {
+    @include outer-container;
+    max-width: 1440px;
+  }
+
+  li {
+    margin-top: 0;
+    margin-bottom: 2em;
+
+    @include marketing-fullsize {
       @include span-columns(4);
       @include omega(3n);
+      margin-bottom: 0;
+      padding: 0 1em;
     }
   }
 
   .benefit-icon {
     background: $upcase-blue;
     border-radius: 50%;
-    color: #fff;
+    color: white;
     float: left;
     height: $icon-bullet-size;
-    padding: $icon-bullet-size /4;
+    line-height: $icon-bullet-size;
     text-align: center;
     width: $icon-bullet-size;
   }
@@ -89,12 +36,9 @@
     padding-bottom: 2em;
   }
 
-  h2 {
-    border-bottom: 1px solid transparentize($base-font-color, .8);
-    display: inline-block;
-    font-size: $icon-bullet-size /1.5;
-    margin-bottom: $icon-bullet-size /6;
-    padding-top: 0;
-    line-height: $icon-bullet-size /1.4;
+  h3 {
+    font-size: 1.5em;
+    font-weight: 600;
+    margin: 0.125em 0 0.5em;
   }
 }

--- a/app/assets/stylesheets/landing/_hero.scss
+++ b/app/assets/stylesheets/landing/_hero.scss
@@ -5,6 +5,7 @@ $landing-hero: #313b41;
     linear-gradient(180deg, rgba($upcase-blue-1, 0.888), rgba($upcase-blue-2, 0.888)),
     url(upcase/laptop.jpg)
   );
+
   background-color: $landing-hero;
   background-position: center center;
   background-size: cover;
@@ -41,7 +42,7 @@ $landing-hero: #313b41;
 }
 
 .hero-cta {
-  padding: 2em;
+  padding: 4em 2em 2em;
   text-align: center;
 
   p {
@@ -54,7 +55,7 @@ $landing-hero: #313b41;
     color: white;
     font-size: 1.125em;
     font-weight: 600;
-    margin: 2em 0;
+    margin: 0 0 2em;
 
     strong {
       font-weight: 700;

--- a/app/assets/stylesheets/landing/_price.scss
+++ b/app/assets/stylesheets/landing/_price.scss
@@ -37,7 +37,7 @@ $price-width: em(864);
     letter-spacing: -0.08em;
     line-height: 1;
     margin: 0;
-    padding: 2rem 2rem 1rem 2rem;
+    padding: 2rem 0rem 1rem 2rem;
     position: relative;
 
     @include marketing-fullsize {
@@ -56,7 +56,7 @@ $price-width: em(864);
     sub {
       font-size: 0.75rem;
       font-weight: 700;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.05em;
       line-height: 1;
       opacity: 0.666;
       text-transform: uppercase;

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,7 +4,7 @@ class TeamsController < ApplicationController
   def index
     @catalog = Catalog.new
 
-    render layout: 'empty-body'
+    render layout: "landing_pages"
   end
 
   def edit

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -17,7 +17,13 @@
             <li class="view-plans">
               <%= link_to t("subscriptions.join_cta"), "#price" %>
             </li>
-            <li class="account"><%= link_to "Sign in", sign_in_path %></li>
+            <li class="account">
+              <% if signed_in? %>
+                <%= link_to 'Account', my_account_path %>
+              <% else %>
+                <%= link_to 'Sign In', sign_in_path %>
+              <% end %>
+            </li>
           </ul>
         </nav>
       </div>

--- a/app/views/subscriptions/testimonials/_alee.html.erb
+++ b/app/views/subscriptions/testimonials/_alee.html.erb
@@ -1,6 +1,6 @@
 <figure>
   <%= image_tag "upcase/testimonial_thumbs/anthony-lee.jpg", alt: "Anthony" %>
-  <p class="quotee">Anthony Lee<strong>Professional</strong> </p>
+  <p class="quotee">Anthony Lee<strong>Thrive Ministry</strong> </p>
 </figure>
 <blockquote>
   <p><strong>I am really loving Upcase.</strong> The most valuable part for me was how I was able to dissect "upcase" app and see how it was built. Having the access to the repo and seeing how codes were structured was such a priceless lesson.</p>

--- a/app/views/subscriptions/testimonials/_bdear.html.erb
+++ b/app/views/subscriptions/testimonials/_bdear.html.erb
@@ -1,6 +1,6 @@
 <figure>
   <%= image_tag "upcase/testimonial_thumbs/brian-dear.jpg", alt: "Ben" %>
-  <p class="quotee">Brian Dear<strong>Professional</strong> </p>
+  <p class="quotee">Brian Dear<strong>Consultant</strong> </p>
 </figure>
 <blockquote>
   <p>There are a lot of training solutions out there, but <strong>Upcase is led by thoughtbot, so I know the stuff we're learning is the absolute best of the best practices</strong>. When I'm teaching junior devs, there's often a lot of conflicting information out there on how to do something, so Upcase helps me establish "better" best practices.</p>

--- a/app/views/subscriptions/testimonials/_ckinoti.html.erb
+++ b/app/views/subscriptions/testimonials/_ckinoti.html.erb
@@ -1,6 +1,6 @@
 <figure>
   <%= image_tag "upcase/testimonial_thumbs/chris-kinoti.jpg", alt: "Chris" %>
-  <p class="quotee">Chris Kinoti<strong>Professional</strong> </p>
+  <p class="quotee">Chris Kinoti<strong>Babel Kenya</strong> </p>
 </figure>
 <blockquote>
   <p><strong>This is the best learning resource I have come across.</strong> I'm having lots of illuminating moments. Your videos at Upcase have solidified everything. Moving and learning faster than I could have imagined!</p>

--- a/app/views/teams/_benefits.html.erb
+++ b/app/views/teams/_benefits.html.erb
@@ -1,0 +1,43 @@
+<section class="benefits">
+  <h2>Develop more than code.</h2>
+  <ul>
+    <li>
+      <div class="benefit-icon">
+        <%= fa_icon "heart" %>
+      </div>
+      <div class="benefit-content">
+        <h3>Keep your team together</h3>
+        <p>Bored people quit. If your team members stop learning and improving,
+        it won't be long before they seek that satisfaction elsewhere. Upcase is
+        full of the real-world knowledge that developers crave.</p>
+      </div>
+    </li>
+    <li>
+      <div class="benefit-icon">
+        <%= fa_icon "life-saver" %>
+      </div>
+      <div class="benefit-content">
+        <h3>You know our code</h3>
+        <p><%= link_to "thoughtbot", "http://thoughtbot.com" %> has created some
+        of the most popular open source software in the Rails ecosystem,
+        including <%= link_to "FactoryGirl", "http://github.com/thoughtbot/factory_girl" %>,
+        <%= link_to "Paperclip", "http://github.com/thoughtbot/paperclip" %>,
+        and <%= link_to "Bourbon", "http://bourbon.io" %>. On Upcase, your team
+        will be able to work directly with the thoughtbot developers and
+        designers who make these tools.</p>
+      </div>
+    </li>
+    <li>
+      <div class="benefit-icon">
+        <%= fa_icon "map-marker" %>
+      </div>
+      <div class="benefit-content">
+        <h3>Hit your deadlines</h3>
+        <p>If simple features have been taking longer, you're probably battling
+        technical debt. We can teach your team how to escape. You'll appreciate
+        the predictable estimates, and your team will love working in a clean
+        codebase.</p>
+      </div>
+    </li>
+  </ul>
+</section>

--- a/app/views/teams/_hero.html.erb
+++ b/app/views/teams/_hero.html.erb
@@ -1,0 +1,8 @@
+<section class="hero">
+    <%= render "subscriptions/upcase.svg" %>
+    <h1>Someone’s getting boss of the year.</h1>
+  <div class="hero-cta">
+    <h5>Sign your team up for Upcase and save 10% per user.</h5>
+    <%= link_to t("subscriptions.join_cta"), "#price", class: "signup" %>
+  </div>
+</section>

--- a/app/views/teams/_plan.html.erb
+++ b/app/views/teams/_plan.html.erb
@@ -1,12 +1,25 @@
-<section class="plan">
-  <div class="price">
-    <span class="amount">
-      <%= formatted_price plan.price %>
-    </span>
-    <div class="info">
-      <span class="interval">per <%= plan_interval plan %></span>
-      <span class="unit">per user</span>
+<section class="pricing" id="price">
+  <header class="price-header">
+    <h3>Enroll your team</h3>
+    <h4><sup>$</sup><%= plan.price %> <sub>per <%= plan_interval plan %> per user</sub></h4>
+  </header>
+  <section class="price-info">
+    <div class="price-description">
+      <p>For development teams who are looking to continue learning new
+      skills, stay on top of best practices, and keep up to date with new
+      technologies.</p>
+      <%= link_to "Get your team started today", new_checkout_path(plan), :class => "signup" %>
     </div>
-  </div>
-  <%= link_to "Enroll your team today", new_checkout_path(plan), class: "sign-up" %>
+    <div class="price-includes">
+      <h5>Includes</h5>
+      <ul>
+        <li>Coding exercises</li>
+        <li>Upcase source code</li>
+        <li>Video Tutorials</li>
+        <li>Community Forum</li>
+        <li>The Weekly Iteration</li>
+        <li><strong>30 day money-back guarantee</strong></li>
+      </ul>
+    </div>
+  </section>
 </section>

--- a/app/views/teams/_testimonials.html.erb
+++ b/app/views/teams/_testimonials.html.erb
@@ -1,19 +1,13 @@
 <section class="testimonials">
-  <div class="inner">
-    <h2>Hear what our members have to say</h2>
-    <div class="feature-quote">
+  <div class="supporting-quotes">
+    <div class="supporting-quote">
+      <%= render 'subscriptions/testimonials/ckinoti' %>
+    </div>
+    <div class="supporting-quote">
       <%= render 'subscriptions/testimonials/bdear' %>
     </div>
-    <div class="supporting-quotes">
-      <div class="supporting-quote">
-        <%= render 'subscriptions/testimonials/ckinoti' %>
-      </div>
-      <div class="supporting-quote">
-        <%= render 'subscriptions/testimonials/alee' %>
-      </div>
-      <div class="supporting-quote">
-        <%= render 'subscriptions/testimonials/bgoldhaber' %>
-      </div>
+    <div class="supporting-quote">
+      <%= render 'subscriptions/testimonials/alee' %>
     </div>
   </div>
 </section>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,72 +1,10 @@
-<% content_for :page_title, "Team Plans and Pricing" %>
+<% content_for :page_title, "Team Pricing" %>
+<% content_for :additional_body_classes, "landing" %>
 
-<% if signed_in? %>
-  <%= link_to 'account', my_account_path, class: 'signin' %>
-<% else %>
-  <%= link_to 'sign in', sign_in_path, class: 'signin' %>
-<% end %>
+<%= render 'teams/hero' %>
 
-<div class="logo">
-  <h1><%= link_to image_tag("upcase/upcase-header-logo-small-gray.svg"), root_path %></h1>
-  <h2>Someone's getting boss of the year</h2>
-</div>
+<%= render 'teams/benefits' %>
 
-<section class="subscriptions">
-  <section class="benefits">
-    <div class="benefit">
-      <div class="benefit-icon">
-        <%= fa_icon "heart" %>
-      </div>
-      <div class="benefit-content">
-        <h2>Keep your team together</h2>
-        <p>Bored people quit. If your team members stop learning and improving,
-        it won't be long before they seek that satisfaction elsewhere. Upcase is
-        full of the real-world knowledge that developers crave.</p>
-      </div>
-    </div>
-    <div class="benefit">
-      <div class="benefit-icon">
-        <%= fa_icon "life-saver" %>
-      </div>
-      <div class="benefit-content">
-        <h2>You know our code</h2>
-        <p><%= link_to "thoughtbot", "http://thoughtbot.com" %> has created some
-        of the most popular open source software in the Rails ecosystem,
-        including <%= link_to "FactoryGirl", "http://github.com/thoughtbot/factory_girl" %>,
-        <%= link_to "Paperclip", "http://github.com/thoughtbot/paperclip" %>,
-        and <%= link_to "Bourbon", "http://bourbon.io" %>. On Upcase, your team
-        will be able to work directly with the thoughtbot developers and
-        designers who make these tools.</p>
-      </div>
-    </div>
-    <div class="benefit">
-      <div class="benefit-icon">
-        <%= fa_icon "map-marker" %>
-      </div>
-      <div class="benefit-content">
-        <h2>Hit your deadlines</h2>
-        <p>If simple features have been taking longer, you're probably battling
-        technical debt. We can teach your team how to escape. You'll appreciate
-        the predictable estimates, and your team will love working in a clean
-        codebase.</p>
-      </div>
-    </div>
-  </section>
+<%= render 'teams/plan', plan: @catalog.team_plan %>
 
-  <%= render 'teams/plan', plan: @catalog.team_plan %>
-  <%= render 'testimonials' %>
-
-  <section class="plan-features">
-    <div class="inner">
-      <%= render 'features/exercises', catalog: @catalog %>
-      <%= render 'features/source_code', catalog: @catalog %>
-      <%= render 'features/video_tutorials', catalog: @catalog %>
-      <%= render 'features/forum', catalog: @catalog %>
-      <%= render 'features/weekly_iteration', catalog: @catalog %>
-    </div>
-  </section>
-</section>
-
-<section class="subscriptions">
-  <%= render 'teams/plan', plan: @catalog.team_plan %>
-</section>
+<%= render 'teams/testimonials' %>

--- a/spec/features/user_creates_team_subscription_spec.rb
+++ b/spec/features/user_creates_team_subscription_spec.rb
@@ -103,6 +103,6 @@ feature "User creates a team subscription" do
 
   def visit_team_plan_checkout_page
     visit teams_path
-    click_link "Enroll your team today"
+    click_link "Get your team started today"
   end
 end


### PR DESCRIPTION
https://trello.com/c/Oh2qSy0e/561-bring-things-from-new-home-page-over-to-teams-page

This update gets the teams page up to speed with the new design elements introduced by the home page redesign.

![upcase-teams-2](https://cloud.githubusercontent.com/assets/5003242/5840786/aeb35b3a-a15d-11e4-975d-cd263ce7dce7.png)
