### PR TITLE
WIP Adjust two column layout and remove thumbnails from Weekly Iteration

### DIFF
--- a/app/assets/javascripts/wistia_helper.js.coffee
+++ b/app/assets/javascripts/wistia_helper.js.coffee
@@ -9,6 +9,11 @@ class @WistiaHelper
     for thumbnail in thumbnails
       @_insertThumbnailUrl(thumbnail)
 
+  embedSummaries: ->
+    summaries = $(".wistia-summary[data-wistia-id]")
+    for summary in summaries
+      @_insertSummary(summary)
+
   _embedVideo: (video) ->
     hashedId = $(video).data('wistia-id')
     $(video).prop("id", "wistia_#{hashedId}")
@@ -36,9 +41,15 @@ class @WistiaHelper
     self = @
     $.getJSON(@_encodedUrl($thumbnail, params), (data) ->
       $thumbnail.attr('src', data.thumbnail_url)
-      minutes = self._convertSecondsToMinutes(data.duration)
-      $thumbnail.next().find('em').text("#{minutes} minutes")
     )
+
+  _insertSummary: (summary) ->
+    $summary = $(summary)
+    $.getJSON(@_encodedUrl($summary, ""), (data) =>
+      minutes = @_convertSecondsToMinutes(data.duration)
+      $summary.find('em').text("#{minutes} minutes")
+    )
+
 
   _encodedUrl: ($elem, params) ->
     hashedId = $elem.data('wistia-id')
@@ -56,3 +67,5 @@ $ ->
     wistia.embedVideos()
   if $('.wistia-thumbnail').length
     wistia.embedThumbnails()
+  if $(".wistia-summary").length
+    wistia.embedSummaries()

--- a/app/assets/stylesheets/_base-extends.scss
+++ b/app/assets/stylesheets/_base-extends.scss
@@ -1,10 +1,5 @@
 %main-content-box {
-  background-color: $base-background-2;
-  border: 1px solid $base-border-color-1;
-  border-radius: 3px;
-  box-shadow: inset 0 1px 1px white, $base-box-shadow;
   margin-bottom: 1em;
-  padding: 24px;
   position: relative;
 }
 

--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -18,7 +18,7 @@ h2 {
 }
 
 h3 {
-  font-size: 26px;
+  font-size: 1.5em;
   font-weight: 600;
 }
 

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -118,12 +118,6 @@
   }
 }
 
-.resources {
-  &:hover {
-    background-color: white;
-  }
-}
-
 .card {
   &.exercise {
     h5 {

--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -90,7 +90,6 @@ body.checkouts-new, body.checkouts-create {
       }
 
       &#checkout_cc_existing {
-        margin-left: 115px;
         width: auto;
 
         label {

--- a/app/assets/stylesheets/_landing-pages.scss
+++ b/app/assets/stylesheets/_landing-pages.scss
@@ -1,7 +1,3 @@
-body.shows-show #videos {
-  margin-top: 25px;
-}
-
 .landing-page-wrapper {
   @include span-columns(9);
   @include shift(1.5);

--- a/app/assets/stylesheets/_licenses-index.scss
+++ b/app/assets/stylesheets/_licenses-index.scss
@@ -1,5 +1,0 @@
-body.licenses-index {
-  table {
-    width: 100%;
-  }
-}

--- a/app/assets/stylesheets/_products-show.scss
+++ b/app/assets/stylesheets/_products-show.scss
@@ -50,10 +50,6 @@ body.videos-show {
 
   aside > div {
     margin-bottom: 1.25rem;
-
-    p:last-of-type {
-      margin-bottom: 0;
-    }
   }
 
   @include body-mobile {

--- a/app/assets/stylesheets/_products-video_tutorials-show.scss
+++ b/app/assets/stylesheets/_products-video_tutorials-show.scss
@@ -4,11 +4,7 @@ body.products-show aside,
 body.video_tutorials-show aside,
 body.shows-show aside,
 body.videos-show aside {
-  #license > div:last-child {
-    margin-bottom: 2rem;
-  }
-
-  #license .subscription-cta {
+  .subscription-cta {
     h2 {
       font-size: 1.3em;
       line-height: 1.5em;
@@ -29,7 +25,6 @@ body.videos-show aside {
   }
 
   div {
-
     h2 a {
       color: $darkwarmgray;
       font-family: $sans-serif;
@@ -45,10 +40,6 @@ body.videos-show aside {
       font-family: $sans-serif;
       font-weight: 600;
       margin: 0 0 .75rem;
-    }
-
-    .license {
-      margin-top: 0;
     }
 
     .location-name {

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -51,49 +51,35 @@
   }
 }
 
-#videos.text-box {
-  @extend %main-content-box;
-  background: $base-background-1;
-  padding-top: 20px;
-  margin-bottom: 2em;
-}
-
 #videos .video {
-  border-top: 1px dashed #ccc;
-  margin: 2em 0;
-  overflow: visible;
-  padding-top: 1.5em;
+  border-bottom: 1px solid $base-border-color-1;
+  display: block;
+  float: left;
+  margin: 0;
+  padding: 3em 0;
+  width: 100%;
 
-  &:first-child {
-    border-top: 0;
-    margin-top: 0;
-    padding-top: 0;
+  &:first-of-type {
+    padding-top: 1em;
   }
 
   &:last-child {
     margin-bottom: 0;
   }
 
-  &.unavailable {
-    opacity: .5;
+  &:only-of-type {
+    border: 0;
   }
 
-  .thumbnail {
+  .video-text:before {
+    content: image-url('play.svg');
     float: left;
-    margin-right: 12px;
-    box-shadow: 0 0 2px rgba(0, 0, 0, .4);
+    margin: 3px 10px 0 0;
   }
 
-  .thumbnail-text {
-    margin-left: 120px;
-
-    h2, h3 {
-      margin: 0;
-      padding: 0;
-
-      @include body-mobile {
-        font-size: 1rem;
-      }
-    }
+  .video-text h2,
+  .video-text h3 {
+    margin: 0;
+    padding: 0;
   }
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -34,7 +34,6 @@
 @import "products-video_tutorials-show";
 @import "checkouts-new";
 @import "products-show";
-@import "licenses-index";
 @import "video";
 @import "topics-index";
 @import "topics-show";

--- a/app/assets/stylesheets/landing/_pages.scss
+++ b/app/assets/stylesheets/landing/_pages.scss
@@ -1,7 +1,3 @@
-body.shows-show #videos {
-  margin-top: 25px;
-}
-
 .landing {
   .content {
     max-width: none;

--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -42,7 +42,23 @@ section {
   }
 
   .text-box-wrapper {
-    @include span-columns(9);
+    @include span-columns(8.5);
+    margin-right: 3%;
+    position: relative;
+
+    &:before {
+      position: absolute;
+      top: 10px;
+      right: -35px;
+      bottom: 0;
+      left: 0;
+      border-right: 1px solid $base-border-color-1;
+      content: "";
+
+      @media screen and (max-width: 755px) {
+        border-right: 0;
+      }
+    }
 
     &.solo {
       margin: auto;
@@ -74,7 +90,6 @@ section {
 
 .text-box {
   @extend %main-content-box;
-  padding: 20px;
 
   h1, h2, h3, h4, h5, h6 {
     color: $darkwarmgray;
@@ -133,6 +148,7 @@ aside {
   display: inline-block;
   float: right;
   @include span-columns(3);
+  padding-left: 30px;
 
   hgroup {
     margin-left: 48px;
@@ -151,7 +167,7 @@ aside {
   }
 
   h3 {
-    margin-top: 40px;
+    margin: 40px 0 10px;
 
     &:first-child, &:only-child {
       margin-top: 0;
@@ -160,6 +176,7 @@ aside {
 
   &, p {
     line-height: 1.5;
+    margin-bottom: 1em;
   }
 
   > div {
@@ -193,16 +210,16 @@ aside {
     padding: 1.5em .5em 2em;
 
     .text-box-wrapper {
-      display: block;
-      float: none;
       @include span-columns(12);
+    }
+
+    aside {
+      padding: 0;
     }
   }
 
   aside {
-    display: block;
-    float: none;
-    padding: 1em 24px;
     @include span-columns(12);
+    margin-top: 3em;
   }
 }

--- a/app/helpers/wistia_helper.rb
+++ b/app/helpers/wistia_helper.rb
@@ -12,29 +12,8 @@ module WistiaHelper
     )
   end
 
-  def small_wistia_iframe_for(clip)
-    content_tag(
-      'figure',
-      nil,
-      class: "wistia-video",
-      data: {
-        wistia_id: clip.wistia_id,
-        width: "563",
-        height: "317"
-      }
-    )
-  end
-
   def large_wistia_thumbnail_for(thumbnail, title)
     thumbnail(thumbnail, title, 960, 540)
-  end
-
-  def medium_wistia_thumbnail_for(thumbnail, title)
-    thumbnail(thumbnail, title, 212, 118)
-  end
-
-  def small_wistia_thumbnail_for(thumbnail, title)
-    thumbnail(thumbnail, title, 100, 60)
   end
 
   private

--- a/app/views/design_for_developers_resources/_sidebar.html.erb
+++ b/app/views/design_for_developers_resources/_sidebar.html.erb
@@ -2,7 +2,6 @@
   <%= link_to 'Take the video tutorial', design_for_developers_url, class: 'button' %>
   <div class="resource-links">
     <h3>Resource Links</h3>
-    <hr>
     <ul>
       <li><a href="/design-for-developers-resources/#design-fundementals">Design Fundamentals</a></li>
       <li><a href="/design-for-developers-resources/#grid-systems">Grid Systems</a></li>
@@ -16,7 +15,6 @@
   </div>
   <div class="cheat-sheets">
     <h3>Cheat sheets</h3>
-    <hr>
     <ul>
       <li><a href="/design-for-developers-resources/brief">Brief</a></li>
       <li><a href="/design-for-developers-resources/principles">Principles</a></li>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -13,7 +13,7 @@
 </div>
 
 <aside>
-  <section id="license" class="repository">
+  <section class="repository">
     <%= link_to(
       t("repository.view_repository"),
       [@repository, :collaboration],

--- a/app/views/shared/_sidebar_forum.html.erb
+++ b/app/views/shared/_sidebar_forum.html.erb
@@ -1,7 +1,6 @@
 <% if current_user_has_active_subscription? %>
   <div class="forum">
     <h3>Forum</h3>
-    <hr>
     <p>Your subscription includes support for any questions you may have about the topic.</p>
     <%= link_to "Visit Forums", Forum.url, class: "button" %>
   </div>

--- a/app/views/shows/show.html.erb
+++ b/app/views/shows/show.html.erb
@@ -5,15 +5,17 @@
 <%= render "products/meta", product: @show %>
 
 <div class="text-box-wrapper">
+  <span class="divider">
+    <h4 class="text">Videos</h4>
+  </span>
   <%= render "watchables/preview" %>
   <div class="text-box">
     <%= render Clip.new("ol6e0miehm") %>
-
     <section id="videos">
       <% @show.published_videos.recently_published_first.each do |video| %>
         <%= content_tag_for :div, video do %>
           <%= link_to video_path(video) do %>
-            <%= render "videos/thumbnail", clip: video.clip, name: video.name %>
+            <%= render "videos/summary", clip: video.clip, name: video.name %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/shows/show_subscribed.html.erb
+++ b/app/views/shows/show_subscribed.html.erb
@@ -7,6 +7,9 @@
 
 <div class="text-box-wrapper">
   <div class="text-box">
+    <span class="divider">
+      <h4 class="text">Videos</h4>
+    </span>
     <section id="videos">
       <%= render @show.published_videos.recently_published_first %>
     </section>

--- a/app/views/video_tutorials/show_subscribed.html.erb
+++ b/app/views/video_tutorials/show_subscribed.html.erb
@@ -6,6 +6,9 @@
 <% end %>
 
 <div class="text-box-wrapper">
+    <span class="divider">
+      <h4 class="text">Video Tutorial</h4>
+    </span>
   <section class="text-box" id="videos">
     <%= render "video_tutorials/videos", watchable: @video_tutorial %>
   </section>

--- a/app/views/videos/_summary.html.erb
+++ b/app/views/videos/_summary.html.erb
@@ -1,0 +1,6 @@
+<div class="video-text">
+  <h3><%= name %></h3>
+  <p class="videoinfo wistia-summary" data-wistia-id="<%= clip.wistia_id %>">
+    <em></em>
+  </p>
+</div>

--- a/app/views/videos/_thumbnail.html.erb
+++ b/app/views/videos/_thumbnail.html.erb
@@ -1,7 +1,0 @@
-<%= small_wistia_thumbnail_for(clip, name) %>
-<div class="thumbnail-text">
-  <h3><%= name %></h3>
-  <p class="videoinfo">
-    <em></em>
-  </p>
-</div>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag_for :div, video do %>
   <%= link_to video_path(video) do %>
-    <%= render 'videos/thumbnail', clip: video.clip, name: video.name %>
+    <%= render 'videos/summary', clip: video.clip, name: video.name %>
   <% end %>
 <% end %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -13,6 +13,9 @@
 <div class="text-box-wrapper">
   <%= render "watchables/preview" %>
   <div class="text-box">
+    <span class="divider">
+      <h4 class="text">Video</h4>
+    </span>
     <%= render @video.preview, name: @video.name %>
 
     <section class='video-notes'>

--- a/app/views/videos/show_subscribed.html.erb
+++ b/app/views/videos/show_subscribed.html.erb
@@ -17,4 +17,8 @@
   </h2>
 <% end %>
 
+<span class="divider">
+  <h4 class="text">Video</h4>
+</span>
+
 <%= render "watch_video", video: @video %>

--- a/app/views/watchables/_aside.html.erb
+++ b/app/views/watchables/_aside.html.erb
@@ -4,7 +4,6 @@
   <% if watchable.repositories.any? %>
     <div class="resources">
       <h3>Repositories</h3>
-      <hr>
       <ul>
         <% watchable.repositories.ordered.each do |repository| %>
           <li><%= link_to repository.name, repository %></li>
@@ -16,7 +15,6 @@
   <% if watchable.resources.present? %>
     <div class="resources">
       <h3>Resources</h3>
-      <hr>
       <%= format_markdown watchable.resources  %>
     </div>
   <% end %>


### PR DESCRIPTION
- Remove wistia thumbnails
- Remove gray bounding box style
- Add thin dividing line style
- Changes affect Weekly Iteration, Video Tutorials, Checkouts/new
- Remove unnecessary license css

https://trello.com/c/9YsozIjC/576-asides-look-weird-with-new-design

![screen shot 2015-01-21 at 1 06 43 pm](https://cloud.githubusercontent.com/assets/2343392/5842484/2e66a21e-a173-11e4-9a46-b0b7edb104e0.png)

![screen shot 2015-01-21 at 1 06 48 pm](https://cloud.githubusercontent.com/assets/2343392/5842486/2e693196-a173-11e4-8262-3ac1dfe5d9db.png)

![screen shot 2015-01-21 at 1 06 58 pm](https://cloud.githubusercontent.com/assets/2343392/5842485/2e6851b8-a173-11e4-83f8-22a28bade7ac.png)

![screen shot 2015-01-21 at 1 09 02 pm](https://cloud.githubusercontent.com/assets/2343392/5842487/2e6c5006-a173-11e4-8bfd-2bf65ae5b76c.png)

These changes affect how things look on multiple pages because I altered the layout.scss. 
The layout will now be more similar to /repositories, and the topic tile style on /explore.
I'd appreciate people checking out how the branch looks locally in addition to reviewing the code. Click around the video tutorials and weekly iteration. Let me know if you see any bugs.
