### PR TITLE
Improve unrecognized format responses

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -14,7 +14,8 @@ class TopicsController < ApplicationController
   end
 
   def show
-    @topic = Topic.find_by_slug!(params[:id])
+    @topic = Topic.find(params[:id])
+    respond_to :html
   end
 
   private

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -19,7 +19,7 @@ class Topic < ActiveRecord::Base
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
 
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :finders]
 
   def self.top
     featured.order("count DESC").limit 20

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Upcase::Application.routes.draw do
   resource :forum_sessions, only: :new
   resource :subscription, only: [:new, :edit, :update]
   resources :coupons, only: :show
-  resources :topics, only: :index, format: :css
+  resources :topics, only: :index, constraints: { format: "css" }
 
   resources :videos, only: [:index, :show] do
     resource :twitter_player_card, only: [:show]

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1,24 +1,63 @@
 require "rails_helper"
 
 describe TopicsController do
-  it "renders topics CSS" do
-    setup_stubbed_topics
+  context "#index" do
+    it "renders topics CSS" do
+      setup_stubbed_topics
 
-    get :index, format: :css
+      get :index, format: :css
 
-    expect(response).to be_success
-    expect(response.headers["Content-Type"]).to match(/text\/css/)
+      expect(response).to be_success
+      expect(response.headers["Content-Type"]).to match(/text\/css/)
+    end
+
+    it "renders 406 for alternate formats" do
+      expect do
+        get :index, format: :json
+        get :index, format: :html
+      end.to raise_error(ActionController::UnknownFormat)
+    end
+  end
+
+  context "#show" do
+    it "renders the show page for a found topic" do
+      topic = stubbed_topic
+      Topic.stubs(:find).with(topic.to_param).returns(topic)
+
+      get :show, id: topic
+
+      expect(Topic).to have_received(:find).with(topic.to_param)
+      expect(response).to be_success
+      expect(response).to render_template "show"
+    end
+
+    it "renders 404 when a topic is not found" do
+      expect do
+        get :show, id: "rails"
+      end.to raise_error(ActiveRecord::RecordNotFound)
+      expect(response).not_to render_template "show"
+    end
+
+    it "renders 406 when an invalid format is used" do
+      topic = stubbed_topic
+      Topic.stubs(:find).with(topic.to_param).returns(topic)
+
+      expect do
+        get :show, id: topic, format: "txt"
+      end.to raise_error(ActionController::UnknownFormat)
+      expect(response).not_to render_template "show"
+    end
   end
 
   def setup_stubbed_topics
-    topics = [topic]
+    topics = [stubbed_topic]
     Mocha::Configuration.allow(:stubbing_non_existent_method) do
       topics.stubs(:maximum).with(:updated_at).returns(Time.now)
     end
     Topic.stubs(:with_colors).returns(topics)
   end
 
-  def topic
+  def stubbed_topic
     build_stubbed(
       :topic,
       slug: "topic",


### PR DESCRIPTION
This isn't working as expected. Even with the respond_to in place, we are still
getting a MissingTemplate exception. I don't know why.

https://trello.com/c/IMxxpvIu/491-unrecognized-format-response-improvements
