### PR TITLE
Prefer name over title

### DIFF
--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -23,6 +23,6 @@ class Api::V1::ExercisesController < ApiController
   end
 
   def exercise_parameters
-    params.require(:exercise).permit(:edit_url, :summary, :title, :url)
+    params.require(:exercise).permit(:edit_url, :summary, :name, :url)
   end
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -5,7 +5,7 @@ class Exercise < ActiveRecord::Base
   has_many :trails, through: :steps, as: :completeables
   has_many :steps, dependent: :destroy, as: :completeable
 
-  validates :title, presence: true
+  validates :name, presence: true
   validates :url, presence: true
 
   def self.ordered

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -8,7 +8,7 @@ class Step < ActiveRecord::Base
 
   acts_as_list scope: :trail
 
-  def title
-    "#{completeable.class.model_name} - #{completeable.title}"
+  def name
+    "#{completeable.class.model_name} - #{completeable.name}"
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -11,7 +11,7 @@ class Video < ActiveRecord::Base
 
   validates :published_on, presence: true
   validates :slug, presence: true, uniqueness: true
-  validates :title, presence: true
+  validates :name, presence: true
   validates :watchable_id, presence: true
   validates :watchable_type, presence: true
   validates :wistia_id, presence: true
@@ -19,7 +19,7 @@ class Video < ActiveRecord::Base
   delegate :included_in_plan?, to: :watchable
   delegate :name, to: :watchable, prefix: true
 
-  friendly_id :title, use: [:slugged, :finders]
+  friendly_id :name, use: [:slugged, :finders]
 
   def self.ordered
     order('position asc')

--- a/app/views/exercises/_exercise_for_trail.html.erb
+++ b/app/views/exercises/_exercise_for_trail.html.erb
@@ -3,11 +3,11 @@
 
   <div class="tooltip">
     <figure class="exercise card <%= exercise.state.parameterize %>-exercise">
-      <%= completeable_link exercise.url, title: exercise.title do %>
+      <%= completeable_link exercise.url, title: exercise.name do %>
         <h5>
           <%= t(exercise.state.parameterize, scope: [:exercises, :statuses]) %>
         </h5>
-        <h4><%= exercise.title %></h4>
+        <h4><%= exercise.name %></h4>
         <p><%= exercise.summary %></p>
       <% end %>
 

--- a/app/views/exercises/_exercise_for_trail_preview.html.erb
+++ b/app/views/exercises/_exercise_for_trail_preview.html.erb
@@ -1,8 +1,8 @@
 <figure class="exercise <%= exercise.state.parameterize %>-exercise">
   <div class="dot"></div>
 
-  <%= completeable_link exercise.url, title: exercise.title do %>
-    <h3><%= exercise.title %></h3>
+  <%= completeable_link exercise.url, title: exercise.name do %>
+    <h3><%= exercise.name %></h3>
     <p><%= exercise.summary %></p>
   <% end %>
 

--- a/app/views/explore/_latest_show_video.html.erb
+++ b/app/views/explore/_latest_show_video.html.erb
@@ -1,6 +1,6 @@
 <li class="tile show <%= topic_slugs(video) %>">
   <h2><%= show.name %></h2>
-  <h1><%= link_to video.title, video %></h1>
+  <h1><%= link_to video.name, video %></h1>
   <p class="description"><%= show.tagline %></p>
   <%= link_to "View All Episodes", show, class: "cta" %>
 </li>

--- a/app/views/products/videos/_video.html.erb
+++ b/app/views/products/videos/_video.html.erb
@@ -1,10 +1,10 @@
 <figure class="tile weekly-iteration <%= topic_slugs(video) %>">
-  <%= link_to video, title: video.title do %>
+  <%= link_to video, title: video.name do %>
     <% video.teachers.each do |teacher| %>
       <div class="person"><%= teacher_gravatar teacher, 92 %></div>
     <% end %>
     <h2>Weekly Iteration</h2>
-    <h1><%= video.title %></h1>
+    <h1><%= video.name %></h1>
     <h3><%= teacher_names(video.teachers) %></h3>
     <p class="description"><%= truncate_html video.notes_html %></p>
   <% end %>

--- a/app/views/shows/show.html.erb
+++ b/app/views/shows/show.html.erb
@@ -13,7 +13,7 @@
       <% @show.published_videos.recently_published_first.each do |video| %>
         <%= content_tag_for :div, video do %>
           <%= link_to video_path(video) do %>
-            <%= render "videos/thumbnail", clip: video.clip, title: video.title %>
+            <%= render "videos/thumbnail", clip: video.clip, name: video.name %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/trails/_exercise_dot.html.erb
+++ b/app/views/trails/_exercise_dot.html.erb
@@ -1,5 +1,5 @@
 <% if exercise.can_be_accessed? %>
-  <%= completeable_link exercise.url, title: exercise.title do %>
+  <%= completeable_link exercise.url, title: exercise.name do %>
     <div class="dot"></div>
   <% end %>
 <% else %>

--- a/app/views/twitter_player_cards/_meta.html.erb
+++ b/app/views/twitter_player_cards/_meta.html.erb
@@ -1,6 +1,6 @@
 <meta name="twitter:card" content="player">
 <meta name="twitter:site" content="@upcase">
-<meta name="twitter:title" content="<%= video.title %>">
+<meta name="twitter:title" content="<%= video.name %>">
 <meta name="twitter:description" content="<%= video_description(video, length: 200) %>">
 <meta name="twitter:image" content="<%= image_url("twitter-card.png") %>">
 <meta name="twitter:player" content="<%= video_twitter_player_card_url(video) %>">

--- a/app/views/video_thumbnails/_video_thumbnail.html.erb
+++ b/app/views/video_thumbnails/_video_thumbnail.html.erb
@@ -1,1 +1,1 @@
-<%= large_wistia_thumbnail_for(video_thumbnail, title) %>
+<%= large_wistia_thumbnail_for(video_thumbnail, name) %>

--- a/app/views/videos/_thumbnail.html.erb
+++ b/app/views/videos/_thumbnail.html.erb
@@ -1,6 +1,6 @@
-<%= small_wistia_thumbnail_for(clip, title) %>
+<%= small_wistia_thumbnail_for(clip, name) %>
 <div class="thumbnail-text">
-  <h3><%= title %></h3>
+  <h3><%= name %></h3>
   <p class="videoinfo">
     <em></em>
   </p>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag_for :div, video do %>
   <%= link_to video_path(video) do %>
-    <%= render 'videos/thumbnail', clip: video.clip, title: video.title %>
+    <%= render 'videos/thumbnail', clip: video.clip, name: video.name %>
   <% end %>
 <% end %>

--- a/app/views/videos/_video.rss.builder
+++ b/app/views/videos/_video.rss.builder
@@ -3,5 +3,5 @@ xml.item do
   xml.guid video_url(video)
   xml.link video_url(video)
   xml.pubDate video.created_at.to_s(:rfc822)
-  xml.title video.title
+  xml.title video.name
 end

--- a/app/views/videos/_video_for_trail.html.erb
+++ b/app/views/videos/_video_for_trail.html.erb
@@ -3,11 +3,11 @@
 
   <div class="tooltip">
     <figure class="exercise card <%= video.state.parameterize %>-exercise">
-      <%= completeable_link video_path(video), title: video.title do %>
+      <%= completeable_link video_path(video), title: video.name do %>
         <h5>
           <%= t(video.state.parameterize, scope: [:exercises, :statuses]) %>
         </h5>
-        <h4><%= video.title %></h4>
+        <h4><%= video.name %></h4>
         <p><%= video.summary %></p>
       <% end %>
 

--- a/app/views/videos/_video_for_trail_preview.html.erb
+++ b/app/views/videos/_video_for_trail_preview.html.erb
@@ -1,8 +1,8 @@
 <figure class="exercise <%= video.state.parameterize %>-exercise">
   <div class="dot"></div>
 
-  <%= completeable_link video_path(video), title: video.title do %>
-    <h3><%= video.title %></h3>
+  <%= completeable_link video_path(video), title: video.name do %>
+    <h3><%= video.name %></h3>
     <p><%= video.summary %></p>
   <% end %>
 

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, @video.title.html_safe %>
+<% content_for :page_title, @video.name.html_safe %>
 
 <% if @video.preview_wistia_id.present? %>
   <% content_for :head do %>
@@ -13,7 +13,7 @@
 <div class="text-box-wrapper">
   <%= render "watchables/preview" %>
   <div class="text-box">
-    <%= render @video.preview, title: @video.title %>
+    <%= render @video.preview, name: @video.name %>
 
     <section class='video-notes'>
       <h3>Notes</h3>

--- a/app/views/videos/show_subscribed.html.erb
+++ b/app/views/videos/show_subscribed.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, @video.title.html_safe %>
+<% content_for :page_title, @video.name.html_safe %>
 
 <% if @watchable.collection? %>
   <% content_for :additional_header_links do %>
@@ -10,7 +10,7 @@
   <h1><%= @video.watchable_name %></h1>
   <h2 class="tagline">
     <% if @video.watchable.collection? %>
-      <%= @video.title %>
+      <%= @video.name %>
     <% else %>
       Watch or download video
     <% end %>

--- a/db/migrate/20150122215447_rename_exercise_title_to_name.rb
+++ b/db/migrate/20150122215447_rename_exercise_title_to_name.rb
@@ -1,0 +1,5 @@
+class RenameExerciseTitleToName < ActiveRecord::Migration
+  def change
+    rename_column :exercises, :title, :name
+  end
+end

--- a/db/migrate/20150123153826_rename_video_title_to_name.rb
+++ b/db/migrate/20150123153826_rename_video_title_to_name.rb
@@ -1,0 +1,5 @@
+class RenameVideoTitleToName < ActiveRecord::Migration
+  def change
+    rename_column :videos, :title, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20150127171316) do
   end
 
   create_table "exercises", force: :cascade do |t|
-    t.string   "title",                      null: false
+    t.string   "name",                       null: false
     t.string   "url",                        null: false
     t.text     "summary",                    null: false
     t.datetime "created_at"
@@ -364,7 +364,7 @@ ActiveRecord::Schema.define(version: 20150127171316) do
   create_table "videos", force: :cascade do |t|
     t.integer  "watchable_id"
     t.string   "wistia_id"
-    t.string   "title"
+    t.string   "name"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.string   "watchable_type"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -104,12 +104,12 @@ namespace :dev do
     create_episode 7, "Rails as a JSON database", "Ruby on Rails"
   end
 
-  def create_episode(age_in_days, title, topic_name)
+  def create_episode(age_in_days, name, topic_name)
     episode = create(
       :video,
       notes: "Blah" + " blah" * 100,
       published_on: age_in_days.days.ago,
-      title: title,
+      name: name,
       watchable: @weekly_iteration
     )
     classify episode, topic_name
@@ -242,7 +242,7 @@ namespace :dev do
       :video,
       notes: "Blah" + " blah" * 100,
       published_on: 1.day.ago,
-      title: "Red, Green, Refactor",
+      name: "Red, Green, Refactor",
       watchable: @weekly_iteration,
       wistia_id: "uaxw299qz9",
       preview_wistia_id: "uaxw299qz9"
@@ -328,15 +328,15 @@ namespace :dev do
     puts "(Please sign in as whetstone@example.com to see trail progress.)"
   end
 
-  def create_steps_for(trail, *titles)
-    titles.map do |title|
-      exercise = FactoryGirl.create(:exercise, title: title, public: true)
+  def create_steps_for(trail, *names)
+    names.map do |name|
+      exercise = FactoryGirl.create(:exercise, name: name, public: true)
       FactoryGirl.create(:step, trail: trail, completeable: exercise)
     end
   end
 
-  def classify_exercise(title, topic_name)
-    classify Exercise.find_by!(title: title), topic_name
+  def classify_exercise(name, topic_name)
+    classify Exercise.find_by!(name: name), topic_name
   end
 
   def classify(classifiable, topic_name)

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1::ExercisesController do
       exercise = stub("exercise", update_attributes: false, errors: errors)
       Exercise.stubs(find_or_initialize_by: exercise)
 
-      put :update, id: "uuid-1234", exercise: { title: "", url: "" }
+      put :update, id: "uuid-1234", exercise: { name: "", url: "" }
 
       expect(response.status).to eq 422
       expect(response.body).to eq({ errors: errors }.to_json)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -398,7 +398,7 @@ FactoryGirl.define do
 
   factory :video do
     association :watchable, factory: :video_tutorial
-    title
+    name
     wistia_id '1194803'
     published_on { 1.day.from_now }
 
@@ -415,11 +415,11 @@ FactoryGirl.define do
 
   factory :exercise do
     transient do
-      slug { title.downcase.gsub(/\s+/, "-") }
+      slug { name.downcase.gsub(/\s+/, "-") }
     end
 
     summary "Exercise summary"
-    sequence(:title) { |n| "Exercise #{n}" }
+    sequence(:name) { |n| "Exercise #{n}" }
     url { "http://localhost:7000/exercises/#{slug}" }
     uuid
 

--- a/spec/features/subscriber_explores_weekly_iteration_spec.rb
+++ b/spec/features/subscriber_explores_weekly_iteration_spec.rb
@@ -10,7 +10,7 @@ feature "User without a subscription" do
 
     expect(page).to have_content(show.name)
     expect(page).to have_content(show.tagline)
-    expect(page).to have_content(twi_video.title)
+    expect(page).to have_content(twi_video.name)
     expect(page).to have_content("View All Episodes")
 
     expect(page).to have_content(video_tutorial.name)

--- a/spec/features/subscriber_follows_trail_spec.rb
+++ b/spec/features/subscriber_follows_trail_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 feature "subscriber follows trail" do
   scenario "clicks into exercise" do
     exercises = [
-      create(:exercise, title: "First Exercise"),
-      create(:exercise, title: "Second Exercise")
+      create(:exercise, name: "First Exercise"),
+      create(:exercise, name: "Second Exercise")
     ]
     create(:trail, :published, name: "Baby Exercises", exercises: exercises)
 
@@ -16,8 +16,8 @@ feature "subscriber follows trail" do
 
   scenario "sees status based on completed exercises" do
     exercises = [
-      create(:exercise, title: "First Exercise"),
-      create(:exercise, title: "Second Exercise")
+      create(:exercise, name: "First Exercise"),
+      create(:exercise, name: "Second Exercise")
     ]
     create(:trail, :published, name: "Baby Exercises", exercises: exercises)
     user = create(:subscriber)

--- a/spec/features/subscriber_views_trail_details_spec.rb
+++ b/spec/features/subscriber_views_trail_details_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 feature "subscriber views trail details" do
   scenario "sees progress" do
     exercises = [
-      create(:exercise, title: "First Exercise"),
-      create(:exercise, title: "Second Exercise")
+      create(:exercise, name: "First Exercise"),
+      create(:exercise, name: "Second Exercise")
     ]
-    video = create(:video, title: "First Video")
+    video = create(:video, name: "First Video")
     create(
       :trail,
       :published,

--- a/spec/features/user_views_show_spec.rb
+++ b/spec/features/user_views_show_spec.rb
@@ -11,15 +11,15 @@ feature "User views show" do
     visit show_path(show, as: user)
 
     expect(page).to have_content(show.name)
-    expect(page).to have_content(published_video.title)
+    expect(page).to have_content(published_video.name)
     expect(page).to have_content(download.display_name)
-    expect(page).not_to have_content(video.title)
+    expect(page).not_to have_content(video.name)
     expect_page_to_not_have_preview_cta
 
-    click_on published_video.title
+    click_on published_video.name
 
     expect_page_to_not_have_preview_cta
-    expect_page_to_have_title("#{published_video.title} | Upcase")
+    expect_page_to_have_title("#{published_video.name} | Upcase")
   end
 
   def have_link_to(text)

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -22,12 +22,12 @@ describe "Videos" do
       visit video_tutorial_path(video_tutorial)
 
       expect(page).to have_content("2 lessons in this video tutorial")
-      expect(page).to have_content(published_video_one.title)
-      expect(page).to have_content(published_video_two.title)
-      expect(page).not_to have_content(video.title)
+      expect(page).to have_content(published_video_one.name)
+      expect(page).to have_content(published_video_two.name)
+      expect(page).not_to have_content(video.name)
       expect(
-        page.body.index(published_video_one.title) <
-        page.body.index(published_video_two.title)
+        page.body.index(published_video_one.name) <
+        page.body.index(published_video_two.name)
       ).to be
 
       visit video_path(published_video_two)
@@ -53,10 +53,10 @@ describe "Videos" do
 
       visit video_tutorial_path(video_tutorial)
 
-      expect(page).to have_content(published_video_one.title)
-      expect(page).to have_content(published_video_two.title)
+      expect(page).to have_content(published_video_one.name)
+      expect(page).to have_content(published_video_two.name)
       expect(page).to have_content("2 minutes")
-      expect(page).not_to have_content(video.title)
+      expect(page).not_to have_content(video.name)
     end
 
     it "doesn't say it's a series with one published video" do
@@ -96,13 +96,13 @@ describe "Videos" do
       expect(text_in(channel, ".//link")).to eq(show_url(show))
       expect(text_in(channel, ".//description")).to eq(show.short_description)
 
-      unpublished_xpath = ".//item/title[text()='#{video.title}']"
+      unpublished_xpath = ".//item/title[text()='#{video.name}']"
       expect(channel.xpath(unpublished_xpath)).to be_empty
 
       published_videos.each_with_index do |published_video, index|
         item = channel.xpath(".//item")[index]
 
-        expect(text_in(item, ".//title")).to eq(published_video.title)
+        expect(text_in(item, ".//title")).to eq(published_video.name)
         expect(text_in(item, ".//link")).
           to eq(video_url(published_video))
 
@@ -136,13 +136,13 @@ describe "Videos" do
         "Improve your programming skills with focused exercises."
       )
 
-      unpublished_xpath = ".//item/title[text()='#{video.title}']"
+      unpublished_xpath = ".//item/title[text()='#{video.name}']"
       expect(channel.xpath(unpublished_xpath)).to be_empty
 
       published_videos.each_with_index do |published_video, index|
         item = channel.xpath(".//item")[index]
 
-        expect(text_in(item, ".//title")).to eq(published_video.title)
+        expect(text_in(item, ".//title")).to eq(published_video.name)
         expect(text_in(item, ".//link")).
           to eq(video_url(published_video))
 

--- a/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
+++ b/spec/features/visitor_views_weekly_iteration_episodes_spec.rb
@@ -5,13 +5,13 @@ feature "Visitor" do
     show_name = Show::THE_WEEKLY_ITERATION
     show = create(:show, name: show_name)
     create(:basic_plan)
-    video_title_with_unsafe_character = "Unfriendly Nil's Unfriendly"
+    video_name_with_unsafe_character = "Unfriendly Nil's Unfriendly"
     video_notes = "Nil is contagious."
     create(
       :video,
       :published,
       :with_preview,
-      title: video_title_with_unsafe_character,
+      name: video_name_with_unsafe_character,
       notes: video_notes,
       watchable: show
     )
@@ -21,17 +21,17 @@ feature "Visitor" do
 
     expect(page).to have_content(show_name)
     expect_page_to_have_title("#{show.title} | Upcase")
-    expect(page).not_to have_content(video.title)
+    expect(page).not_to have_content(video.name)
     expect_page_to_have_preview_cta
 
-    click_link video_title_with_unsafe_character
+    click_link video_name_with_unsafe_character
 
     expect(page).to have_content(video_notes)
     expect_page_to_have_preview_cta
     expect(page).to have_content(
       "Subscribe to #{I18n.t('shared.subscription.name')}"
     )
-    expect_page_to_have_title("#{video_title_with_unsafe_character} | Upcase")
+    expect_page_to_have_title("#{video_name_with_unsafe_character} | Upcase")
   end
 
   def expect_page_to_have_preview_cta

--- a/spec/models/completeable_with_progress_spec.rb
+++ b/spec/models/completeable_with_progress_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 describe CompleteableWithProgress do
-  describe "#title" do
+  describe "#name" do
     it "delegates to its completeable" do
-      title = "some-title"
-      exercise = Exercise.new(title: title)
+      name = "some-name"
+      exercise = Exercise.new(name: name)
       completeable_with_progress = CompleteableWithProgress.
         new(exercise, "Unstarted")
 
-      result = completeable_with_progress.title
+      result = completeable_with_progress.name
 
-      expect(result).to eq(title)
+      expect(result).to eq(name)
     end
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Exercise do
-  it { should validate_presence_of(:title) }
+  it { should validate_presence_of(:name) }
   it { should validate_presence_of(:url) }
   it { should have_many(:classifications) }
   it { should have_many(:topics).through(:classifications) }
@@ -10,21 +10,21 @@ describe Exercise do
 
   describe ".ordered" do
     it "returns older exercises first" do
-      create(:exercise, title: "first", created_at: 3.days.ago)
-      create(:exercise, title: "third", created_at: 1.day.ago)
-      create(:exercise, title: "second", created_at: 2.days.ago)
+      create(:exercise, name: "first", created_at: 3.days.ago)
+      create(:exercise, name: "third", created_at: 1.day.ago)
+      create(:exercise, name: "second", created_at: 2.days.ago)
 
-      expect(Exercise.ordered.pluck(:title)).to eq(%w(first second third))
+      expect(Exercise.ordered.pluck(:name)).to eq(%w(first second third))
     end
   end
 
   describe ".public" do
     it "only returns public exercises" do
-      create(:exercise, title: "first", public: true)
-      create(:exercise, title: "second", public: true)
-      create(:exercise, title: "hidden", public: false)
+      create(:exercise, name: "first", public: true)
+      create(:exercise, name: "second", public: true)
+      create(:exercise, name: "hidden", public: false)
 
-      expect(Exercise.public.pluck(:title)).to match_array(%w(first second))
+      expect(Exercise.public.pluck(:name)).to match_array(%w(first second))
     end
   end
 end

--- a/spec/models/show_spec.rb
+++ b/spec/models/show_spec.rb
@@ -22,13 +22,13 @@ describe Show do
       create_video "unpublished", show: show, published_on: 1.day.from_now
       create_video "other_show", show: other_show, published_on: Time.now
 
-      expect(show.latest_video.title).to eq("latest_published")
+      expect(show.latest_video.name).to eq("latest_published")
     end
 
-    def create_video(title, show:, published_on:)
+    def create_video(name, show:, published_on:)
       create(
         :video,
-        title: title,
+        name: name,
         watchable: show,
         published_on: published_on
       )

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -11,12 +11,12 @@ describe Step do
     it { should validate_uniqueness_of(:position).scoped_to(:trail_id) }
   end
 
-  describe "#title" do
-    it "returns the completeable type and title" do
-      completeable = create(:exercise, title: "My Completeable Title")
+  describe "#name" do
+    it "returns the completeable type and name" do
+      completeable = create(:exercise, name: "My Completeable Title")
       step = build(:step, completeable: completeable)
 
-      expect(step.title).to eq "Exercise - My Completeable Title"
+      expect(step.name).to eq "Exercise - My Completeable Title"
     end
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -10,7 +10,7 @@ describe Video do
 
   it { should validate_presence_of(:published_on) }
   it { should validate_presence_of(:slug) }
-  it { should validate_presence_of(:title) }
+  it { should validate_presence_of(:name) }
   it { should validate_presence_of(:watchable_id) }
   it { should validate_presence_of(:watchable_type) }
   it { should validate_presence_of(:wistia_id) }
@@ -59,12 +59,12 @@ describe Video do
 
   context '.recently_published_first' do
     it 'sorts the collection so that recently published videos are first' do
-      create(:video, published_on: Date.today, title: 'new')
-      create(:video, published_on: 2.days.ago, title: 'old')
-      create(:video, published_on: Date.yesterday, title: 'middle')
-      titles = %w(new middle old)
+      create(:video, published_on: Date.today, name: 'new')
+      create(:video, published_on: 2.days.ago, name: 'old')
+      create(:video, published_on: Date.yesterday, name: 'middle')
+      names = %w(new middle old)
 
-      expect(Video.recently_published_first.map(&:title)).to eq titles
+      expect(Video.recently_published_first.map(&:name)).to eq names
     end
   end
 

--- a/spec/requests/exercises_synchronization_spec.rb
+++ b/spec/requests/exercises_synchronization_spec.rb
@@ -9,7 +9,7 @@ describe "PUT /api/v1/exercises/:id" do
       expect(Exercise.count).to eq 1
 
       exercise = Exercise.first
-      expect(exercise.title).to eq exercise_attributes[:title]
+      expect(exercise.name).to eq exercise_attributes[:name]
       expect(exercise.uuid).to eq "uuid-1234"
       expect(exercise.url).to eq exercise_attributes[:url]
       expect(exercise.edit_url).to eq exercise_attributes[:edit_url]
@@ -19,7 +19,7 @@ describe "PUT /api/v1/exercises/:id" do
 
   context "when an exercise with given uuid exists" do
     it "updates the exercise" do
-      create(:exercise, title: "Old Title", uuid: "uuid-1234")
+      create(:exercise, name: "Old Title", uuid: "uuid-1234")
 
       perform_request("uuid-1234", exercise_attributes)
 
@@ -27,7 +27,7 @@ describe "PUT /api/v1/exercises/:id" do
       expect(Exercise.count).to eq 1
 
       exercise = Exercise.first
-      expect(exercise.title).to eq exercise_attributes[:title]
+      expect(exercise.name).to eq exercise_attributes[:name]
     end
   end
 
@@ -47,7 +47,7 @@ describe "PUT /api/v1/exercises/:id" do
     {
       edit_url:
         "https://exercise.upcase.com/admin/exercises/shakespeare-analyzer/edit",
-      title: "Shakespeare Analyzer",
+      name: "Shakespeare Analyzer",
       summary: "Analyse Shakespeare's literature",
       url: "https://exercise.upcase.com/exercises/shakespeare-analyzer"
     }

--- a/spec/services/completeable_with_progress_query_spec.rb
+++ b/spec/services/completeable_with_progress_query_spec.rb
@@ -13,8 +13,8 @@ describe CompleteableWithProgressQuery do
 
       completeables_query = query.to_a
 
-      expect(completeables_query[0].title).to eq(exercise_step_1.title)
-      expect(completeables_query[1].title).to eq(video_step_2.title)
+      expect(completeables_query[0].name).to eq(exercise_step_1.name)
+      expect(completeables_query[1].name).to eq(video_step_2.name)
       expect(completeables_query[0].state).to eq(Status::NEXT_UP)
       expect(completeables_query[1].state).to eq(Status::UNSTARTED)
       expect(completeables_query[2].state).to eq(Status::UNSTARTED)

--- a/spec/services/topic_with_resources_factory_spec.rb
+++ b/spec/services/topic_with_resources_factory_spec.rb
@@ -6,13 +6,13 @@ describe TopicWithResourcesFactory do
       topic = create(:topic)
       other_topic = create(:topic)
       resources = [
-        create(:video, :published, title: "video-one"),
+        create(:video, :published, name: "video-one"),
         create(:video_tutorial, name: "video_tutorial-one"),
       ]
       resources.each do |classifiable|
         topic.classifications.create!(classifiable: classifiable)
       end
-      other_resource = create(:exercise, title: "exercise-two")
+      other_resource = create(:exercise, name: "exercise-two")
       other_topic.classifications.create!(classifiable: other_resource)
       factory = TopicWithResourcesFactory.new(catalog: Catalog.new)
 

--- a/spec/support/fake_upcase_exercises.rb
+++ b/spec/support/fake_upcase_exercises.rb
@@ -6,7 +6,7 @@ class FakeUpcaseExercises < Sinatra::Base
   get "/exercises/:slug" do |slug|
     exercise = Exercise.find_by!("url LIKE ?", "%/exercises/#{slug}")
     <<-HTML
-      Exercise: #{exercise.title}
+      Exercise: #{exercise.name}
     HTML
   end
 

--- a/spec/views/explore/_videos.html.erb_spec.rb
+++ b/spec/views/explore/_videos.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe "explore/_videos.html" do
       render "explore/videos", show: show, video_tutorial: video_tutorial
 
       expect(rendered).to have_text(show.tagline)
-      expect(rendered).to have_text(latest_video.title)
+      expect(rendered).to have_text(latest_video.name)
     end
   end
 

--- a/spec/views/twitter_player_cards/_meta.html.erb_spec.rb
+++ b/spec/views/twitter_player_cards/_meta.html.erb_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 describe "twitter_player_cards/_meta.html.erb" do
   it "renders Twitter Player Card meta tags" do
-    title = "1986 NBA Finals"
+    name = "1986 NBA Finals"
     description = "Bird steals the ball! Underneath to DJ and he lays it in!!!"
     wistia_id = "abc123"
     view_stubs(video_description: description)
     video = create(
       :video,
-      title: title,
+      name: name,
       wistia_id: wistia_id
     )
 
@@ -17,7 +17,7 @@ describe "twitter_player_cards/_meta.html.erb" do
     {
       "card" => "player",
       "site" => "@upcase",
-      "title" => title,
+      "title" => name,
       "description" => description,
       "image" => "http://test.host/assets/twitter-card.png",
       "player" => "http://test.host/videos/1986-nba-finals/twitter_player_card",
@@ -25,9 +25,9 @@ describe "twitter_player_cards/_meta.html.erb" do
       "player:height" => "276",
       "player:stream" => "https://thoughtbotlearn.wistia.com/medias/#{wistia_id}",
       "player:stream:content_type" => "video/mp4",
-    }.each do |name, content|
+    }.each do |key, content|
       expect(rendered).
-        to have_css("meta[name='twitter:#{name}'][content='#{content}']")
+        to have_css("meta[name='twitter:#{key}'][content='#{content}']")
     end
   end
 end


### PR DESCRIPTION
- Rename Exercise title to name
- Rename Video title to name

Trello card: https://trello.com/c/4ANSMTrK

My first commit to upcase, so if you have more knowledge of things I may have overlooked then please let me know. I left out the products/workshops title change because I think they should still be considered something different to just the name attribute.

I believe this also needs to be deployed along with a new upcase-exercises PR that makes the same change. I'm tidying that PR up next and will commit shortly. Let me know if there are other repos relying on the upcase API.
