### PR TITLE
Fix video tooltips

### DIFF
--- a/app/views/videos/_video_for_trail.html.erb
+++ b/app/views/videos/_video_for_trail.html.erb
@@ -5,7 +5,7 @@
     <figure class="exercise card <%= video.state.parameterize %>-exercise">
       <%= completeable_link video_path(video), title: video.name do %>
         <h5>
-          <%= t(video.state.parameterize, scope: [:exercises, :statuses]) %>
+          <%= t(video.state.parameterize, scope: [:videos, :statuses]) %>
         </h5>
         <h4><%= video.name %></h4>
         <p><%= video.summary %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,13 @@ en:
       update:
         success: Your profile has been updated.
 
+  videos:
+    statuses:
+      next-up: "Video"
+      unstarted: "Video"
+      in_progress: "In Progress"
+      complete: "Complete"
+
   watchables:
     preview:
       cta: This video is a preview. <a href="%{subscribe_url}">Subscribe to Upcase</a> to access the full-length video, and all other videos.

--- a/spec/views/videos/_video_for_trail.html.erb_spec.rb
+++ b/spec/views/videos/_video_for_trail.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "videos/_video_for_trail.html" do
+  it "titles the tooltip with Video" do
+    stub_user
+    video = stub_video(state: "unstarted")
+
+    render "videos/video_for_trail", video: video
+
+    expect(rendered).to have_content("Video")
+    expect(rendered).not_to have_content("Exercise")
+  end
+
+  def stub_user
+    view_stubs(:current_user_has_access_to?).returns(true)
+    build_stubbed(:user).tap do |user|
+      view_stubs(:current_user).returns(user)
+    end
+  end
+
+  def stub_video(state: "Imaginary")
+    Mocha::Configuration.allow(:stubbing_non_existent_method) do
+      build_stubbed(:video).tap do |video|
+        video.stubs(:can_be_accessed?)
+        video.stubs(:state).returns(state)
+      end
+    end
+  end
+end


### PR DESCRIPTION
They were displaying as "Exercise", but will now display as "Video"

https://trello.com/c/l57nQ5w7/395-add-ability-to-associate-steps-with-videos

![screen shot 2015-01-28 at 4 06 31 pm](https://cloud.githubusercontent.com/assets/1431996/5946969/acd415b6-a707-11e4-919b-bf4b5aae7fb9.png)
