### PR TITLE
Improve topics grid sass

### DIFF
--- a/app/assets/stylesheets/landing/_topics-grid.scss
+++ b/app/assets/stylesheets/landing/_topics-grid.scss
@@ -1,24 +1,63 @@
+%quarter {
+  @include marketing-fullsize {
+    width: 25%;
+  }
+}
+
+%fifth {
+  @include marketing-fullsize {
+    width: 20%;
+  }
+}
+
+%sixth {
+  @include marketing-fullsize {
+    width: 16.666%;
+  }
+}
+
 .topics-grid {
   background: $base-background-2;
   margin-bottom: 0;
-  padding: 2em 2em 4em;
+  padding: 2em 1.5em 4em;
   position: relative;
 
   ol {
-    @include outer-container;
+    @include display(flex);
+    @include flex-wrap(wrap);
+    margin: 0 auto;
+    max-width: 1116px;
   }
 
   .topic-link {
-    @include span-columns(6);
-    @include omega(2n);
     display: block;
-    margin-bottom: 2.36%;
+    padding: 0.5em;
     text-decoration: none;
+    width: 50%;
 
     @include marketing-small {
-      @include span-columns(3);
-      @include omega-reset(2n);
-      @include omega(4n);
+      width: 33.333%;
+    }
+
+    @each $n in 7, 8 {
+      &:first-child:nth-last-child(#{$n}),
+      &:first-child:nth-last-child(#{$n}) ~ .topic-link {
+        @extend %quarter;
+      }
+    }
+
+    @each $n in 9, 10, 13, 14, 15 {
+      &:first-child:nth-last-child(#{$n}),
+      &:first-child:nth-last-child(#{$n}) ~ .topic-link {
+        @extend %fifth;
+      }
+    }
+
+    @each $n in 6, 11, 12, 16, 17, 18 {
+      &:first-child:nth-last-child(#{$n}),
+      &:first-child:nth-last-child(#{$n}) ~ .topic-link {
+        @extend %sixth;
+      }
     }
   }
 


### PR DESCRIPTION
https://trello.com/c/ihl1Rlsb/583-make-home-page-topics-css-more-robust

Overhaul the grid styles so the grid will look nice regardless of the number of items it contains.
- Simplify by using flexbox instead of Neat columns
- Adjust grid items to be a one quarter/fifth/sixth width of the grid depending on how many siblings they have.

So, if we have 9 topics, instead of this:

![image](https://cloud.githubusercontent.com/assets/5003242/5960916/7bd0bd6a-a79e-11e4-8365-25fba2a32106.png)

It will do this:

![image](https://cloud.githubusercontent.com/assets/5003242/5960928/918fb0b6-a79e-11e4-88d6-f5f2e44e795b.png)

11 topics will do this:

![image](https://cloud.githubusercontent.com/assets/5003242/5960934/9d77b55e-a79e-11e4-85ef-2a1905951233.png)
