### PR TITLE
Use `Forum.url` in receipt

### DIFF
--- a/app/views/subscription_mailer/subscription_receipt.text.erb
+++ b/app/views/subscription_mailer/subscription_receipt.text.erb
@@ -7,7 +7,7 @@ You can view the invoice for this month at
 
 Have a technical question about something you're working on in your personal
 project, a video tutorial, or any of our books?  Post it to the forum at
-http://forum.thoughtbot.com
+<%= Forum.url %>
 
 Thanks for subscribing to Upcase!
 thoughtbot

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -90,6 +90,14 @@ describe SubscriptionMailer do
       )
     end
 
+    it "links to the forum" do
+      Forum.stubs(url: "https://forum.example.com")
+
+      expect(subscription_receipt_email).to(
+        have_body_text("https://forum.example.com")
+      )
+    end
+
     def subscription_receipt_email
       SubscriptionMailer.subscription_receipt(
         'email@example.com',


### PR DESCRIPTION
https://trello.com/c/ACydJ4oU/564-receipt-email-has-old-link-to-forum
