### PR TITLE
Improve header rollover

### DIFF
--- a/app/assets/stylesheets/landing/_nav.scss
+++ b/app/assets/stylesheets/landing/_nav.scss
@@ -17,8 +17,19 @@
       @include position(absolute, 0em 0em null 0em);
       background: none;
 
-      nav li a {
-        border-left: none;
+      nav li {
+        margin: 8px;
+
+        &:hover {
+          background: rgba(black, 0.12);
+          border-radius: 3px;
+        }
+
+        a {
+          border-left: none;
+          height: 44px;
+          padding: 0.5rem 1.5rem;
+        }
       }
     }
   }


### PR DESCRIPTION
https://trello.com/c/3UUqCedh/603-improve-home-page-header-hover-state

![image](https://cloud.githubusercontent.com/assets/5003242/6004605/8d095adc-aac9-11e4-8c75-57ceece5cf82.png)

Adds rollover styles for the header when it is above the hero.
