### PR TITLE
Add Gravatar fallback

### DIFF
--- a/app/assets/images/account.svg
+++ b/app/assets/images/account.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+<path d="M12 2c-5.525 0-10 4.475-10 10s4.475 10 10 10 10-4.475 10-10-4.475-10-10-10zM12 5c1.655 0 3 1.345 3 3 0 1.66-1.345 3-3 3s-3-1.34-3-3c0-1.655 1.345-3 3-3zM12 19.2c-2.505 0-4.705-1.28-6-3.22 0.025-1.985 4.005-3.080 6-3.080s5.97 1.095 6 3.080c-1.295 1.94-3.495 3.22-6 3.22z" fill="rgb(255, 255, 255)"></path>
+</svg>

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -132,7 +132,14 @@ body.passwords-create {
     }
 
     .account a {
-      padding: 1rem;
+      background: image-url("account.svg") center center no-repeat;
+      background-size: em(26);
+      padding: em(15);
+      width: $navigation-height + 1px;
+
+      img {
+        @include linear-gradient(#3481ea, #118ed5);
+      }
     }
 
     .subscription a {


### PR DESCRIPTION
https://trello.com/c/DmBnKmb2/549-user-without-gravatar

Add a fallback account icon to the nav bar, in the event that Gravatar is blocked by a user's browser extension or fails for some other reason.

![image](https://cloud.githubusercontent.com/assets/5003242/6030174/3021d09a-abbb-11e4-8cbd-d126c6bacc4d.png)
