### PR TITLE
Center mobile Gravatar

### DIFF
--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -137,6 +137,10 @@ body.passwords-create {
       padding: em(15);
       width: $navigation-height + 1px;
 
+      @media screen and (max-width: 755px) {
+        width: 100%;
+      }
+
       img {
         @include linear-gradient(#3481ea, #118ed5);
       }


### PR DESCRIPTION
https://trello.com/c/2E9a7SA1/613-center-avatar-on-mobile

Noticed the gravatar/fallback was not centered at low resolutions, this fixes that.

![image](https://cloud.githubusercontent.com/assets/5003242/6044018/2f54d7ca-ac56-11e4-9bc9-36844e2b83bf.png)
