### PR TITLE
WIP: Improve forum links

### DIFF
--- a/app/assets/stylesheets/_products-show.scss
+++ b/app/assets/stylesheets/_products-show.scss
@@ -48,8 +48,14 @@ body.videos-show {
     list-style-type: none;
   }
 
-  aside > div {
-    margin-bottom: 1.25rem;
+  aside {
+    > div {
+      margin-bottom: 1.25rem;
+    }
+
+    .button {
+      width: 100%;
+    }
   }
 
   @include body-mobile {

--- a/app/views/shared/_sidebar_forum.html.erb
+++ b/app/views/shared/_sidebar_forum.html.erb
@@ -1,7 +1,5 @@
 <% if current_user_has_active_subscription? %>
   <div class="forum">
-    <h3>Forum</h3>
-    <p>Your subscription includes support for any questions you may have about the topic.</p>
-    <%= link_to "Visit Forums", Forum.url, class: "button" %>
+    <%= link_to "Discuss in the Forum", Forum.url, class: "button" %>
   </div>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/K5dTty0T/602-improve-forum-links-on-everything

Removes forum header & explanation and increases width of buttons in the right column to the full width of the column.

![image](https://cloud.githubusercontent.com/assets/5003242/6049032/1851a890-ac7a-11e4-8ab4-c610b3197039.png)

Still needs development  – I _think_ this is all that is necessary as far as design goes. I did find another partial that links to the forums –  `app/views/products/_forum_link.html.erb` – but I can't tell if/where it is being used.

I was also thinking this button could read "Discuss this topic" if we're linking to a specific category, and "Visit the forums" if we're not.
