### PR TITLE
Fix landing header

### DIFF
--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -17,7 +17,7 @@
             <li class="view-plans">
               <%= link_to t("subscriptions.join_cta"), "#price" %>
             </li>
-            <li class="account">
+            <li>
               <% if signed_in? %>
                 <%= link_to 'Account', my_account_path %>
               <% else %>


### PR DESCRIPTION
Related to this: https://trello.com/c/DmBnKmb2/549-user-without-gravatar

Removes .account class from Sign In/Account link in the landing page header, so the gravatar fallback icon does not show up behind the link.
