### PR TITLE
Fix sign in button

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,7 +41,7 @@
           <li class="view-plans">
             <%= link_to t("subscriptions.join_cta"), new_subscription_path %>
           </li>
-          <li class="account"><%= link_to "Sign in", sign_in_path %></li>
+          <li><%= link_to "Sign in", sign_in_path %></li>
         <% end %>
       </ul>
     </nav>


### PR DESCRIPTION
Another fix related to this: https://trello.com/c/DmBnKmb2/549-user-without-gravatar

Removes account class from sign in button.
