### PR TITLE
Upgrade to annual billing page: display savings

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -82,6 +82,10 @@ class Plan < ActiveRecord::Base
     annual_plan.price
   end
 
+  def annualized_savings
+    annualized_payment - discounted_annual_payment
+  end
+
   def annual_plan_sku
     annual_plan.sku
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,6 +32,14 @@ class Team < ActiveRecord::Base
     users_count < plan.minimum_quantity
   end
 
+  def users_count
+    users.count
+  end
+
+  def annualized_savings
+    users_count * plan.annualized_savings
+  end
+
   private
 
   def update_billing_quantity
@@ -44,9 +52,5 @@ class Team < ActiveRecord::Base
 
   def fulfillment_for(user)
     SubscriptionFulfillment.new(user, plan)
-  end
-
-  def users_count
-    users.count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,10 @@ class User < ActiveRecord::Base
     plan.try(:name)
   end
 
+  def team_owner?
+    team && team.owner?(self)
+  end
+
   def subscription
     [personal_subscription, team_subscription].compact.detect(&:active?)
   end

--- a/app/views/annual_billings/_annual_savings.html.erb
+++ b/app/views/annual_billings/_annual_savings.html.erb
@@ -1,0 +1,10 @@
+<dt>
+  <p><%= "For #{pluralize(team.users_count, "team member")}, you save:" %></p>
+</dt>
+<dd>
+  <p>
+    <span class="subscription-charge">$<%= team.annualized_savings %></span>
+    per year
+  </p>
+</dd>
+

--- a/app/views/annual_billings/new.html.erb
+++ b/app/views/annual_billings/new.html.erb
@@ -42,14 +42,23 @@
     <p>What you pay now (annually):</p>
   </dt>
   <dd>
-    <p class="subscription-charge">$<%= @annualized_payment %></p>
+    <p>
+      <span class="subscription-charge">$<%= @annualized_payment %></span>
+      per member
+    </p>
   </dd>
   <dt>
     <p>What you'll pay when you switch to annual billing:</p>
   </dt>
   <dd>
-    <p class="subscription-charge">$<%= @discounted_annual_payment %></p>
+    <p>
+      <span class="subscription-charge">$<%= @discounted_annual_payment %></span>
+      per member
+    </p>
   </dd>
+  <%- if current_user.team_owner? %>
+    <%= render partial: "annual_savings", locals: { team: current_user.team } %>
+  <% end %>
   <dd>
     <p class="disclaimer">Annual plans are charged up-front, once a year. We
     offer a 100% refund when requested within 30 days.</p>

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -131,6 +131,14 @@ describe Plan do
     end
   end
 
+  describe "#annualized_savings" do
+    it "returns savings gained when moving to yearly plan" do
+      plan = build_stubbed(:plan, :with_annual_plan)
+
+      expect(plan.annualized_savings).to eq(198)
+    end
+  end
+
   describe "#annual_plan_sku" do
     it "returns the sku of associated annual plan" do
       plan = build_stubbed(:plan, :with_annual_plan)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -51,6 +51,26 @@ describe Team do
       end
     end
 
+    context "#users_count" do
+      it "returns the number of team members" do
+        team = build_stubbed(:team)
+        create_list(:user, 2, team: team)
+
+        expect(team.users_count).to eq(2)
+      end
+    end
+
+    context "#annualized_savings" do
+      it "returns savings gained if moved to yearly plan" do
+        user = create(:user, :with_team_subscription)
+        user.plan.update(annual_plan: create(:plan, :annual))
+        team = user.team
+        allow(team).to receive(:users_count).and_return(3)
+
+        expect(team.annualized_savings).to eq(234)
+      end
+    end
+
     context "when above the minimum" do
       it "updates the team's subscription with the number of team members" do
         team = team_with_stubbed_subscription_change_quantity

--- a/spec/views/annual_billings/_annual_saving.html.erb_spec.rb
+++ b/spec/views/annual_billings/_annual_saving.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "annual_billings/_annual_savings.html.erb" do
+  context "when a team considers signing up for annual billing" do
+    it "renders how much the team will save considering team members count" do
+      user = build_stubbed(:user, :with_team_subscription)
+      allow(user.plan).to receive(:discounted_annual_payment).and_return(990)
+      team = user.team
+      allow(team).to receive(:users_count).and_return(2)
+
+      render "annual_billings/annual_savings", current_user: user, team: team
+
+      expect(rendered).to include("For 2 team members, you save:")
+      expect(rendered).to include("$156") # (1068 - 990) * 2
+      expect(rendered).to include("per year")
+    end
+  end
+end


### PR DESCRIPTION
- User#team_owner? check
- Plan#annualized_saving
- Team#annualized_saving which is grabbed from plan multiplied by users_count
- Added indication 'per user' for verbosity clearer message
