### PR TITLE
Fix cancellation

### DIFF
--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -47,11 +47,7 @@ section {
     position: relative;
 
     &:before {
-      position: absolute;
-      top: 10px;
-      right: -35px;
-      bottom: 0;
-      left: 0;
+      @include position(absolute, 10px -35px 0px null);
       border-right: 1px solid $base-border-color-1;
       content: "";
 


### PR DESCRIPTION
Remove .text-box-wrapper's pseudo element's "left" property -- it was overlayed on top of content in the wrapper.
