### PR TITLE
Trails breadcrumbs

### DIFF
--- a/app/assets/stylesheets/_trails-show.scss
+++ b/app/assets/stylesheets/_trails-show.scss
@@ -1,4 +1,20 @@
 .trails-show {
+  .breadcrumbs {
+    color: $gray-3;
+
+    a {
+      color: $upcase-blue;
+      font-size: .9em;
+      padding: 0 10px;
+
+      &:last-child {
+        color: $gray-2;
+        font-weight: 400;
+        pointer-events: none;
+      }
+    }
+  }
+
   header {
     @include display(flex);
     margin-top: 3.2em;

--- a/app/helpers/trails_helper.rb
+++ b/app/helpers/trails_helper.rb
@@ -1,0 +1,7 @@
+module TrailsHelper
+  def trail_breadcrumbs(trail, separator = ">")
+    [trail.topic, trail].map { |obj| link_to(obj, obj) }.
+      unshift(link_to("Trails", trails_path)).
+      join(" #{separator} ").html_safe
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -41,6 +41,10 @@ class Topic < ActiveRecord::Base
     where("color != ''")
   end
 
+  def to_s
+    name
+  end
+
   def published_trails
     trails.published
   end

--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -22,6 +22,10 @@ class Trail < ActiveRecord::Base
     where(published: true)
   end
 
+  def to_s
+    name
+  end
+
   # Override setters so it preserves the order
   def step_ids=(new_step_ids)
     super

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -1,4 +1,6 @@
-<%= link_to "< Back to #{topic.name} resources", topic_resources_path(topic) %>
+<div class="breadcrumbs">
+  <%= trail_breadcrumbs(trail) %>
+</div>
 
 <header>
   <div class="topic-image">

--- a/spec/helpers/trails_helper_spec.rb
+++ b/spec/helpers/trails_helper_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe TrailsHelper do
+  describe "#trail_breadcrumbs" do
+    it "constructs breadcrumbs for a trail" do
+      topic = build_stubbed(:topic, slug: "design")
+      trail = build_stubbed(:trail, slug: "sass", topic: topic)
+
+      result = helper.trail_breadcrumbs(trail)
+
+      expect(result).to include trails_path
+      expect(result).to include "/design"
+      expect(result).to include "/sass"
+    end
+  end
+end


### PR DESCRIPTION
Breadcrumbs can be done in so many ways so I thought I'd do the simplest implementation for now until we need to accommodate more options and be more flexible. So basically created breadcrumbs that are trail only specific.

I also wasn't sure the html markup that people prefer to use:
- I created a string for the crumbs. Would a designer prefer a `<ul>` structure instead?
- I did not assign specific classes for each of the nodes of the breadcrumbs. Maybe a designer would want that for styling purposes.

But it works, and it looks ok. I also removed the "back to resources" link because it seemed redundant.

Your thoughts?

https://trello.com/c/FmnOVxOx
