### PR TITLE
WIP - Add placeholder markup for trail prerequisites

### DIFF
--- a/app/assets/stylesheets/_trails-show.scss
+++ b/app/assets/stylesheets/_trails-show.scss
@@ -1,7 +1,11 @@
 .trails-show {
+  .prerequisite {
+    margin-top: 1em;
+  }
+
   header {
     @include display(flex);
-    margin-top: 3.2em;
+    margin-top: 2em;
 
     @media screen and (max-width: 755px) {
       display: block;

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -32,13 +32,12 @@ $not-started-dot-color: #D8D8D8;
     text-align: center;
   }
 
-  & > div {
+  .active-trails > div {
     margin-bottom: 5em;
   }
 
   .trail {
     width: 100%;
-    margin-bottom: 5em;
 
     header {
       @include clearfix;

--- a/app/views/practice/_active_trail.html.erb
+++ b/app/views/practice/_active_trail.html.erb
@@ -1,5 +1,6 @@
 <div class="<%= trail.unstarted? ? "unstarted" : "started" %>">
   <section class="trail <%= topic_class(trail.topic) %>">
+    <p class="prerequisite">Hey, before you start this...Have you done the <a href="">Intro to Rails</a> tutorial?</p>
     <header>
       <span class="topic-label"><%= trail.topic.name %></span>
       <h1><%= link_to trail.name, trail %></h1>

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -1,5 +1,5 @@
 <%= link_to "< Back to #{topic.name} resources", topic_resources_path(topic) %>
-
+<p class="prerequisite">Hey, before you start this...Have you done the <a href="">Intro to Rails</a> tutorial?</p>
 <header>
   <div class="topic-image">
     <%= image_tag "topics/#{topic.slug}.svg" %>


### PR DESCRIPTION
This is placeholder markup for the messaging we want to display above certain trails.
The idea behind this work comes from this growth experiment:
https://github.com/thoughtbot/upcase-growth/pull/7/files

I have "Hey, before you start this...Have you done the <a href="">Intro to Rails</a> tutorial?" in here for placement. 

This message should appear above the Rails Fundamentals trail wherever it appears: on /practice, /trails, trails-show pages, and topic resources pages (ie. /rails/resources). Also on the "start exercise" page, but that work would go in upcase-exercises repo.

![screen shot 2015-02-11 at 11 44 26 am](https://cloud.githubusercontent.com/assets/2343392/6156805/b4acb7da-b20a-11e4-8a9a-6ea947ade9e6.png)

![screen shot 2015-02-11 at 11 43 25 am](https://cloud.githubusercontent.com/assets/2343392/6156812/c1e57b58-b20a-11e4-888f-0cf7266225a2.png)

![screen shot 2015-02-11 at 11 44 01 am](https://cloud.githubusercontent.com/assets/2343392/6156810/ba48cf9e-b20a-11e4-8030-a706a13d8ffe.png)

We will also want to add a hint/suggested prerequisites for:
- Testing Fundamentals
- Test Doubles
- Refactoring

It's up to the developer how much we want to do here now - we can just implement this one hint for Rails Fundamentals for now, but we do eventually want the ability to add a suggested prerequisite to any trail.

We also want the hint messaging to go away for completed trails, and go away if a user has completed the suggested video or trail.
