### PR TITLE
Notify visitors when they enter a successful coupon

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -54,6 +54,7 @@
 @import "landing/pages";
 @import "landing/nav";
 @import "landing/hero";
+@import "landing/flashes";
 @import "landing/topics-grid";
 @import "landing/features";
 @import "landing/price";

--- a/app/assets/stylesheets/landing/_flashes.scss
+++ b/app/assets/stylesheets/landing/_flashes.scss
@@ -1,0 +1,50 @@
+.flashes {
+  @include position(absolute, 0em 0em null 0em);
+  margin: 0;
+  max-width: none;
+  padding: 0;
+  z-index: 25;
+
+  @include marketing-fullsize {
+    position: fixed;
+  }
+
+  .flash {
+    @include animation(fall 0.75s);
+    @include animation-delay(0.75s);
+    @include animation-fill-mode(both);
+    background: $upcase-blue-1;
+    border: 0;
+    border-radius: 0;
+    box-shadow: 0 0 0 2px rgba(#000000, 0.1);
+    color: #ffffff;
+    display: block;
+    font-size: 1.25em;
+    font-weight: 300;
+    line-height: 1.5rem;
+    padding: 1rem 2rem;
+  }
+}
+
+@include keyframes(fall) {
+
+  from {
+    @include transform(translateY(-200%));
+  }
+
+  to {
+    @include transform(translateY(0%));
+  }
+}
+
+.pricing {
+
+  .flashes {
+    margin: 1em 0;
+    padding: 0;
+  }
+
+  .flash {
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/landing/_hero.scss
+++ b/app/assets/stylesheets/landing/_hero.scss
@@ -1,4 +1,4 @@
-$landing-hero: #313b41;
+$hero-green: #4dd1aa;
 
 .hero {
   @include background-image(
@@ -6,10 +6,10 @@ $landing-hero: #313b41;
     url(upcase/laptop.jpg)
   );
 
-  background-color: $landing-hero;
+  background-color: $upcase-blue-2;
   background-position: center center;
   background-size: cover;
-  padding: 4em 2em 2em;
+  padding: 6em 2em 3em;
   position: relative;
   text-align: center;
   z-index: 10;
@@ -68,7 +68,7 @@ $landing-hero: #313b41;
   }
 
   .signup {
-    background: #0FD197;
+    background: $hero-green;
     font-size: 1.25em;
     font-weight: 300;
     margin: 0;

--- a/app/assets/stylesheets/landing/_nav.scss
+++ b/app/assets/stylesheets/landing/_nav.scss
@@ -1,6 +1,6 @@
 .landing #header-wrapper {
   margin-bottom: 0;
-  z-index: 9999;
+  z-index: 20;
 
   @include marketing-fullsize {
     padding: 0 2em;
@@ -38,6 +38,7 @@
     @include position(fixed, 0em 0em 0 0em);
     @include transform(translateY(-100%));
     @include transition(transform 0.2s);
+    z-index: 30;
 
     @media screen and (max-width: 755px) {
       display: none;

--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -2,8 +2,9 @@ class CouponsController < ApplicationController
   def show
     if coupon.valid?
       session[:coupon] = coupon.code
+      flash[:notice] = t("coupons.flashes.success", code: coupon.code)
     else
-      flash[:notice] = "The coupon code you supplied is not valid."
+      flash[:error] = t("coupons.flashes.invalid")
     end
 
     redirect_to root_path

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -29,6 +29,10 @@
       </div>
     </section>
 
+    <div class="header-flash">
+      <%= render 'shared/flashes' %>
+    </div>
+
     <section class="content">
       <% if content_for?(:subject_block) %>
         <section class="subject"><%= yield(:subject_block) %></section>

--- a/app/views/subscriptions/_price.html.erb
+++ b/app/views/subscriptions/_price.html.erb
@@ -10,6 +10,7 @@
       technologies.</p>
       <%= link_to "Start Learning", new_checkout_path(plan: primary), :class => "signup" %>
       <%= link_to "Get Your Team Started", teams_path, :class => "signup grey" %>
+      <%= render 'shared/flashes' %>
     </div>
     <div class="price-includes">
       <h5>Includes</h5>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,11 @@ en:
       already_subscribed: You are already subscribed. You can change your plan.
       plan_not_found: We have a new subscription plan for you.
 
+  coupons:
+    flashes:
+      success: Your coupon %{code} was processed successfully. The discount will be applied at checkout.
+      invalid: The coupon code you supplied is not valid.
+
   subscriptions:
     accept_discounted_annual_subscription: Yes! I want to save $$$ and keep learning
     join_cta: See Pricing

--- a/spec/controllers/coupons_controller_spec.rb
+++ b/spec/controllers/coupons_controller_spec.rb
@@ -9,6 +9,9 @@ describe CouponsController do
         get :show, id: "5OFF"
 
         expect(session[:coupon]).to eq("5OFF")
+        expect(flash[:notice]).to(
+          eq I18n.t("coupons.flashes.success", code: "5OFF")
+        )
         expect(response).to redirect_to(root_path)
       end
     end
@@ -18,7 +21,7 @@ describe CouponsController do
         get :show, id: "5OFF"
 
         expect(session[:coupon]).to be_nil
-        expect(flash[:notice]).to include "is not valid"
+        expect(flash[:error]).to eq I18n.t("coupons.flashes.invalid")
         expect(response).to redirect_to(root_path)
       end
     end


### PR DESCRIPTION
https://trello.com/c/YFcKC7jP/588-when-i-have-followed-a-coupon-url-i-want-to-be-informed-about-the-coupon-so-that-i-know-that-i-will-get-it-when-i-check-out
- Add hard-coded flash notice to coupons controller
- Add flashes partial to landing layout
- Style/animate hero flash
- Style price block flash

![image](https://cloud.githubusercontent.com/assets/5003242/6171719/030ad1f4-b2a2-11e4-9ee1-f77d2b85d7e8.png)

![image](https://cloud.githubusercontent.com/assets/5003242/6171725/0a321898-b2a2-11e4-9aa2-89ea1c7c26c3.png)

Needs development:
- Use real coupon copy
- Fix broken test
