### PR TITLE
Increase z-index on tooltips.

### DIFF
--- a/app/assets/stylesheets/_tooltip.scss
+++ b/app/assets/stylesheets/_tooltip.scss
@@ -9,7 +9,7 @@
         pointer-events: none;
         position: absolute;
         top: 40px;
-        z-index: 1;
+        z-index: 2;
 
         &:before, &:after {
           @include triangle($arrow-size 8px, $base-border-color-1, up);


### PR DESCRIPTION
Fixes issue where "Completed Trails" text covers tooltip.
