### PR TITLE
All video tutorials are collections

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -69,10 +69,6 @@ class Product < ActiveRecord::Base
     github_team.present?
   end
 
-  def collection?
-    false
-  end
-
   def to_aside_partial
     "#{self.class.name.underscore.pluralize}/aside"
   end

--- a/app/models/video_tutorial.rb
+++ b/app/models/video_tutorial.rb
@@ -5,10 +5,6 @@ class VideoTutorial < Product
     Teacher.joins(:video).merge(videos).to_a.uniq(&:user_id)
   end
 
-  def collection?
-    published_videos.count > 1
-  end
-
   def included_in_plan?(plan)
     plan.has_feature?(:video_tutorials)
   end

--- a/app/views/videos/show_subscribed.html.erb
+++ b/app/views/videos/show_subscribed.html.erb
@@ -1,19 +1,13 @@
 <% content_for :page_title, @video.name.html_safe %>
 
-<% if @watchable.collection? %>
-  <% content_for :additional_header_links do %>
-    <li class="all-videos"><%= link_to 'All Videos', @video.watchable %></li>
-  <% end %>
+<% content_for :additional_header_links do %>
+  <li class="all-videos"><%= link_to 'All Videos', @video.watchable %></li>
 <% end %>
 
 <% content_for :subject_block do %>
   <h1><%= @video.watchable_name %></h1>
   <h2 class="tagline">
-    <% if @video.watchable.collection? %>
-      <%= @video.name %>
-    <% else %>
-      Watch or download video
-    <% end %>
+    <%= @video.name %>
   </h2>
 <% end %>
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -47,12 +47,6 @@ describe Product do
     end
   end
 
-  describe '#collection?' do
-    it 'returns false' do
-      expect(Product.new).not_to be_collection
-    end
-  end
-
   describe "#fulfill" do
     it "fulfills using GitHub with a GitHub team" do
       user = build_stubbed(:user)

--- a/spec/models/video_tutorial_spec.rb
+++ b/spec/models/video_tutorial_spec.rb
@@ -57,26 +57,6 @@ describe VideoTutorial do
     end
   end
 
-  describe "#collection?" do
-    it "is a collection if there is more than one published video" do
-      video_tutorial = create(:video_tutorial)
-      create_list(:video, 2, :published, watchable: video_tutorial)
-
-      expect(video_tutorial).to be_collection
-    end
-
-    it "is not a collection if there is 1 published video or less" do
-      video_tutorial = create(:video_tutorial)
-
-      expect(video_tutorial).not_to be_collection
-
-      create(:video, :published, watchable: video_tutorial)
-      create(:video, watchable: video_tutorial)
-
-      expect(video_tutorial).not_to be_collection
-    end
-  end
-
   describe "#teachers" do
     it "returns unique teachers from its videos" do
       only_first = create(:user, name: "only_first")


### PR DESCRIPTION
Because:
- We're converging on the trail concept
- It doesn't make sense to have a trail with one step

This commit:
- Assumes all video tutorials are collections
- Removes code checking for single-video tutorials

https://trello.com/c/tjhwKYew/605
