### PR TITLE
Merge video tutorial and exercise permissions

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -10,14 +10,14 @@ class HomesController < ApplicationController
   private
 
   def redirect_user_to_dashboard
-    if show_exercises?
+    if show_trails?
       redirect_to practice_path
     else
       redirect_to Show.the_weekly_iteration
     end
   end
 
-  def show_exercises?
-    current_user.subscription.nil? || current_user.has_access_to?(:exercises)
+  def show_trails?
+    current_user.subscription.nil? || current_user.has_access_to?(:trails)
   end
 end

--- a/app/controllers/video_tutorials_controller.rb
+++ b/app/controllers/video_tutorials_controller.rb
@@ -2,7 +2,7 @@ class VideoTutorialsController < ApplicationController
   def show
     @video_tutorial = VideoTutorial.friendly.find(params[:id])
 
-    if current_user_has_access_to?(:video_tutorials)
+    if current_user_has_access_to?(:trails)
       render "show_subscribed"
     end
   end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -12,7 +12,7 @@ module ProductsHelper
   end
 
   def completeable_link(url, options = {}, &block)
-    if current_user_has_access_to?(:exercises)
+    if current_user_has_access_to?(:trails)
       link_to url, options, &block
     else
       link_to edit_subscription_path, options, &block

--- a/app/helpers/resources_helper.rb
+++ b/app/helpers/resources_helper.rb
@@ -28,6 +28,6 @@ module ResourcesHelper
   end
 
   def features
-    %i(exercises shows video_tutorials)
+    %i(trails shows)
   end
 end

--- a/app/models/features/factory.rb
+++ b/app/models/features/factory.rb
@@ -1,9 +1,9 @@
 module Features
   class Factory
     GENERIC_FEATURES = %w(
-      exercises
       forum
       shows
+      trails
     )
     FULFILLABLE_FEATURES = %w(mentor repositories)
     ALL_FEATURES = GENERIC_FEATURES + FULFILLABLE_FEATURES

--- a/app/models/video_tutorial.rb
+++ b/app/models/video_tutorial.rb
@@ -6,6 +6,6 @@ class VideoTutorial < Product
   end
 
   def included_in_plan?(plan)
-    plan.has_feature?(:video_tutorials)
+    plan.has_feature?(:trails)
   end
 end

--- a/app/views/checkout_mailer/receipt.text.erb
+++ b/app/views/checkout_mailer/receipt.text.erb
@@ -5,7 +5,7 @@ You will receive an email from your mentor soon.
 <%- end -%>
 
 In the meantime, one of the first things you might do is visit our Trail Maps
-<%- if @checkout.plan.has_feature?(:video_tutorials) -%>
+<%- if @checkout.plan.has_feature?(:trails) -%>
 and check off your skills to determine which video tutorials are right for you:
 <%- else -%>
 and check off your skills to identify new things to learn:

--- a/app/views/exercises/_exercise_for_trail.html.erb
+++ b/app/views/exercises/_exercise_for_trail.html.erb
@@ -11,7 +11,7 @@
         <p><%= exercise.summary %></p>
       <% end %>
 
-      <% unless current_user_has_access_to?(:exercises) %>
+      <% unless current_user_has_access_to?(:trails) %>
         <%= render "products/locked" %>
       <% end %>
     </figure>

--- a/app/views/exercises/_exercise_for_trail_preview.html.erb
+++ b/app/views/exercises/_exercise_for_trail_preview.html.erb
@@ -6,7 +6,7 @@
     <p><%= exercise.summary %></p>
   <% end %>
 
-  <% unless current_user_has_access_to?(:exercises) %>
+  <% unless current_user_has_access_to?(:trails) %>
     <%= render "products/locked" %>
   <% end %>
 </figure>

--- a/app/views/videos/_video_for_trail.html.erb
+++ b/app/views/videos/_video_for_trail.html.erb
@@ -11,7 +11,7 @@
         <p><%= video.summary %></p>
       <% end %>
 
-      <% unless current_user_has_access_to?(:exercises) %>
+      <% unless current_user_has_access_to?(:trails) %>
         <%= render "products/locked" %>
       <% end %>
     </figure>

--- a/app/views/videos/_video_for_trail_preview.html.erb
+++ b/app/views/videos/_video_for_trail_preview.html.erb
@@ -6,7 +6,7 @@
     <p><%= video.summary %></p>
   <% end %>
 
-  <% unless current_user_has_access_to?(:exercises) %>
+  <% unless current_user_has_access_to?(:trails) %>
     <%= render "products/locked" %>
   <% end %>
 </figure>

--- a/db/migrate/20150225211138_merge_video_tutorial_and_exercise_permissions.rb
+++ b/db/migrate/20150225211138_merge_video_tutorial_and_exercise_permissions.rb
@@ -1,0 +1,20 @@
+class MergeVideoTutorialAndExercisePermissions < ActiveRecord::Migration
+  def up
+    add_column :plans, :includes_trails, :boolean, default: false, null: false
+    connection.update(<<-SQL)
+      UPDATE plans SET includes_trails = includes_video_tutorials
+    SQL
+    remove_column :plans, :includes_video_tutorials
+    remove_column :plans, :includes_exercises
+  end
+
+  def down
+    add_column :plans, :includes_exercises, :boolean, default: true, null: false
+    add_column :plans, :includes_video_tutorials, :boolean, default: true
+    connection.update(<<-SQL)
+      UPDATE plans SET includes_video_tutorials = includes_trails,
+                       includes_exercises = includes_trails
+    SQL
+    remove_column :plans, :includes_trails
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150219211138) do
+ActiveRecord::Schema.define(version: 20150225211138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,26 +149,25 @@ ActiveRecord::Schema.define(version: 20150219211138) do
   add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "plans", force: :cascade do |t|
-    t.string   "name",                                     null: false
-    t.string   "sku",                                      null: false
-    t.string   "short_description",                        null: false
-    t.text     "description",                              null: false
-    t.boolean  "active",                   default: true,  null: false
-    t.integer  "price",                                    null: false
+    t.string   "name",                                  null: false
+    t.string   "sku",                                   null: false
+    t.string   "short_description",                     null: false
+    t.text     "description",                           null: false
+    t.boolean  "active",                default: true,  null: false
+    t.integer  "price",                                 null: false
     t.text     "terms"
-    t.boolean  "includes_mentor",          default: false
-    t.boolean  "includes_video_tutorials", default: true
-    t.boolean  "featured",                 default: true,  null: false
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
-    t.boolean  "includes_exercises",       default: true,  null: false
-    t.boolean  "includes_repositories",    default: true,  null: false
-    t.boolean  "includes_forum",           default: true,  null: false
-    t.boolean  "includes_shows",           default: true,  null: false
-    t.boolean  "includes_team",            default: false, null: false
-    t.boolean  "annual",                   default: false
+    t.boolean  "includes_mentor",       default: false
+    t.boolean  "featured",              default: true,  null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "includes_repositories", default: true,  null: false
+    t.boolean  "includes_forum",        default: true,  null: false
+    t.boolean  "includes_shows",        default: true,  null: false
+    t.boolean  "includes_team",         default: false, null: false
+    t.boolean  "annual",                default: false
     t.integer  "annual_plan_id"
-    t.integer  "minimum_quantity",         default: 1,     null: false
+    t.integer  "minimum_quantity",      default: 1,     null: false
+    t.boolean  "includes_trails",       default: false, null: false
   end
 
   add_index "plans", ["annual_plan_id"], name: "index_plans_on_annual_plan_id", using: :btree

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -16,7 +16,7 @@ describe HomesController do
   end
 
   it "redirects to products if subscriber has access to exercises" do
-    plan = build_stubbed(:plan, includes_exercises: true)
+    plan = build_stubbed(:plan, includes_trails: true)
     subscriber = create(:user, :with_subscription, plan: plan)
     sign_in_as subscriber
 
@@ -27,7 +27,7 @@ describe HomesController do
 
   it "redirects to The Weekly Iteration if subscriber has no exercise access" do
     create(:show, name: Show::THE_WEEKLY_ITERATION)
-    plan = build_stubbed(:plan, includes_exercises: false)
+    plan = build_stubbed(:plan, includes_trails: false)
     subscriber = create(:user, :with_subscription, plan: plan)
     sign_in_as subscriber
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -108,13 +108,13 @@ FactoryGirl.define do
     sku "professional"
     short_description 'A great Subscription'
     description 'A long description'
+    includes_trails true
 
     factory :basic_plan do
       sku Plan::THE_WEEKLY_ITERATION_SKU
-      includes_exercises false
+      includes_trails false
       includes_forum false
       includes_repositories false
-      includes_video_tutorials false
     end
 
     trait :includes_mentor do
@@ -283,11 +283,10 @@ FactoryGirl.define do
         plan do
           create(
             :plan,
-            includes_exercises: true,
+            includes_trails: true,
             includes_forum: true,
             includes_mentor: true,
-            includes_repositories: true,
-            includes_video_tutorials: true
+            includes_repositories: true
           )
         end
       end

--- a/spec/features/subscriber_views_completed_trails_spec.rb
+++ b/spec/features/subscriber_views_completed_trails_spec.rb
@@ -1,12 +1,10 @@
-# coding: utf-8
 require "rails_helper"
 
 feature "Completed Trails" do
-  let(:user) { create(:subscriber) }
-
   scenario "subscriber navigates to completed trails" do
-    complete_trail = create_trail(completed_at: 1.week.ago)
-    just_finished_trail = create_trail(completed_at: 1.day.ago)
+    user = create(:subscriber, :with_full_subscription)
+    complete_trail = create_trail_completed_by(user, at: 1.week.ago)
+    just_finished_trail = create_trail_completed_by(user, at: 1.day.ago)
     sign_in_as user
 
     visit root_path
@@ -17,10 +15,10 @@ feature "Completed Trails" do
     expect(page).to have_content(just_finished_trail.name)
   end
 
-  def create_trail(completed_at:)
+  def create_trail_completed_by(user, at:)
     completed_exercise = create(:status, :completed, user: user).completeable
     trail = create(:trail, :published)
-    Timecop.travel(completed_at) do
+    Timecop.travel(at) do
       create(:status, :completed, completeable: trail, user: user)
     end
     create(:step, trail: trail, completeable: completed_exercise)

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -4,7 +4,7 @@ describe ProductsHelper do
   describe "#completeable_link" do
     context "with access to exercises" do
       it "renders a link to the exercise url" do
-        stub_access(exercises: true)
+        stub_access(trails: true)
         url = "http://example.com/some/exercise"
 
         result = helper.completeable_link(url, class: "amazing") { "text" }
@@ -15,7 +15,7 @@ describe ProductsHelper do
 
     context "without access to exercises" do
       it "renders a link to the change plan page" do
-        stub_access(exercises: false)
+        stub_access(trails: false)
         provided_url = "http://example.com"
         expected_url = edit_subscription_path
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -211,25 +211,25 @@ describe Subscription do
       it "returns false" do
         subscription = build_stubbed(:subscription, deactivated_on: Date.today)
 
-        expect(subscription).to_not have_access_to("video_tutorials")
+        expect(subscription).to_not have_access_to(:trails)
       end
     end
 
     context "when subscription is active but does not include feature" do
       it "returns false" do
-        plan = create(:plan, includes_video_tutorials: false)
+        plan = create(:plan, includes_trails: false)
         subscription = build_stubbed(:subscription, plan: plan)
 
-        expect(subscription).to_not have_access_to("video_tutorials")
+        expect(subscription).to_not have_access_to(:trails)
       end
     end
 
     context "when subscription is active and includes feature" do
       it "returns true" do
-        plan = create(:plan, includes_video_tutorials: true)
+        plan = create(:plan, includes_trails: true)
         subscription = build_stubbed(:subscription, plan: plan)
 
-        expect(subscription).to have_access_to("video_tutorials")
+        expect(subscription).to have_access_to(:trails)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -391,7 +391,7 @@ describe User do
       it "returns false" do
         user = build_stubbed(:user)
 
-        expect(user.has_access_to?("video_tutorials")).to_not be
+        expect(user).not_to have_access_to(:trails)
       end
     end
 
@@ -400,7 +400,7 @@ describe User do
         user = create(:subscriber)
         allow(user.subscription).to receive(:active?).and_return(false)
 
-        expect(user.has_access_to?("video_tutorials")).to_not be
+        expect(user).not_to have_access_to(:trails)
       end
     end
 
@@ -410,7 +410,7 @@ describe User do
         allow(user.subscription).to receive(:has_access_to?).
           and_return("expected")
 
-        expect(user.has_access_to?("video_tutorials")).to eq("expected")
+        expect(user.has_access_to?(:trails)).to eq("expected")
       end
     end
 
@@ -425,7 +425,7 @@ describe User do
         allow(user.team.subscription).to receive(:has_access_to?).
           and_return("expected")
 
-        expect(user.has_access_to?("video_tutorials")).to eq("expected")
+        expect(user.has_access_to?(:trails)).to eq("expected")
       end
     end
   end

--- a/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
+++ b/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "exercises/_exercise_for_trail_preview.html" do
   context "without access to exercises" do
     it "renders an upgrade link" do
-      stub_access(exercises: false)
+      stub_access(trails: false)
       stub_current_user
 
       render_exercise
@@ -14,7 +14,7 @@ describe "exercises/_exercise_for_trail_preview.html" do
 
   context "with access to exercises" do
     it "doesn't render an upgrade link" do
-      stub_access(exercises: true)
+      stub_access(trails: true)
       stub_current_user
 
       render_exercise

--- a/spec/views/practice/show.html.erb_spec.rb
+++ b/spec/views/practice/show.html.erb_spec.rb
@@ -17,38 +17,26 @@ describe "practice/show.html" do
 
   context "when a user has access to all features" do
     it "does not render the locked_features partial" do
-      render_show(
-        shows: true,
-        video_tutorials: true,
-        exercises: true
-      )
+      render_show shows: true, trails: true
 
       expect(rendered).not_to have_content("locked")
     end
   end
 
-  context "when a user has access to shows and video tutorials" do
-    it "renders locked features partial with exercises" do
-      render_show shows: true, video_tutorials: true
-
-      expect(rendered).to have_content("Exercises are locked")
-    end
-  end
-
   context "when a user has access to shows" do
     it "renders locked features partial with correct features" do
-      render_show shows: true
+      render_show shows: true, trails: false
 
-      text = "Exercises and video tutorials are locked"
+      text = "Trails are locked"
       expect(rendered).to have_content(text)
     end
   end
 
   context "when a user does not have access to any features" do
     it "renders locked features partial with all features" do
-      render_show
+      render_show shows: false, trails: false
 
-      text = "Exercises, shows, and video tutorials are locked"
+      text = "Trails and shows are locked"
       expect(rendered).to have_content(text)
     end
   end
@@ -80,8 +68,7 @@ describe "practice/show.html" do
       repositories: false,
       forum: false,
       shows: false,
-      video_tutorials: false,
-      exercises: false,
+      trails: false
     }
   end
 end


### PR DESCRIPTION
Because:
- We're merging video tutorials into video trails

This commit:
- Adds a new "includes_trails" permission
- Uses that instead of "video_tutorials" or "exercises"

https://trello.com/c/tjhwKYew/605
