### PR TITLE
Introduce NullShow object

### DIFF
--- a/app/models/null_show.rb
+++ b/app/models/null_show.rb
@@ -1,0 +1,4 @@
+class NullShow
+  def latest_video
+  end
+end

--- a/app/services/explore.rb
+++ b/app/services/explore.rb
@@ -6,7 +6,7 @@ class Explore
   end
 
   def show
-    Show.the_weekly_iteration
+    Show.the_weekly_iteration || NullShow.new
   end
 
   def latest_video_tutorial

--- a/spec/features/subscriber_explores_content_spec.rb
+++ b/spec/features/subscriber_explores_content_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 feature "Subscriber accesses content" do
   before do
-    show = create(:show, name: Show::THE_WEEKLY_ITERATION)
-    create(:video, watchable: show)
     create(:video_tutorial)
   end
 

--- a/spec/models/null_show_spec.rb
+++ b/spec/models/null_show_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe NullShow do
+  describe "#latest_video" do
+    it "it returns nil" do
+      result = NullShow.new.latest_video
+
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/services/explore_spec.rb
+++ b/spec/services/explore_spec.rb
@@ -2,14 +2,29 @@ require "rails_helper"
 
 describe Explore do
   describe "#show" do
-    it "returns The Weekly Iteration" do
-      user = double
-      twi_show = double
-      allow(Show).to receive(:the_weekly_iteration).and_return(twi_show)
+    context "when The Weekly Iteration exits" do
+      it "returns it" do
+        user = double
+        the_weekly_iteration = double
+        allow(Show).to(
+          receive(:the_weekly_iteration).and_return(the_weekly_iteration)
+        )
 
-      show = Explore.new(user).show
+        show = Explore.new(user).show
 
-      expect(show).to eq(twi_show)
+        expect(show).to eq(the_weekly_iteration)
+      end
+    end
+
+    context "when The Weekly Iteration does not exist" do
+      it "returns a NullShow" do
+        user = double
+        allow(Show).to receive(:the_weekly_iteration).and_return(nil)
+
+        show = Explore.new(user).show
+
+        expect(show).to be_a NullShow
+      end
     end
   end
 


### PR DESCRIPTION
Previously, any test that hit the Explore page needed to create a Show
in the database with a particular name ("The Weekly Iteration").

Instead, this commit returns a NullShow if that record cannot be found.
