### PR TITLE
Turn off `simplecov` by default

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 APP_DOMAIN=example.com
-COVERAGE=true
 SECRET_KEY_BASE=test_secret
 SUPPORT_EMAIL=help@example.com
 CLEARANCE_COOKIE_NAME=upcase_remember_token


### PR DESCRIPTION
If you want to generate coverage, simply run

```
$ CONVERAGE=1 bin/rake
```
