### PR TITLE
WIP -   Make /practice user-specific and show latest weekly iteration

### DIFF
--- a/app/assets/stylesheets/_tile.scss
+++ b/app/assets/stylesheets/_tile.scss
@@ -74,6 +74,10 @@
   }
 }
 
+.tiles p {
+  margin-bottom: 40px;
+}
+
 .resources-index .tiles-container .tile {
   height: 280px;
 

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -336,7 +336,7 @@ $not-started-dot-color: #D8D8D8;
 
   .complete {
     width: 47%;
-    border: 10px solid $gray-5;
+    box-shadow: 0 0 0 1px $gray-4;
     height: $card-height;
     margin: 0 0 30px;
     padding: $card-padding;
@@ -344,10 +344,6 @@ $not-started-dot-color: #D8D8D8;
 
     .trail {
       padding: 0;
-    }
-
-    header, p {
-      text-align: center;
     }
 
     .topic-label {
@@ -369,7 +365,7 @@ $not-started-dot-color: #D8D8D8;
     }
 
     ul {
-      left: 10px;
+      left: 20px;
       list-style-type: none;
       margin-left: 0;
       position: absolute;
@@ -381,7 +377,7 @@ $not-started-dot-color: #D8D8D8;
       display: inline-block;
 
       &:before {
-        height: 3px;
+        height: 2px;
         background: $gray-5;
       }
 
@@ -396,7 +392,7 @@ $not-started-dot-color: #D8D8D8;
           display: block;
           background: $gray-5;
           content: "";
-          height: 3px;
+          height: 2px;
           position: absolute;
           right: 50%;
           top: 48%;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -60,3 +60,7 @@
 @import "landing/testimonials";
 
 @import "prettify";
+
+.new-user-state {
+  border: thin solid red;
+}

--- a/app/assets/stylesheets/topics.scss.erb
+++ b/app/assets/stylesheets/topics.scss.erb
@@ -29,4 +29,8 @@
     background: <%= topic.color %>;
     color: <%= topic.color_accent %>;
   }
+
+  .trails-progress .complete {
+    border-top: 10px solid <%= topic.color %>;
+  }
 <% end %>

--- a/app/views/completed_trails/_trail.html.erb
+++ b/app/views/completed_trails/_trail.html.erb
@@ -4,7 +4,6 @@
   <div class="complete">
     <section class="trail <%= topic_class(trail.topic) %>">
       <header>
-        <span class="topic-label"><%= trail.topic.name %></span>
         <h1><%= link_to trail.name, trail %></h1>
         <p><%= trail.complete_text %></p>
       </header>

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -11,9 +11,9 @@
       <section class="subject">
         <h1>Welcome, <%= current_user.first_name %>.</h1>
         <h2>
-          These new trails are focused exercises targeting your interests. They
-          help you learn by doing and keep your skillset sharp.
+          Here's where you left off...
         </h2>
+        <h2 class="new-user-state">Get started with Upcase trails to keep your programming skills sharp! Trails are made of videos and exercises, so you can learn by watching and doing.</h2>
       </section>
 
       <% if @practice.active_trails.any? %>
@@ -22,6 +22,29 @@
             <h4 class="text">Your Trails</h4>
           </span>
           <%= render partial: "practice/active_trail", collection: @practice.active_trails, as: :trail %>
+          <div class="new-user-state">
+            <p>You haven't started any trails yet. What are you interested in practicing?</p>
+            <section class="trail-titles">
+              <ul>
+                <li class="design">
+                  <a href="">Trail Link</a>
+                </li>
+                <li class="haskell">
+                  <a href="">Trail Link</a>
+                </li>
+                <li class="rails">
+                  <a href="">Trail Link</a>
+                </li>
+                <li class="ios">
+                  <a href="">Trail Link</a>
+                </li>
+                <li class="testing">
+                  <a href="">Trail Link</a>
+                </li>
+              </ul>
+            </section>
+          </div>
+          <p>Not sure what you want? <a href="/explore">Explore</a> everything Upcase has to offer.</p>
         </section>
       <% end %>
 
@@ -35,16 +58,20 @@
           </section>
         </section>
       <% end %>
-
-      <footer>
-        <% if @practice.has_completed_trails? %>
-          <p>
-            <%= link_to completed_trails_path do %>
-              View completed trails &rarr;
-            <% end %>
-          </p>
-        <% end %>
-      </footer>
+    </section>
+        <section class="weekly-iteration tiles">
+      <span class="divider">
+        <h4 class="text">The Weekly Iteration</h4>
+      </span>
+      <p>See what we're talking about each week on <a href="">The Weekly Iteration &rarr;</a></p>
+      <ul>
+        <li class="tile show ios">
+          <h2>Latest episode</h2>
+          <h1><a href="">Swift Fundamentals</a></h1>
+          <p class="description">This is the episode tagline.</p>
+          <a class="cta" href="">View Episode</a>
+        </li>
+      </ul>
     </section>
   </div>
 </section>


### PR DESCRIPTION
Right now, we show all trails on /practice, but we want this page to
show only content that is relevant to the user - Trails she has started,
trails she has completed, and the latest episode of the weekly
iteration.
- Only show trails a user has started or done
- Show different copy, and show all trails for a new user who hasn't started anything.
- Show latest weekly iteration
- Add topic color border to completed trail cards
  https://trello.com/c/XOvqPlUY/640-let-s-improve-what-s-above-the-fold-on-the-practice-page

Here's what this branch looks like - red border indicates the blank slate/new user/no trails started state. The new-user-state class was just added to point out what styles should be shown, and can be removed once it is implemented.
![practice_new](https://cloud.githubusercontent.com/assets/2343392/6334488/cf17c568-bb49-11e4-8fe8-ca9add57f734.png)

This PR shows the design with placeholder markup and is ready for development.
