### PR TITLE
Clear scheduled_for_cancellation_on when a user changed their plan

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -55,6 +55,7 @@ class Subscription < ActiveRecord::Base
   def write_plan(sku:)
     update_features do
       self.plan = Plan.find_by!(sku: sku)
+      self.scheduled_for_cancellation_on = nil
       save!
       track_updated
     end

--- a/spec/features/user_renews_subscription_spec.rb
+++ b/spec/features/user_renews_subscription_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+feature "User renews a subscription" do
+  scenario "when already deactivated" do
+    create(:trail, :published)
+    create(:basic_plan)
+    user = create(:user, :with_inactive_subscription)
+
+    sign_in_as user
+    visit join_path
+    click_link "Start Learning"
+
+    fill_out_credit_card_form_with_valid_credit_card
+    expect(user.subscriptions.count).to eq 2
+  end
+
+  scenario "when scheduled_for_cancellation_on but not deactivated yet" do
+    create(:trail, :published)
+    create(:basic_plan)
+    user = create(:subscriber)
+    Cancellation.new(user.subscription, "reason").schedule
+
+    sign_in_as user
+    visit new_checkout_path(plan: user.plan)
+    click_link "Start learning"
+
+    expect(page).to have_content(I18n.t("subscriptions.flashes.change.success"))
+    expect(user.subscriptions.count).to eq 1
+
+    visit "/my_account"
+    expect(page).to have_no_content("Scheduled for cancellation on")
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -172,6 +172,7 @@ describe Subscription do
       subscription.write_plan(sku: different_plan.sku)
 
       expect(subscription.plan).to eq different_plan
+      expect(subscription.scheduled_for_cancellation_on).to be_nil
     end
 
     it "fulfills features gained by the new plan" do


### PR DESCRIPTION
For example, when we have a subscriber that cancels their plan, which is not
actually deactivated until the end of the subscription period. Then the user
changes their mind, and change their plan again to a different plan, but
their subscription still has scheduled_for_cancellation_on set and being
displayed on their account page.

I'm also thinking that we might not need these feature tests, if we are testing that the attribute is being cleared in the model.

But am thinking that we will need a rake task to clean scheduled_for_cancellation_on values like in the case of Jade.

Trello: https://trello.com/c/SFZSEQz4
