### PR TITLE
Move upcoming charge copy on team#edit

### DIFF
--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -6,12 +6,19 @@
 <div class="text-box-wrapper solo">
   <div class="text-box">
     <h4>
+      Upcoming Charge
+    </h4>
+
+    <span>
+      Your next charge will be on
+      <%= @team.subscription.next_payment_on.to_s(:simple) %> for
+      <%= number_to_currency(@team.subscription.next_payment_amount_in_dollars) %>
+    </span>
+  </div>
+
+  <div class="text-box">
+    <h4>
       Members
-      <span>
-        - Your next charge will be on
-        <%= @team.subscription.next_payment_on.to_s(:simple) %> for
-        <%= number_to_currency(@team.subscription.next_payment_amount_in_dollars) %>
-      </span>
     </h4>
 
     <ul class="members">


### PR DESCRIPTION
Styling looked a little funky on the upcoming charge copy. Moved it.

Before:
![screen shot 2015-03-25 at 5 11 00 pm](https://cloud.githubusercontent.com/assets/46677/6835565/0e7386c2-d312-11e4-9ba4-d2a33470c562.png)

After:
![screen shot 2015-03-25 at 5 10 22 pm](https://cloud.githubusercontent.com/assets/46677/6835564/0e731e12-d312-11e4-9252-a2b5fc44b95d.png)
