### PR TITLE
Remove teacher details from trail partial

### DIFF
--- a/app/views/trails/_incomplete_trail.html.erb
+++ b/app/views/trails/_incomplete_trail.html.erb
@@ -3,8 +3,6 @@
     <header>
       <span class="topic-label"><%= trail.topic %></span>
       <h1><%= link_to trail, trail %></h1>
-      <%= render trail.teachers %>
-      <p class="teacher-name"><%= teacher_names trail.teachers %></p>
       <p class="description"><%= trail.description %></p>
       <%= render "practice/trail_description_tooltip", trail: trail %>
     </header>


### PR DESCRIPTION
Styling hasn't really been worked out for these details, making the
practice page look odd.

**Before:**
![screen shot 2015-03-26 at 1 45 25 pm](https://cloud.githubusercontent.com/assets/46677/6853070/0f3580a8-d3bf-11e4-86f1-95d41b5bde18.png)

**After:**
![screen shot 2015-03-26 at 1 45 16 pm](https://cloud.githubusercontent.com/assets/46677/6853079/20ab37d8-d3bf-11e4-8b7f-6e1633683731.png)
