### PR TITLE
Sort started trails to the top on /practice

### DIFF
--- a/app/services/practice.rb
+++ b/app/services/practice.rb
@@ -12,7 +12,7 @@ class Practice
   end
 
   def incomplete_trails
-    trails.select(&:incomplete?)
+    trails.select(&:incomplete?).partition(&:in_progress?).flatten
   end
 
   private

--- a/spec/services/practice_spec.rb
+++ b/spec/services/practice_spec.rb
@@ -67,5 +67,19 @@ describe Practice do
 
       expect(practice.incomplete_trails).to be_empty
     end
+
+    context "sorting" do
+      it "returns all started trails before any unstarted trails" do
+        user = build_stubbed(:user)
+        started_trail = create(:trail, :published, name: "Started")
+        create(:status, completeable: started_trail, user: user)
+        create(:trail, :published, name: "Unstarted")
+        practice = Practice.new(user)
+
+        result = practice.incomplete_trails
+
+        expect(result.map(&:name)).to eq(["Started", "Unstarted"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently we're simply interleaving started and unstarted trails on `/practice`. This looks a bit jumbled and confusing.

This commit sorts trails so that started trails appear first, then unstarted trails, then complete trails.

**Before:**
![screen shot 2015-03-26 at 2 27 12 pm](https://cloud.githubusercontent.com/assets/46677/6853908/3fcfe01e-d3c4-11e4-8e9d-b0be7beb459b.png)

**After:**
![screen shot 2015-03-26 at 2 27 02 pm](https://cloud.githubusercontent.com/assets/46677/6853912/432ff28a-d3c4-11e4-8581-639f99ce5e7e.png)
