### PR TITLE
Tell signed-out users to sign up. Signed-in to upgrade.

### DIFF
--- a/app/views/exercises/_exercise_for_trail.html.erb
+++ b/app/views/exercises/_exercise_for_trail.html.erb
@@ -10,10 +10,6 @@
         <h4><%= exercise.name %></h4>
         <p><%= exercise.summary %></p>
       <% end %>
-
-      <% unless current_user_has_access_to?(:trails) %>
-        <%= render "products/locked" %>
-      <% end %>
     </figure>
   </div>
 </div>

--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -2,7 +2,14 @@
   <span class="icon">
     <%= image_tag("icons/lock.svg", size: "11x15") %>
   </span>
-  <%= link_to 'Get access by upgrading',
-              edit_subscription_path,
-              class: 'upgrade-link' %>
+
+  <% if signed_in? %>
+    <%= link_to 'Get access by upgrading',
+      edit_subscription_path,
+      class: 'upgrade-link' %>
+  <% else %>
+    <%= link_to 'Get access by joining Upcase',
+      join_path,
+      class: 'upgrade-link' %>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,7 +105,7 @@ en:
     reason: Why have you decided to leave?
     reason_explanation: This information will help us make Upcase better for future members.
     change_plan: Change plan
-    choose_plan_html: Start learning
+    choose_plan: Switch Plan
     current_plan_html: <p class="current-plan">This is your current plan</p>
     cancellation_scheduled_on: Scheduled for cancellation on %{date}
     discount:

--- a/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
+++ b/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "exercises/_exercise_for_trail_preview.html" do
   context "without access to exercises" do
     it "renders an upgrade link" do
       stub_access(trails: false)
-      stub_current_user
+      stub_signed_in
 
       render_exercise
 
@@ -15,7 +15,7 @@ describe "exercises/_exercise_for_trail_preview.html" do
   context "with access to exercises" do
     it "doesn't render an upgrade link" do
       stub_access(trails: true)
-      stub_current_user
+      stub_signed_in
 
       render_exercise
 
@@ -29,8 +29,8 @@ describe "exercises/_exercise_for_trail_preview.html" do
     end
   end
 
-  def stub_current_user
-    view_stubs(:current_user).and_return(build_stubbed(:user))
+  def stub_signed_in
+    view_stubs(:signed_in?).and_return(true)
   end
 
   def render_exercise

--- a/spec/views/products/_locked.html.erb_spec.rb
+++ b/spec/views/products/_locked.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "products/_locked" do
+  context "when the user is signed in" do
+    it "encourages them to upgrade" do
+      stub_signed_in_with(build_stubbed(:user))
+
+      render partial: "products/locked"
+
+      expect(rendered).to include("Get access by upgrading")
+    end
+  end
+
+  context "when the user is not signed in" do
+    it "encourages them to join" do
+      stub_signed_in_with(nil)
+
+      render partial: "products/locked"
+
+      expect(rendered).to include("Get access by joining Upcase")
+      expect(rendered).to have_css("a[href='#{join_path}']")
+    end
+  end
+
+  def stub_signed_in_with(value)
+    view_stubs(:signed_in?).and_return(value)
+  end
+end


### PR DESCRIPTION
Additionally:
- Remove CTA on exercise hover. It's unstyled and rarely seen anyway.
- Change wording on plan change buttons. Users have reported
  accidentally changing their plan, which is reasonble since the CTA
  isn't very clear.
