### PR TITLE
Fix missing translation

### DIFF
--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -44,7 +44,7 @@ module CheckoutsHelper
 
   def change_plan_link(plan)
     if current_user.plan == plan
-      I18n.t("subscriptions.current_plan_html").html_safe
+      t("subscriptions.current_plan_html")
     else
       update_plan_link(plan)
     end
@@ -52,7 +52,7 @@ module CheckoutsHelper
 
   def update_plan_link(plan)
     link_to(
-      I18n.t("subscriptions.choose_plan_html").html_safe,
+      t("subscriptions.choose_plan"),
       subscription_path(plan_id: plan),
       method: :put,
       class: "sign-up"
@@ -61,7 +61,7 @@ module CheckoutsHelper
 
   def new_plan_link(plan)
     link_to(
-      I18n.t("subscriptions.choose_plan_html").html_safe,
+      t("subscriptions.choose_plan_html"),
       new_checkout_path(plan),
       class: "sign-up"
     )

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -142,7 +142,7 @@ feature "User creates a subscription" do
 
     click_link I18n.t("subscriptions.change_plan")
     within("[data-sku='#{new_plan.sku}']") do
-      click_link I18n.t("subscriptions.choose_plan_html")
+      click_link I18n.t("subscriptions.choose_plan")
     end
 
     expect(current_path).to eq my_account_path


### PR DESCRIPTION
Also convert helpers to use `t` instead of `I18n.t`, which adds behavior
like raising an exception for missing translations and automatic HTML
safing.
