### PR TITLE
Update a user's card when they sign up again

### DIFF
--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -34,11 +34,3 @@ $('.reveal-address').click(function() {
 
   return false;
 });
-
-$(document).ready(function(){
-  $(".use_existing_card").click(function(event){
-    $("#checkout_cc_input").toggle();
-    $("#checkout_expiration_input").toggle();
-    $("#checkout_cvc_input").toggle();
-  });
-});

--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -88,14 +88,6 @@ body.checkouts-new, body.checkouts-create {
           white-space: normal;
         }
       }
-
-      &#checkout_cc_existing {
-        width: auto;
-
-        label {
-          width: auto;
-        }
-      }
     }
   }
 
@@ -235,11 +227,6 @@ body.checkouts-new, body.checkouts-create {
         clear: left;
       }
 
-      &#checkout_cc_existing {
-        input, label {
-          display: inline-block;
-        }
-      }
     }
   }
 }

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -114,8 +114,4 @@ class CheckoutsController < ApplicationController
   def plan
     Plan.find_by(sku: params[:plan])
   end
-
-  def using_existing_card?
-    params[:use_existing_card] == "on"
-  end
 end

--- a/app/models/stripe_subscription.rb
+++ b/app/models/stripe_subscription.rb
@@ -25,9 +25,16 @@ class StripeSubscription
   end
 
   def ensure_customer_exists
-    unless customer_exists?
+    if customer_exists?
+      update_card
+    else
       create_customer
     end
+  end
+
+  def update_card
+    stripe_customer.card = @checkout.stripe_token
+    stripe_customer.save
   end
 
   def customer_exists?

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -39,14 +39,6 @@
       <%= image_tag "icons/discover.png" %>
     </li>
     <li class="payment-errors"></li>
-    <% if signed_in? && current_user.credit_card %>
-      <li id="checkout_cc_existing" class="stripe">
-        <input type="checkbox" id="use_existing_card" name="use_existing_card" class="use_existing_card" />
-        <label for="use_existing_card">
-          Use existing card (<%= display_card_type(current_user.credit_card["type"]) %> ending in <%= current_user.credit_card["last4"] %>)
-        </label>
-      </li>
-    <% end %>
     <li id="checkout_cc_input" class="stripe">
       <label for='card-number'>Card Number</label>
       <input type='text' size='20' autocomplete='off' id='card-number' class='card-number'/>

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -48,10 +48,6 @@
       $("input.github_username[required]").each(checkUsername);
 
       if($('li.error .github_username').length == 0) {
-        if($("input.use_existing_card").is(":checked")) {
-          return true;
-        }
-
         // disable the submit button to prevent repeated clicks
         $('fieldset.actions input').prop("disabled", true);
         <% unless Rails.env.test? %>

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -185,15 +185,6 @@ feature "User creates a subscription" do
     expect(page).not_to have_content("Your Billing Info")
   end
 
-  scenario "User subscribes with an existing credit card", js: true do
-    user = create(:user, :with_github, stripe_customer_id: "test")
-
-    visit new_checkout_path(@plan, as: user)
-    pay_using_stripe_with_existing_card
-
-    expect_to_see_checkout_success_flash_for(@plan.name)
-  end
-
   def visit_plan_checkout_page
     visit new_checkout_path(@plan)
   end

--- a/spec/support/stripe_helpers.rb
+++ b/spec/support/stripe_helpers.rb
@@ -1,9 +1,4 @@
 module StripeHelpers
-  def pay_using_stripe_with_existing_card
-    find(:css, "input.use_existing_card").set(true)
-    click_button 'Submit Payment'
-  end
-
   def stub_stripe_to_fail
     FakeStripe.failure = true
   end


### PR DESCRIPTION
This fixes a bug for users who sign up, cancel, and try to sign up
again.

Before this fix, we attempted to charge their _old_, original
card, even when they provided a new one for us to use. This led to
confusing errors like us reporting that someone's clearly-not-expired
card was.

Additionally, this commit removes the ability for users to sign up a
second time using the a card we have on file for them. That
functionality is not well-supported by our Stripe fake, and made the
completion of this bugfix substantially more difficult. Users who are
signing up a second time after canceling will have to enter their card
again. I'm comfortable removing this since it simplifies a very complex
part of the codebase, and the functionality lost benefits a small
portion of members.

https://trello.com/c/VljVeZS3/8
