### PR TITLE
Filter out gems from backtraces

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -2,10 +2,9 @@ SHOULDA_NOISE      = %w( shoulda )
 FACTORY_GIRL_NOISE = %w( factory_girl )
 THOUGHTBOT_NOISE   = SHOULDA_NOISE + FACTORY_GIRL_NOISE
 
-Rails.backtrace_cleaner.add_silencer do |line| 
+Rails.backtrace_cleaner.add_silencer do |line|
   THOUGHTBOT_NOISE.any? { |dir| line.include?(dir) }
 end
 
 # When debugging, uncomment the next line.
 # Rails.backtrace_cleaner.remove_silencers!
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.backtrace_exclusion_patterns << %r{/gems/}
 end


### PR DESCRIPTION
- Also remove whitespace in `backtrace_silencers.rb`
