### PR TITLE
Make GitHub username a required attribute on User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true
   validates :mentor_id, presence: true, if: :has_subscription_with_mentor?
-  validates :github_username, uniqueness: { allow_blank: true }
+  validates :github_username, uniqueness: true, presence: true
 
   delegate :email, to: :mentor, prefix: true, allow_nil: true
   delegate :first_name, to: :mentor, prefix: true, allow_nil: true

--- a/db/migrate/20150410155813_add_null_constraint_for_github_username.rb
+++ b/db/migrate/20150410155813_add_null_constraint_for_github_username.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintForGithubUsername < ActiveRecord::Migration
+  def change
+    change_column :users, :github_username, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410153006) do
+ActiveRecord::Schema.define(version: 20150410155813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,7 +313,7 @@ ActiveRecord::Schema.define(version: 20150410153006) do
     t.string   "reference"
     t.boolean  "admin",                          default: false, null: false
     t.string   "stripe_customer_id",             default: "",    null: false
-    t.string   "github_username"
+    t.string   "github_username",                                null: false
     t.string   "auth_provider"
     t.integer  "auth_uid"
     t.string   "organization"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -226,6 +226,7 @@ FactoryGirl.define do
     email
     name
     password 'password'
+    github_username
 
     transient do
       subscription nil

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -26,15 +26,6 @@ feature "User creates a subscription" do
     expect_submit_button_to_contain("per year")
   end
 
-  scenario "user without github username sees github username input" do
-    current_user.github_username = nil
-    current_user.save!
-
-    visit_plan_checkout_page
-
-    expect(page).to have_github_input
-  end
-
   scenario "user with address has invoice address fields prepopulated" do
     current_user.update!(
       address1: "742 Evergreen Terrace",
@@ -171,18 +162,6 @@ feature "User creates a subscription" do
     find(".video_tutorial > a").click
 
     expect(page).not_to have_link("Subscribe to #{plan.name}")
-  end
-
-  scenario "existing user tries to subscribe with duplicate github", js: true do
-    create(:user, github_username: "taken")
-    user = create(:user)
-
-    visit new_checkout_path(@plan, as: user)
-    fill_in "GitHub username", with: "taken"
-    fill_out_subscription_form_with_valid_credit_card
-
-    expect(page).to have_content("has already been taken")
-    expect(page).not_to have_content("Your Billing Info")
   end
 
   def visit_plan_checkout_page

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -69,13 +69,13 @@ describe Checkout do
       expect(checkout.user).to be_persisted
     end
 
-    it "saves github_username to the user" do
-      user = create(:user, github_username: nil)
-      checkout = build(:checkout, user: user, github_username: "tbot")
+    it "updates github_username on the user" do
+      user = create(:user, github_username: "old")
+      checkout = build(:checkout, user: user, github_username: "new")
 
       checkout.fulfill
 
-      expect(user.github_username).to eq "tbot"
+      expect(user.github_username).to eq "new"
     end
 
     it "requires a unique GitHub username if there is no user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,11 +5,12 @@ describe User do
     it { should belong_to(:mentor) }
     it { should belong_to(:team) }
     it { should have_many(:subscriptions).dependent(:destroy) }
-    it { should validate_uniqueness_of(:github_username) }
   end
 
   context "validations" do
     it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:github_username) }
+    it { should validate_uniqueness_of(:github_username) }
   end
 
   context "with a subscription that includes a mentor" do
@@ -36,16 +37,6 @@ describe User do
 
       user_with_multi_part_last_name = User.new(name: "First van der Last")
       expect(user_with_multi_part_last_name.last_name).to eq "van der Last"
-    end
-  end
-
-  context "#github_username" do
-    it "doesn't raise DB exception when saving empty strings" do
-      create(:user, github_username: "")
-      user = build(:user, github_username: "")
-
-      expect(user.save).to be true
-      expect(user.github_username).to be nil
     end
   end
 

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -11,7 +11,6 @@ module CheckoutHelpers
   end
 
   def fill_out_subscription_form_with(credit_card_number)
-    fill_in 'GitHub username', with: 'cpytel'
     fill_out_credit_card_form_with(credit_card_number)
   end
 


### PR DESCRIPTION
This validation codifies something that was already mostly enforced.
When someone signs up for a subscription, we already require a unique GH
username. This just enforces it more strongly.

There were some User records in production who didn't have usernames.
They were mostly old and never subscribed, which suggests they were from
the days when we saved progress on the original trails, or authenticated
against Upcase for Carnival. I saved a backup and then deleted these
users.

There are a small handful (~20) of users with subscriptions who don't
have usernames specified. I'm updating them with GitHub usernames after
googling them. For people who I can't find, I'll email.

I think we can merge this change now and finish making all the User
records valid later.
