### PR TITLE
Continue trail redirect

### DIFF
--- a/app/controllers/exercise_trails_controller.rb
+++ b/app/controllers/exercise_trails_controller.rb
@@ -1,0 +1,17 @@
+class ExerciseTrailsController < ApplicationController
+  def show
+    trail = exercise.trail
+
+    if trail.present?
+      redirect_to trail, status: :moved_permanently
+    else
+      redirect_to root_path, notice: t(".no_trail")
+    end
+  end
+
+  private
+
+  def exercise
+    Exercise.find_by!(uuid: params[:exercise_id])
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -2,8 +2,8 @@ class Exercise < ActiveRecord::Base
   has_many :classifications, as: :classifiable, dependent: :destroy
   has_many :statuses, as: :completeable, dependent: :destroy
   has_many :topics, through: :classifications
-  has_many :trails, through: :steps, as: :completeables
-  has_many :steps, dependent: :destroy, as: :completeable
+  has_one :trail, through: :step, as: :completeables
+  has_one :step, dependent: :destroy, as: :completeable
 
   validates :name, presence: true
   validates :url, presence: true

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,11 +4,11 @@ class Video < ActiveRecord::Base
   belongs_to :watchable, polymorphic: true
   has_many :classifications, as: :classifiable
   has_many :statuses, as: :completeable, dependent: :destroy
-  has_many :steps, as: :completeable, dependent: :destroy
   has_many :teachers, dependent: :destroy
   has_many :topics, through: :classifications
-  has_many :trails, through: :steps
   has_many :users, through: :teachers
+  has_one :step, as: :completeable, dependent: :destroy
+  has_one :trail, through: :step
 
   validates :published_on, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/app/services/status_updater.rb
+++ b/app/services/status_updater.rb
@@ -6,7 +6,7 @@ class StatusUpdater
 
   def update_state(state)
     create_status(state)
-    update_trails
+    update_trail
   end
 
   protected
@@ -19,7 +19,10 @@ class StatusUpdater
     Status.create!(completeable: completeable, user: user, state: state)
   end
 
-  def update_trails
-    completeable.trails.each { |trail| trail.update_state_for(user) }
+  def update_trail
+    trail = completeable.trail
+    if trail.present?
+      trail.update_state_for(user)
+    end
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -140,7 +140,7 @@ RailsAdmin.config do |config|
 
       field :public
       field :topics
-      field :trails
+      field :trail
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,12 +12,15 @@ en:
     meta_description: 'Video Tutorials, and videos to help you learn web design and development.'
     app_name: 'Upcase'
 
+  exercist_trails:
+    show:
+      no_trail: "No trail found for the exercise."
 
   exercises:
     statuses:
       next-up: "Exercise"
       unstarted: "Exercise"
-      in_progress: "In Progress"
+      in-progress: "In Progress"
       complete: "Complete"
 
   formtastic:
@@ -159,7 +162,7 @@ en:
     statuses:
       next-up: "Video"
       unstarted: "Video"
-      in_progress: "In Progress"
+      in-progress: "In Progress"
       complete: "Complete"
 
   watchables:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Upcase::Application.routes.draw do
   draw :admin
   draw :api
   draw :clearance
+  draw :exercises
   draw :pages
   draw :plan
   draw :podcasts

--- a/config/routes/exercises.rb
+++ b/config/routes/exercises.rb
@@ -1,0 +1,3 @@
+resources :exercises, only: [] do
+  resource :trail, controller: "exercise_trails", only: [:show]
+end

--- a/db/migrate/20150415145819_add_unique_index_to_steps_on_trail_and_completeable.rb
+++ b/db/migrate/20150415145819_add_unique_index_to_steps_on_trail_and_completeable.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToStepsOnTrailAndCompleteable < ActiveRecord::Migration
+  def up
+    add_index :steps,
+              [:trail_id, :completeable_id, :completeable_type],
+              name: "index_steps_on_trail_and_completeable_unique",
+              unique: true
+    remove_index :steps, :trail_id
+  end
+
+  def down
+    add_index :steps, :trail_id
+    remove_index :steps, name: "index_steps_on_trail_and_completeable_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410155813) do
+ActiveRecord::Schema.define(version: 20150415145819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -238,8 +238,8 @@ ActiveRecord::Schema.define(version: 20150410155813) do
     t.string   "completeable_type", null: false
   end
 
+  add_index "steps", ["trail_id", "completeable_id", "completeable_type"], name: "index_steps_on_trail_and_completeable_unique", unique: true, using: :btree
   add_index "steps", ["trail_id", "position"], name: "index_steps_on_trail_id_and_position", using: :btree
-  add_index "steps", ["trail_id"], name: "index_steps_on_trail_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|
     t.integer  "user_id"

--- a/spec/controllers/exercise_trails_controller_spec.rb
+++ b/spec/controllers/exercise_trails_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe ExerciseTrailsController do
+  include StubCurrentUserHelper
+
+  describe "#show" do
+    context "with a recognized exercise" do
+      it "should redirect to trail page" do
+        trail = create(:trail)
+        exercise = create(:exercise)
+        trail.exercises << exercise
+
+        get :show, exercise_id: exercise.uuid
+
+        expect(response).to redirect_to(trail)
+      end
+    end
+
+    context "with an unrecognized exercise" do
+      it "returns a 404" do
+        expect { get :show, exercise_id: "not-a-real-id" }.
+          to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with an exercise not associated to a trail" do
+      it "redirects to the root with a notice" do
+        exercise = create(:exercise)
+
+        get :show, exercise_id: exercise.uuid
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq(no_trail_notice)
+      end
+    end
+
+    def no_trail_notice
+      I18n.t("exercise_trails.show.no_trail")
+    end
+  end
+end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -5,8 +5,8 @@ describe Exercise do
   it { should validate_presence_of(:url) }
   it { should have_many(:classifications) }
   it { should have_many(:topics).through(:classifications) }
-  it { should have_many(:trails).through(:steps) }
-  it { should have_many(:steps).dependent(:destroy) }
+  it { should have_one(:trail).through(:step) }
+  it { should have_one(:step).dependent(:destroy) }
 
   describe ".ordered" do
     it "returns older exercises first" do

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -4,11 +4,11 @@ describe Video do
   it { should belong_to(:watchable) }
   it { should have_many(:classifications) }
   it { should have_many(:statuses).dependent(:destroy) }
-  it { should have_many(:steps).dependent(:destroy) }
   it { should have_many(:teachers).dependent(:destroy) }
   it { should have_many(:topics).through(:classifications) }
-  it { should have_many(:trails).through(:steps) }
   it { should have_many(:users).through(:teachers) }
+  it { should have_one(:step).dependent(:destroy) }
+  it { should have_one(:trail).through(:step) }
 
   it { should validate_presence_of(:published_on) }
   it { should validate_presence_of(:slug) }

--- a/spec/services/status_updater_spec.rb
+++ b/spec/services/status_updater_spec.rb
@@ -13,8 +13,8 @@ describe StatusUpdater do
         with(user: user, completeable: completeable, state: "New state")
     end
 
-    it "updates the state for trails associated with the completeable" do
-      completeable = mock_completeable(trails: [trail])
+    it "updates the state for the trail associated with the completeable" do
+      completeable = mock_completeable(trail: trail)
       updater = StatusUpdater.new(completeable, user)
       allow(Status).to receive(:create!)
 
@@ -23,9 +23,9 @@ describe StatusUpdater do
       expect(trail).to have_received(:update_state_for)
     end
 
-    def mock_completeable(trails: [])
-      @completeable ||= double("completeable").tap do |completeable|
-        allow(completeable).to receive(:trails).and_return(trails)
+    def mock_completeable(trail: nil)
+      double("completeable").tap do |completeable|
+        allow(completeable).to receive(:trail).and_return(trail)
       end
     end
 

--- a/spec/support/stub_current_user.rb
+++ b/spec/support/stub_current_user.rb
@@ -3,4 +3,10 @@ module StubCurrentUserHelper
     allow(controller).to receive(:signed_in?).and_return(true)
     allow(controller).to receive(:current_user).and_return(user)
   end
+
+  def stub_current_user
+    build_stubbed(:subscriber).tap do |user|
+      stub_current_user_with(user)
+    end
+  end
 end


### PR DESCRIPTION
Currently users are redirected to the `/practice` page with no additional guidance after completing an exercise in the exercises app. This change exposes a new route and controller that will allow us to redirect users back to a trail after they complete an exercise, providing continuity. This relies on an exercise having **one**, not many trails. All data matched this assumption, but the code was implemented using a `has_many` relationship. Since both exercises and videos act as completeables for, `Video` was also changed to use a `have_one` trail relationship.
- [x] Implement controller with redirect logic
- [x] Refactor `Exercise` and `Video` to `have_one` trail, rather than many
- [x] Add a DB index to enforce the uniqueness of the `have_one` relationship
