### PR TITLE
Don't feature plans by default

### DIFF
--- a/db/migrate/20150417173205_dont_make_new_plans_featured.rb
+++ b/db/migrate/20150417173205_dont_make_new_plans_featured.rb
@@ -1,0 +1,5 @@
+class DontMakeNewPlansFeatured < ActiveRecord::Migration
+  def change
+    change_column_default :plans, :featured, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150415145819) do
+ActiveRecord::Schema.define(version: 20150417173205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,7 +157,7 @@ ActiveRecord::Schema.define(version: 20150415145819) do
     t.integer  "price_in_dollars",                                  null: false
     t.text     "terms"
     t.boolean  "includes_mentor",                   default: false
-    t.boolean  "featured",                          default: true,  null: false
+    t.boolean  "featured",                          default: false, null: false
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
     t.boolean  "includes_repositories",             default: true,  null: false

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -22,6 +22,7 @@ namespace :dev do
   def create_individual_plans
     @basic_plan = create(
       :plan,
+      :featured,
       price_in_dollars: 9,
       name: "The Weekly Iteration",
       short_description: "One new video per week on advanced Ruby topics.",
@@ -38,6 +39,7 @@ namespace :dev do
 
     @professional_plan = create(
       :plan,
+      :featured,
       price_in_dollars: 29,
       name: "Professional",
       short_description: "Do exercises and become a general whiz kid.",
@@ -46,6 +48,7 @@ namespace :dev do
 
     @mentor_plan = create(
       :plan,
+      :featured,
       includes_mentor: true,
       price_in_dollars: 249,
       name: "1-on-1 Coaching",

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -122,6 +122,10 @@ FactoryGirl.define do
       annual true
     end
 
+    trait :featured do
+      featured true
+    end
+
     trait :includes_mentor do
       includes_mentor true
     end

--- a/spec/features/user_creates_team_subscription_spec.rb
+++ b/spec/features/user_creates_team_subscription_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "User creates a team subscription" do
   background do
-    create(:plan, :team)
+    create(:plan, :team, :featured)
     sign_in
   end
 

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -125,7 +125,7 @@ feature "User creates a subscription" do
   end
 
   scenario "changes subscription plan" do
-    new_plan = create(:plan, sku: Plan::PROFESSIONAL_SKU)
+    new_plan = create(:plan, :featured)
     sign_in_as_user_with_subscription
     visit my_account_path
 
@@ -139,7 +139,7 @@ feature "User creates a subscription" do
     expect(current_path).to eq my_account_path
     expect_to_see_the_current_plan(new_plan)
     expect(page).to have_content(I18n.t("subscriptions.flashes.change.success"))
-    expect(FakeStripe.customer_plan_id).to eq Plan::PROFESSIONAL_SKU
+    expect(FakeStripe.customer_plan_id).to eq new_plan.sku
   end
 
   scenario "does not see option to update billing if not subscribing" do

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -7,7 +7,6 @@ feature 'Visitor signs up for a subscription' do
 
   scenario 'visitor signs up by navigating from landing page' do
     create(:trail, :published)
-    create(:basic_plan)
 
     visit "/"
     click_link "Start Learning"
@@ -128,7 +127,7 @@ feature 'Visitor signs up for a subscription' do
   end
 
   def create_plan
-    @plan = create(:plan, sku: Plan::PROFESSIONAL_SKU)
+    @plan = create(:plan, :featured)
   end
 
   def attempt_to_subscribe


### PR DESCRIPTION
Setting this flag to true causes plans to render on the `subscriptions/edit` page, which isn't generally what we want.
