### PR TITLE
Don't use js driver when not necessary

### DIFF
--- a/spec/features/user_creates_team_subscription_spec.rb
+++ b/spec/features/user_creates_team_subscription_spec.rb
@@ -22,7 +22,7 @@ feature "User creates a team subscription" do
     expect_submit_button_to_contain("per month")
   end
 
-  scenario "creates a subscription with a valid amount off coupon", js: true do
+  scenario "creates a subscription with a valid amount off coupon" do
     create_amount_stripe_coupon("5OFF", "once", 500)
 
     visit coupon_path("5OFF")

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -12,13 +12,13 @@ feature "User creates a subscription" do
     expect(current_user).not_to have_active_subscription
   end
 
-  scenario "sees that the subscription is per month", js: true do
+  scenario "sees that the subscription is per month" do
     visit_plan_checkout_page
 
     expect_submit_button_to_contain("per month")
   end
 
-  scenario "sees that the subscription is per year", js: true do
+  scenario "sees that the subscription is per year" do
     allow_any_instance_of(Plan).to receive(:subscription_interval).
       and_return("year")
     visit_plan_checkout_page
@@ -58,7 +58,7 @@ feature "User creates a subscription" do
     expect(page).not_to have_github_input
   end
 
-  scenario "with a valid amount off coupon", js: true do
+  scenario "with a valid amount off coupon" do
     create_amount_stripe_coupon("5OFF", "once", 500)
 
     visit coupon_path("5OFF")
@@ -75,7 +75,7 @@ feature "User creates a subscription" do
     expect(FakeStripe.last_coupon_used).to eq "5OFF"
   end
 
-  scenario "with a free month coupon", js: true do
+  scenario "with a free month coupon" do
     create_recurring_stripe_coupon("THREEFREE", 3, 9900)
 
     visit coupon_path("THREEFREE")
@@ -90,7 +90,7 @@ feature "User creates a subscription" do
     expect(FakeStripe.last_coupon_used).to eq "THREEFREE"
   end
 
-  scenario "with a valid percent off coupon", js: true do
+  scenario "with a valid percent off coupon" do
     create_percentage_off_stripe_coupon("50OFF", "once", 50)
 
     visit coupon_path("50OFF")
@@ -108,7 +108,7 @@ feature "User creates a subscription" do
     expect(FakeStripe.last_coupon_used).to eq "50OFF"
   end
 
-  scenario "with an invalid coupon", js: true do
+  scenario "with an invalid coupon" do
     visit coupon_path("50OFF")
     expect(page).to have_content("The coupon code you supplied is not valid.")
 

--- a/spec/features/user_updates_credit_card_spec.rb
+++ b/spec/features/user_updates_credit_card_spec.rb
@@ -14,7 +14,7 @@ feature 'User updated credit card' do
     expect(page).to have_content(I18n.t('subscriptions.flashes.update.success'))
   end
 
-  scenario 'updates Stripe subscription with declining credit card', js: true do
+  scenario "updates Stripe subscription with declining credit card" do
     sign_in_as_user_with_subscription
     visit my_account_path
     FakeStripe.failure = true

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Videos" do
   context "GET /" do
-    it "lists the published videos for a video_tutorial", js: true do
+    it "lists the published videos for a video_tutorial" do
       sign_in_as_user_with_subscription
       video_tutorial = create(:video_tutorial)
       published_video_one = create(

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -54,7 +54,7 @@ feature 'Visitor signs up for a subscription' do
     expect_to_see_checkout_success_flash_for(@plan.name)
   end
 
-  scenario "Visitor attempts to subscribe without specifying a GitHub username", js: true do
+  scenario "without specifying a GitHub username" do
     attempt_to_subscribe
 
     user = build(:user)


### PR DESCRIPTION
After finding a spec that was using the js driver when it didn't need
to, I decided to do a quick audit of all our specs that use capybara
webkit.

The specs in this commit all pass without using the driver. Given how
much faster they run without it, I've removed that requirement.

A non-scientific `time rspec` shows the suite running 12% faster after
these changes. 🚀
