### PR TITLE
Refactor Checkout and CheckoutsController

### DIFF
--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -26,29 +26,6 @@ feature "User creates a subscription" do
     expect_submit_button_to_contain("per year")
   end
 
-  scenario "user with address has invoice address fields prepopulated" do
-    current_user.update!(
-      address1: "742 Evergreen Terrace",
-      address2: ".",
-      city: "Springfield",
-      country: "USA",
-      organization: "The Simpsons",
-      state: "Oh The Mistery",
-      zip_code: "More Mistery"
-    )
-
-    visit_plan_checkout_page
-    click_on "Need an address on your receipt?"
-
-    expect(find_field("Address 1").value).to eq "742 Evergreen Terrace"
-    expect(find_field("Address 2").value).to eq "."
-    expect(find_field("City").value).to eq "Springfield"
-    expect(find_field("Country").value).to eq "USA"
-    expect(find_field("Organization").value).to eq "The Simpsons"
-    expect(find_field("State / Province").value).to eq "Oh The Mistery"
-    expect(find_field("Zip Code").value).to eq "More Mistery"
-  end
-
   scenario "user with github username doesn't see github username input" do
     current_user.github_username = "cpyteltest"
     current_user.save!

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -5,7 +5,6 @@ describe Checkout do
   it { should belong_to(:plan) }
 
   it { should validate_presence_of(:user) }
-  it { should validate_presence_of(:github_username) }
 
   it { should delegate(:plan_includes_team?).to(:plan).as(:includes_team?) }
   it { should delegate(:plan_name).to(:plan).as(:name) }


### PR DESCRIPTION
We'd like to try some experiments around checkout soon. Unfortunately,
the checkout-related code is currently a bit hairy.

This commit attempts to run a comb through it.

Note: this commit removes a feature. Users who have an existing account
on which they've specified an address and who want their invoices to
have that address will now have to type that address by hand if they
sign up a second time. Only three percent of our last 1,000 users have
any kind of address specified at all, and this only affects users who
sign up a _second_ time, so I'm comfortable removing this.
