### PR TITLE
Environment banner

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
 @import "layout/flashes";
 @import "layout/header";
 @import "layout/footer";
+@import "layout/environment-banner";
 
 @import "tooltip";
 @import "animations";

--- a/app/assets/stylesheets/layout/_environment-banner.scss
+++ b/app/assets/stylesheets/layout/_environment-banner.scss
@@ -1,0 +1,16 @@
+.environment-banner {
+  font-size: 0.8em;
+  text-align: center;
+
+  $dev-green: #008000;
+
+  &.development {
+    background: lighten($dev-green, 10%);
+    color: lighten($dev-green, 70%);
+  }
+
+  &.staging {
+    background: lighten($upcase-red, 10%);
+    color: lighten($upcase-red, 70%);
+  }
+}

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -1,0 +1,22 @@
+module EnvironmentBannerHelper
+  def current_branch
+    if git_available?
+      `git rev-parse --abbrev-ref HEAD`.chomp
+    else
+      ENV.fetch("CURRENT_BRANCH", "--branch-not-found--")
+    end
+  end
+
+  def current_sha
+    if git_available?
+      `git log -1 --abbrev-commit --oneline | cut -d ' ' -f 1`
+    else
+      ENV.fetch("CURRENT_SHA", "--sha-not-found--")
+    end
+  end
+
+  def git_available?
+    to_dev_null = "> /dev/null 2>&1"
+    system("which git #{to_dev_null} && git rev-parse --git-dir #{to_dev_null}")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   </head>
 
   <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
+    <%= render "shared/environment_banner" %>
     <%= render 'shared/header' %>
 
     <%= render 'shared/flashes' %>

--- a/app/views/shared/_environment_banner.html.erb
+++ b/app/views/shared/_environment_banner.html.erb
@@ -1,0 +1,5 @@
+<% unless Rails.env.production? %>
+  <div class="environment-banner <%= Rails.env %>">
+    <%= Rails.env %> | <%= "#{current_branch}@#{current_sha}" %>
+  </div>
+<% end %>

--- a/bin/deploy
+++ b/bin/deploy
@@ -24,6 +24,14 @@ else
   heroku run rake db:migrate --remote "$1"
   heroku restart --remote "$1"
 
+  if [ "$1" = "staging" ]; then
+    current_sha="$(git log -1 --abbrev-commit --oneline | cut -d ' ' -f 1)"
+    heroku config:set \
+      CURRENT_BRANCH="$branch" \
+      CURRENT_SHA="$current_sha" \
+      --remote "$1"
+  fi
+
   if [ "$1" = "production" ]; then
     open https://upcase.com
     heroku addons:open newrelic --remote "$1"


### PR DESCRIPTION
This PR resurrects @tute's work ([Original PR](https://github.com/thoughtbot/upcase/pull/858#issuecomment-54357722) and [research card in trello](https://trello.com/c/N93Bdvxp/361-add-rake-environment-branch-and-last-commit-sha-in-the-layout-for-non-production-environments)) on adding an environment specific banner for dev and staging to clarify what is currently deployed and which environment is being viewed.

This PR leverages the `bin/deploy` script to set ENV vars on staging which are used by the banner, while falling back to dynamic git commands in dev mode (when in a git repo). There is a possibility of someone pushing directly to staging via `git push staging master` which would cause this to be out of sync, but I'm personally fine with that trade off as Circle does most deploys to staging and uses `bin/deploy`, and most devs / designers are in the habit.
### Staging:

![image](https://cloud.githubusercontent.com/assets/420113/7210779/ce18cde4-e522-11e4-96b9-d096ed22ff1c.png)
### Dev:

![image](https://cloud.githubusercontent.com/assets/420113/7210788/e0bd0776-e522-11e4-91b3-64ead32b5d8d.png)
