### PR TITLE
Show Start Trail button for video trails

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,10 @@ module ApplicationHelper
     "https://forum.upcase.com/#{suffix}"
   end
 
+  def exercise_path(exercise)
+    exercise.url
+  end
+
   def blog_articles_url(topic)
     "http://robots.thoughtbot.com/tags/#{topic.slug}"
   end

--- a/app/models/trail_with_progress.rb
+++ b/app/models/trail_with_progress.rb
@@ -38,6 +38,10 @@ class TrailWithProgress < SimpleDelegator
     statuses_by_id[@trail.id].try(:first) || Unstarted.new
   end
 
+  def steps_remaining
+    @trail.steps_remaining_for(@user)
+  end
+
   private
 
   attr_reader :trail, :user

--- a/app/views/trails/_incomplete_trail.html.erb
+++ b/app/views/trails/_incomplete_trail.html.erb
@@ -9,8 +9,8 @@
 
     <%= render "trails/step_dots", trail: trail %>
 
-    <% if trail.exercises.present? %>
-      <%= completeable_link trail.exercises.first.url, class: "start-trail" do %>
+    <% if trail.steps.present? %>
+      <%= completeable_link url_for(trail.steps.first.completeable), class: "start-trail" do %>
         Start trail
       <% end %>
     <% end %>

--- a/app/views/trails/_steps_remaining.html.erb
+++ b/app/views/trails/_steps_remaining.html.erb
@@ -1,6 +1,6 @@
 <span class="numerical-progress">
   <%= pluralize(
-    trail.steps_remaining_for(current_user),
+    trail.steps_remaining,
     "step"
   ) %> remaining
 </span>

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -292,11 +292,6 @@ namespace :dev do
     )
     teach video, bio: "Dan I am"
     FactoryGirl.create(:step, trail: trail, completeable: video)
-    FactoryGirl.create(:status,
-      completeable: trail,
-      state: Status::IN_PROGRESS,
-      user: user
-    )
 
     puts_trail trail, "unstarted"
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -206,6 +206,10 @@ FactoryGirl.define do
     trait :explorable do
       explorable true
     end
+
+    after :stub do |topic|
+      topic.slug ||= topic.name.parameterize
+    end
   end
 
   factory :completion do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#exercise_path" do
+    it "returns the remote URL for the exercise" do
+      exercise = build_stubbed(:exercise)
+
+      result = helper.exercise_path(exercise)
+
+      expect(result).to eq(exercise.url)
+    end
+  end
+end

--- a/spec/models/trail_with_progress_spec.rb
+++ b/spec/models/trail_with_progress_spec.rb
@@ -132,6 +132,21 @@ describe TrailWithProgress do
     end
   end
 
+  describe "#steps_remaining" do
+    it "delegates to the trail" do
+      trail = create_trail_with_progress(
+        Status::COMPLETE,
+        Status::IN_PROGRESS,
+        nil,
+        nil
+      )
+
+      result = trail.steps_remaining
+
+      expect(result).to eq(3)
+    end
+  end
+
   def create_trail_with_progress(*states)
     user = create(:user)
     exercises =

--- a/spec/views/topics/_trail.html.erb_spec.rb
+++ b/spec/views/topics/_trail.html.erb_spec.rb
@@ -41,6 +41,7 @@ describe "topics/_trail.html" do
       allow(trail).to receive(:complete?).and_return(complete)
       allow(trail).to receive(:just_finished?).and_return(just_finished)
       allow(trail).to receive(:unstarted?).and_return(unstarted)
+      allow(trail).to receive(:steps_remaining).and_return(1)
     end
   end
 

--- a/spec/views/trails/_incomplete_trail.html.erb_spec.rb
+++ b/spec/views/trails/_incomplete_trail.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "trails/_incomplete_trail.html" do
+  context "for a trail with only videos" do
+    it "renders a Start Trail link" do
+      render_trail completeables: [build_stubbed(:video)]
+
+      expect(rendered).to have_start_trail_link
+    end
+  end
+
+  context "for a trail with only exercises" do
+    it "renders a Start Trail link" do
+      render_trail completeables: [build_stubbed(:exercise)]
+
+      expect(rendered).to have_start_trail_link
+    end
+  end
+
+  context "for an empty trail" do
+    it "doesn't render a Start Trail link" do
+      render_trail completeables: []
+
+      expect(rendered).not_to have_start_trail_link
+    end
+  end
+
+  def render_trail(*trail_args)
+    view_stubs(:current_user_has_access_to?).and_return(true)
+
+    render "trails/incomplete_trail", trail: build_trail(*trail_args)
+  end
+
+  def build_trail(completeables:)
+    steps = completeables.map do |completeable|
+      build_stubbed(:step, completeable: completeable)
+    end
+
+    TrailWithProgress.new(
+      build_stubbed(:trail, steps: steps),
+      user: build_stubbed(:user)
+    )
+  end
+
+  def have_start_trail_link
+    have_link("Start trail")
+  end
+end


### PR DESCRIPTION
We were only linking to exercise steps to start trails. This resulted in
the "Start Trail" button now showing up for video trails.

Included refactorings:
- Introduces `TrailWithProgress#steps_remaining to avoid unnecessary use
  of`current_user` in a view.
- Fixes `Topic` factory to stub out a slug when using `build_stubbed`.
- Introduces `ApplicationHelper#exercise_path` to enable polymorphic
  URLs.

There was previously no test coverage for the affected views. Coverage
was introduced and extended.

https://trello.com/c/geRJfsaK/621
