### PR TITLE
Remove `public` attribute from Exercises

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,7 +1,5 @@
 class Exercise < ActiveRecord::Base
-  has_many :classifications, as: :classifiable, dependent: :destroy
   has_many :statuses, as: :completeable, dependent: :destroy
-  has_many :topics, through: :classifications
   has_one :trail, through: :step, as: :completeables
   has_one :step, dependent: :destroy, as: :completeable
 
@@ -10,9 +8,5 @@ class Exercise < ActiveRecord::Base
 
   def self.ordered
     order(:created_at)
-  end
-
-  def self.public
-    where(public: true)
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,7 +4,6 @@ class Topic < ActiveRecord::Base
   has_many :classifications, dependent: :destroy
 
   with_options(through: :classifications, source: :classifiable) do |options|
-    options.has_many :exercises, source_type: 'Exercise'
     options.has_many :products, source_type: 'Product'
     options.has_many :topics, source_type: 'Topic'
     options.has_many :videos, source_type: 'Video'

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -111,7 +111,6 @@ RailsAdmin.config do |config|
         partial "whetstone_edit_url"
       end
 
-      field :public
       field :topics
       field :trail
     end

--- a/db/migrate/20150421144230_drop_public_from_exercises.rb
+++ b/db/migrate/20150421144230_drop_public_from_exercises.rb
@@ -1,0 +1,5 @@
+class DropPublicFromExercises < ActiveRecord::Migration
+  def change
+    remove_column :exercises, :public, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20150421160114_clean_exercise_classifications.rb
+++ b/db/migrate/20150421160114_clean_exercise_classifications.rb
@@ -1,0 +1,10 @@
+class CleanExerciseClassifications < ActiveRecord::Migration
+  def up
+    delete <<-SQL
+      DELETE FROM classifications WHERE classifiable_type = 'Exercise';
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,17 +61,15 @@ ActiveRecord::Schema.define(version: 20150422152603) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "exercises", force: :cascade do |t|
-    t.string   "name",       limit: 255,                 null: false
-    t.string   "url",        limit: 255,                 null: false
-    t.text     "summary",                                null: false
+    t.string   "name",       limit: 255, null: false
+    t.string   "url",        limit: 255, null: false
+    t.text     "summary",                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "uuid",       limit: 255,                 null: false
-    t.boolean  "public",                 default: false, null: false
+    t.string   "uuid",       limit: 255, null: false
     t.string   "edit_url",   limit: 255
   end
 
-  add_index "exercises", ["public"], name: "index_exercises_on_public", using: :btree
   add_index "exercises", ["uuid"], name: "index_exercises_on_uuid", unique: true, using: :btree
 
   create_table "invitations", force: :cascade do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -238,9 +238,6 @@ namespace :dev do
     teach video, bio: "The Amazing Dan"
     FactoryGirl.create(:step, trail: trail, completeable: video)
 
-    classify_exercise "Passing Your First Test", "Testing"
-    classify_exercise "Testing ActiveRecord", "Testing"
-    classify_exercise "Write an Integration Test", "Testing"
     puts_trail trail, "unstarted"
 
     trail = FactoryGirl.create(:trail, :published, name: "Design Essentials")
@@ -272,9 +269,6 @@ namespace :dev do
       "Extract Class",
       "Replace Variable with Query"
     )
-    classify_exercise "Extract Method", "Clean Code"
-    classify_exercise "Extract Class", "Clean Code"
-    classify_exercise "Replace Variable with Query", "Clean Code"
     FactoryGirl.create(:status,
       completeable: trail,
       state: Status::IN_PROGRESS,
@@ -289,9 +283,6 @@ namespace :dev do
       "Install Homebrew",
       "Intro to the App Store"
     )
-    classify_exercise "Install Xcode", "iOS"
-    classify_exercise "Install Homebrew", "Workflow"
-    classify_exercise "Intro to the App Store", "iOS"
     FactoryGirl.create(:status,
       completeable: trail,
       state: Status::COMPLETE,
@@ -340,7 +331,7 @@ namespace :dev do
 
   def create_steps_for(trail, *names)
     names.map do |name|
-      exercise = FactoryGirl.create(:exercise, name: name, public: true)
+      exercise = FactoryGirl.create(:exercise, name: name)
       FactoryGirl.create(:step, trail: trail, completeable: exercise)
     end
   end
@@ -348,10 +339,6 @@ namespace :dev do
   def teach(video, bio:)
     user = FactoryGirl.create(:user, bio: bio)
     FactoryGirl.create(:teacher, video: video, user: user)
-  end
-
-  def classify_exercise(name, topic_name)
-    classify Exercise.find_by!(name: name), topic_name
   end
 
   def classify(classifiable, topic_name)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -414,10 +414,6 @@ FactoryGirl.define do
     sequence(:name) { |n| "Exercise #{n}" }
     url { "http://localhost:7000/exercises/#{slug}" }
     uuid
-
-    trait :public do
-      public true
-    end
   end
 
   factory :oauth_access_token, class: "Doorkeeper::AccessToken" do

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 describe Exercise do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:url) }
-  it { should have_many(:classifications) }
-  it { should have_many(:topics).through(:classifications) }
   it { should have_one(:trail).through(:step) }
   it { should have_one(:step).dependent(:destroy) }
 
@@ -15,16 +13,6 @@ describe Exercise do
       create(:exercise, name: "second", created_at: 2.days.ago)
 
       expect(Exercise.ordered.pluck(:name)).to eq(%w(first second third))
-    end
-  end
-
-  describe ".public" do
-    it "only returns public exercises" do
-      create(:exercise, name: "first", public: true)
-      create(:exercise, name: "second", public: true)
-      create(:exercise, name: "hidden", public: false)
-
-      expect(Exercise.public.pluck(:name)).to match_array(%w(first second))
     end
   end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe Topic do
   # Associations
   it { should have_many(:classifications).dependent(:destroy) }
-  it { should have_many(:exercises).through(:classifications) }
   it { should have_many(:products).through(:classifications) }
   it { should have_many(:topics).through(:classifications) }
   it { should have_many(:videos).through(:classifications) }


### PR DESCRIPTION
Previously it was expected that exercises could be displayed independently on a
Topic page, and the `public` flag would determine their visibility. Now all
exercises are expected to be viewed within the context of a trail and the
trail's `published` flag determines the visibility of both the trail and any
associated exercises.

With this in mind we are removing the `public` field to simplify the exercise
model.

---

Relatedly, do we want to remove the topic association from exercises as well, and similarly rely on the Trail -> topic relationship?
