### PR TITLE
Replace latest video tutorial with video trail

### DIFF
--- a/app/services/explore.rb
+++ b/app/services/explore.rb
@@ -7,8 +7,12 @@ class Explore
     Show.the_weekly_iteration
   end
 
-  def latest_video_tutorial
-    VideoTutorial.active.order(:created_at).last
+  def latest_video_trail
+    Trail.
+      most_recent_published.
+      distinct.
+      joins(:steps).where(steps: { completeable_type: "Video" }).
+      first
   end
 
   def topics

--- a/app/views/explore/_videos.html.erb
+++ b/app/views/explore/_videos.html.erb
@@ -12,11 +12,11 @@
       ) %>
     <% end %>
 
-    <li class="tile video-tutorial <%= topic_slugs(video_tutorial) %>">
+    <li class="tile video-tutorial <%= topic_class(trail.topic) %>">
       <h2>Video Tutorial</h2>
-      <h1><%= link_to video_tutorial.name, video_tutorial %></h1>
-      <p class="description"><%= video_tutorial.tagline %></p>
-      <%= link_to "View All Videos", products_path, class: "cta" %>
+      <h1><%= link_to trail.name, trail %></h1>
+      <p class="description"><%= trail.description %></p>
+      <%= link_to "View All Trails", trails_path, class: "cta" %>
     </li>
   </ul>
 </section>

--- a/app/views/explore/show.html.erb
+++ b/app/views/explore/show.html.erb
@@ -18,7 +18,7 @@
     <%= render(
       "videos",
       show: @explore.show,
-      video_tutorial: @explore.latest_video_tutorial
+      trail: @explore.latest_video_trail
     ) %>
 
     <%= render "all_trails", trails: @explore.trails %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -479,6 +479,13 @@ FactoryGirl.define do
         end
       end
     end
+
+    trait :video do
+      after :create do |trail|
+        video = create(:video, watchable: nil)
+        create(:step, trail: trail, completeable: video)
+      end
+    end
   end
 
   factory :step do

--- a/spec/features/subscriber_explores_content_spec.rb
+++ b/spec/features/subscriber_explores_content_spec.rb
@@ -4,22 +4,7 @@ feature "Subscriber accesses content" do
   before do
     show = create(:show, name: Show::THE_WEEKLY_ITERATION)
     create(:video, watchable: show)
-    create(:video_tutorial)
-  end
-
-  scenario "subscriber without access to video_tutorials attempts to begin a video_tutorial" do
-    sign_in_as_user_with_downgraded_subscription
-    visit explore_path
-    click_video_tutorial_detail_link
-
-    expect(page.body).to include(
-      I18n.t("watchables.preview.cta", subscribe_url: subscribe_path).html_safe
-    )
-    expect(page).to have_content I18n.t("video_tutorial.upgrade_cta")
-
-    click_link I18n.t("video_tutorial.upgrade_cta")
-
-    expect(current_path).to eq edit_subscription_path
+    create(:trail, :published, :video)
   end
 
   scenario "gets added to the GitHub team for a repository" do
@@ -35,19 +20,8 @@ feature "Subscriber accesses content" do
     expect(page).to have_content("We're adding you to the GitHub repository")
   end
 
-  def get_access_to_video_tutorial
-    sign_in_as_user_with_subscription
-    visit explore_path
-    click_video_tutorial_detail_link
-    click_link I18n.t("video_tutorial.checkout_cta")
-  end
-
   def stub_github_fulfillment_job
     allow(GithubFulfillmentJob).to receive(:enqueue)
-  end
-
-  def click_video_tutorial_detail_link
-    find(".video-tutorial a:first").click
   end
 
   def have_added_current_user_to_team_for(product)

--- a/spec/features/subscriber_explores_weekly_iteration_spec.rb
+++ b/spec/features/subscriber_explores_weekly_iteration_spec.rb
@@ -4,7 +4,7 @@ feature "User without a subscription" do
   scenario "Sees latest TWI and Video Tutorial in Explore" do
     show = create(:show, name: Show::THE_WEEKLY_ITERATION)
     twi_video = create(:video, :published, watchable: show)
-    video_tutorial = create(:video_tutorial)
+    trail = create(:trail, :published, :video)
 
     visit explore_path(as: create(:user))
 
@@ -13,8 +13,8 @@ feature "User without a subscription" do
     expect(page).to have_content(twi_video.name)
     expect(page).to have_content("View All Episodes")
 
-    expect(page).to have_content(video_tutorial.name)
-    expect(page).to have_content(video_tutorial.tagline)
-    expect(page).to have_content("View All Videos")
+    expect(page).to have_content(trail.name)
+    expect(page).to have_content(trail.description)
+    expect(page).to have_content("View All Trails")
   end
 end

--- a/spec/features/subscriber_views_topic_spec.rb
+++ b/spec/features/subscriber_views_topic_spec.rb
@@ -5,7 +5,7 @@ feature "Subscriber views a topic" do
     create(:show, name: Show::THE_WEEKLY_ITERATION)
     topic = create(:topic, :explorable)
     video = create(:video)
-    trail = create(:trail, :published)
+    trail = create(:trail, :published, :video)
     topic.videos << video
     topic.trails << trail
 

--- a/spec/services/explore_spec.rb
+++ b/spec/services/explore_spec.rb
@@ -13,21 +13,32 @@ describe Explore do
     end
   end
 
-  describe "#latest_video_tutorial" do
-    it "returns most recent active VideoTutorial" do
-      user = double
-      video_tutorial = double
-      order_scope = double("Order Scope", last: video_tutorial)
-      active_scope = double("Active Scope", order: order_scope)
-      allow(VideoTutorial).to receive(:active).and_return(active_scope)
-      allow(active_scope).to receive(:order).with(:created_at).
-        and_return(order_scope)
+  describe "#latest_video_trail" do
+    it "returns most recent published video trail" do
+      user = double(:user)
+      create_trail("Video Trail", published: 1.day.ago, type: :video)
+      create_trail("Old Trail", published: 2.days.ago, type: :video)
+      create_trail("Unpublished Trail", published: false, type: :video)
+      create_trail("Exercise Trail", published: Time.now, type: :exercise)
 
-      result = Explore.new(user).latest_video_tutorial
+      result = Explore.new(user).latest_video_trail
 
-      expect(result).to eq(video_tutorial)
-      expect(VideoTutorial).to have_received(:active)
-      expect(active_scope).to have_received(:order).with(:created_at)
+      expect(result.name).to eq("Video Trail")
+    end
+
+    def create_trail(name, published:, type:)
+      trail = create(
+        :trail,
+        name: name,
+        published: published.present?,
+        created_at: published || Time.now
+      )
+
+      create(
+        :step,
+        trail: trail,
+        completeable: create(type)
+      )
     end
   end
 

--- a/spec/views/explore/_videos.html.erb_spec.rb
+++ b/spec/views/explore/_videos.html.erb_spec.rb
@@ -6,9 +6,9 @@ describe "explore/_videos.html" do
       latest_video = build_stubbed(:video)
       show = build_stubbed(:show)
       allow(show).to receive(:latest_video).and_return(latest_video)
-      video_tutorial = build_stubbed(:video_tutorial)
+      trail = build_stubbed(:trail)
 
-      render "explore/videos", show: show, video_tutorial: video_tutorial
+      render "explore/videos", show: show, trail: trail
 
       expect(rendered).to have_text(show.tagline)
       expect(rendered).to have_text(latest_video.name)
@@ -19,9 +19,9 @@ describe "explore/_videos.html" do
     it "skips the video" do
       show = build_stubbed(:show)
       allow(show).to receive(:latest_video).and_return(nil)
-      video_tutorial = build_stubbed(:video_tutorial)
+      trail = build_stubbed(:trail)
 
-      render "explore/videos", show: show, video_tutorial: video_tutorial
+      render "explore/videos", show: show, trail: trail
 
       expect(rendered).not_to have_text(show.tagline)
     end


### PR DESCRIPTION
Because:
- We showcase one video tutorial on the Explore page
- This page was broken without any video tutorials

This commit:
- Replaces that with the latest video trail
- Makes sure at least one video trail exists on explore page tests
- Removes redundant test coverage now that video tutorials and trails
  are merged

https://trello.com/c/tjhwKYew/605
