### PR TITLE
Fix errors for unsaved videos

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -53,7 +53,7 @@ class Video < ActiveRecord::Base
   end
 
   def watchable
-    super || step.trail
+    super || step.try(:trail)
   end
 
   def to_param

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -157,5 +157,15 @@ describe Video do
         expect(result).to eq(trail)
       end
     end
+
+    context "for an unsaved video" do
+      it "returns nil" do
+        video = Video.new
+
+        result = video.watchable
+
+        expect(result).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
The RailsAdmin form for making a video was broken because:
- `Video#watchable` looked for a direct association or a trail
- Unsaved videos have neither, so we were getting nil reference errors

This makes `watchable` more paranoid.
