### PR TITLE
[FEATURE] Embed Trails progress in videos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,6 @@ gem "validates_email_format_of"
 gem "vanity", github: "assaf/vanity"
 
 group :development do
-  gem "better_errors"
-  gem "binding_of_caller"
   gem "quiet_assets"
   gem "spring"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,12 +66,6 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     bcrypt (3.1.9)
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bluecloth (2.2.0)
     bourbon (3.2.3)
       sass (~> 3.2)
@@ -107,7 +101,6 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
-    debug_inspector (0.0.2)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
@@ -375,8 +368,6 @@ DEPENDENCIES
   airbrake
   analytics-ruby (~> 2.0.0)
   aws-sdk
-  better_errors
-  binding_of_caller
   bluecloth
   bourbon (~> 3.2.1)
   capybara

--- a/app/controllers/progress_bars_controller.rb
+++ b/app/controllers/progress_bars_controller.rb
@@ -1,8 +1,14 @@
 class ProgressBarsController < ApplicationController
-
   def show
-    _trail = Trail.find(params[:trail_id])
-    @trail = TrailWithProgress.new(_trail, user: current_user)
+    @trail_with_progress = build_trail_with_progress
+
     render layout: false
+  end
+
+  private
+
+  def build_trail_with_progress
+    trail = Trail.find(params[:trail_id])
+    TrailWithProgress.new(trail, user: current_user)
   end
 end

--- a/app/views/progress_bars/show.html.erb
+++ b/app/views/progress_bars/show.html.erb
@@ -1,1 +1,1 @@
-<%= render "trails/progress", trail: @trail, user: current_user %>
+<%= render "trails/progress", trail: @trail_with_progress, user: current_user %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -16,7 +16,6 @@
     <span class="divider">
       <h4 class="text">Video</h4>
     </span>
-
     <%= render @video.preview, name: @video.name %>
 
     <section class='video-notes'>

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -1,33 +1,6 @@
 require "rails_helper"
 
 describe "videos/show" do
-  context "with a corresponding trail" do
-    it "embeds the trail progress" do
-      video = create(
-        :video,
-        :published,
-        step: create(:step),
-      )
-      stub_controller(video)
-
-      render template: "videos/show"
-
-      expect(rendered).to have_trail_progress
-    end
-  end
-
-  context "without a corresponding trail" do
-    it "doesn't embed the trail progress" do
-      video = create(:video, :published)
-
-      stub_controller(video)
-
-      render template: "videos/show"
-
-      expect(rendered).not_to have_trail_progress
-    end
-  end
-
   it "embeds a preview when available" do
     video = create(
       :video,
@@ -64,10 +37,6 @@ describe "videos/show" do
     render template: "videos/show"
 
     expect(rendered).to have_css("img.thumbnail[data-wistia-id='#{wistia_id}']")
-  end
-
-  def have_trail_progress
-    have_css(".trails-progress")
   end
 
   def stub_controller(video)


### PR DESCRIPTION
While following along with a Trail's videos, moving on to other videos
within the trail requires navigating back to the trail itself, finding
the step you were last on, then finding the step in question.

This feature would enable navigation within the context of the current
step.

---

(from chris)

Initial pass at this shows that we can embed the trail progress lights, but they are static and actually prevent a user from progressing to the next step. Overall I think we need something to allow for better continuity between steps, but additional work is needed to determine the best way to do this.

![image](https://cloud.githubusercontent.com/assets/420113/7349334/2c069d6e-ecc6-11e4-909f-284ded7ce844.png)
