### PR TITLE
Restore ability to click "just-completed" trails

### DIFF
--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -449,7 +449,6 @@ $not-started-dot-color: #D8D8D8;
   ///////////////////////////////////////////////////////////////////////////
   .just-finished {
     position: relative;
-    z-index: -1;
     width: 100%;
 
     h1 {


### PR DESCRIPTION
The `z-index: -1;` style declaration was making the links unclickable.

Before:

![unclickable](https://cloud.githubusercontent.com/assets/420113/7373716/16b8b088-ed9c-11e4-9f2a-0065a9937c87.gif)

After:

![trail-links](https://cloud.githubusercontent.com/assets/420113/7373717/1af2d714-ed9c-11e4-993b-0f93722cf66c.gif)
