### PR TITLE
Update pryrc to handle test and non-rails environments

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,4 +1,4 @@
-colors = {
+color_escape_codes = {
   black: "\033[0;30m",
   red: "\033[0;31m",
   green: "\033[0;32m",
@@ -9,21 +9,18 @@ colors = {
   reset: "\033[0;0m"
 }
 
-env_map = {
-  "development" => {
-    color: colors[:reset]
-  },
-  "staging" => {
-    color: colors[:yellow]
-  },
-  "production" => {
-    color: colors[:red]
-  }
+env_colors = {
+  "development" => color_escape_codes[:yellow],
+  "staging" => color_escape_codes[:yellow],
+  "production" => color_escape_codes[:red],
 }
 
-Pry.config.prompt = proc do |obj, nest_level, _|
-  env = env_map[Rails.env]
-  "(#{env[:color]}#{Rails.env}#{colors[:reset]}) #{obj}:#{nest_level}> "
+if defined? Rails
+  Pry.config.prompt = proc do |obj, nest_level, _|
+    color = env_colors.fetch(Rails.env, color_escape_codes[:reset])
+    colored_environment_name = "#{color}#{Rails.env}#{color_escape_codes[:reset]}"
+    "(#{colored_environment_name}) #{obj}:#{nest_level}> "
+  end
 end
 
 eval(File.open(".irbrc").read)


### PR DESCRIPTION
There was no mapping for the "test" env which would cause pry to crash in test mode. Likewise, the pryrc prompt configuration assumed the presence of `Rails`, and would crash if run directly as `pry` from the shell. This fixes both cases.
