### PR TITLE
Display the github username field with errors

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -43,8 +43,8 @@ class Checkout < ActiveRecord::Base
     plan.minimum_quantity
   end
 
-  def needs_github?
-    user.nil? || user.github_username.blank?
+  def needs_github_username?
+    user.nil? || issue_with_github_username?
   end
 
   def coupon
@@ -52,6 +52,10 @@ class Checkout < ActiveRecord::Base
   end
 
   private
+
+  def issue_with_github_username?
+    user.github_username.blank? || user.errors.include?(:github_username)
+  end
 
   def create_subscriptions
     if create_stripe_subscription && save

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -1,5 +1,4 @@
 <%= semantic_form_for checkout, url: checkouts_path(checkout.plan), html: { method: 'post' } do |form| %>
-  <%= form.semantic_errors %>
 
   <%= form.inputs do %>
     <% if signed_out? %>
@@ -19,7 +18,7 @@
       <%= form.input :password, required: true %>
     <% end %>
 
-    <% if checkout.needs_github? %>
+    <% if checkout.needs_github_username? %>
       <%= form.input :github_username, required: true, label: "GitHub username",
         hint: "Be sure to enter a valid, unique GitHub username. Organizations are not allowed." %>
     <% end %>

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -104,6 +104,21 @@ feature 'Visitor signs up for a subscription' do
     expect(page).to have_content I18n.t("checkout.flashes.already_subscribed")
   end
 
+  scenario "visitor attempts to subscribe with existing github username" do
+    existing_user = create(:user, :with_github_auth)
+
+    attempt_to_subscribe
+    fill_out_account_creation_form_as existing_user
+    fill_out_credit_card_form_with_valid_credit_card
+
+    expect(current_path).to be_the_checkouts_page
+    expect_error_on_github_username_field
+  end
+
+  def expect_error_on_github_username_field
+    expect(github_username_field[:class]).to include("error")
+  end
+
   def expect_to_be_on_checkout_page
     expect(current_url).to eq new_checkout_url(@plan)
   end
@@ -132,5 +147,9 @@ feature 'Visitor signs up for a subscription' do
 
   def attempt_to_subscribe
     visit new_checkout_path(@plan)
+  end
+
+  def github_username_field
+    find("#checkout_github_username_input")
   end
 end

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -132,4 +132,28 @@ describe Checkout do
       expect(checkout.coupon.code).to eq "5OFF"
     end
   end
+
+  context "#needs_github_username?" do
+    it "is false if the user has a valid github username" do
+      user = build_stubbed(:user, github_username: "githubuser")
+      checkout = build_stubbed(:checkout, user: user)
+
+      expect(checkout.needs_github_username?).to be(false)
+    end
+
+    it "is true for new users without a github username" do
+      user = build_stubbed(:user, github_username: nil)
+      checkout = build_stubbed(:checkout, user: user)
+
+      expect(checkout.needs_github_username?).to be(true)
+    end
+
+    it "is true if there is an error for the user's github_username field" do
+      user = build_stubbed(:user, github_username: "user")
+      allow(user).to receive(:errors).and_return([:github_username])
+      checkout = build_stubbed(:checkout, user: user)
+
+      expect(checkout.needs_github_username?).to be(true)
+    end
+  end
 end

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -30,12 +30,18 @@ module CheckoutHelpers
     click_button 'Submit Payment'
   end
 
+  def fill_out_account_creation_form_as(user)
+    fill_out_account_creation_form(
+      user.slice(:name, :email, :password, :github_username)
+    )
+  end
+
   def fill_out_account_creation_form(user_attributes={})
-    user = build(:user)
-    fill_in 'Name', with: user_attributes[:name] || user.name
-    fill_in 'Email', with: user_attributes[:email] || user.email
-    fill_in 'Password', with: user.password
-    fill_in 'GitHub username', with: 'cpytel'
+    user = build(:user, { github_username: "cpytel" }.merge(user_attributes))
+    fill_in "Name", with: user.name
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    fill_in "GitHub username", with: user.github_username
   end
 
   def expect_submit_button_to_contain(text)

--- a/spec/support/path_helpers.rb
+++ b/spec/support/path_helpers.rb
@@ -2,4 +2,8 @@ module PathHelpers
   def be_the_practice_page
     eq(practice_path)
   end
+
+  def be_the_checkouts_page
+    match(/checkouts/)
+  end
 end


### PR DESCRIPTION
The Checkout form object had logic to hide the github username when the
associated user instance already had a github username. Unfortunately, in the
case of a user who had created an account via github auth, but was now
attempting to sign up with email and password using their github username, the
sign up would fail, and would re-render the sign up form without the github
username field, preventing the "Github username already taken" message from
being displayed.

This update adds a condition to the `#needs_github?` method on Checkout to
also display the field if there is an error associated with the github username
field.
