### PR TITLE
Break incomplete_trails into two methods

### DIFF
--- a/app/models/trail_with_progress.rb
+++ b/app/models/trail_with_progress.rb
@@ -11,10 +11,6 @@ class TrailWithProgress < SimpleDelegator
     complete? && status.created_at >= 5.days.ago
   end
 
-  def incomplete?
-    unstarted? || in_progress?
-  end
-
   def unstarted?
     statuses_by_id.empty?
   end

--- a/app/services/practice.rb
+++ b/app/services/practice.rb
@@ -11,8 +11,12 @@ class Practice
     trails.select(&:just_finished?)
   end
 
-  def incomplete_trails
-    trails.select(&:incomplete?).partition(&:in_progress?).flatten
+  def unstarted_trails
+    trails.select(&:unstarted?)
+  end
+
+  def in_progress_trails
+    trails.select(&:in_progress?)
   end
 
   private

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -16,14 +16,13 @@
         </h2>
       </section>
 
-      <% if @practice.incomplete_trails.any? %>
-        <section class="incomplete-trails">
-          <span class="divider">
-            <h4 class="text">Your Trails</h4>
-          </span>
-          <%= render partial: "trails/incomplete_trail", collection: @practice.incomplete_trails, as: :trail %>
-        </section>
-      <% end %>
+      <section class="incomplete-trails">
+        <span class="divider">
+          <h4 class="text">Your Trails</h4>
+        </span>
+        <%= render partial: "trails/incomplete_trail", collection: @practice.in_progress_trails, as: :trail %>
+        <%= render partial: "trails/incomplete_trail", collection: @practice.unstarted_trails, as: :trail %>
+      </section>
 
       <% if @practice.just_finished_trails.any? %>
         <section class="completed-trails trails-progress">

--- a/spec/services/practice_spec.rb
+++ b/spec/services/practice_spec.rb
@@ -39,47 +39,31 @@ describe Practice do
     end
   end
 
-  describe "#incomplete_trails" do
-    it "when there are unstarted trails" do
+  describe "#unstarted_trails" do
+    it "returns trails that the user hasn't started" do
       user = build_stubbed(:user)
-      trail = create(:trail, :published)
+      started_trail = create(:trail, :published, name: "Started")
+      create(:status, completeable: started_trail, user: user)
+      create(:trail, :published, name: "Unstarted")
       practice = Practice.new(user)
 
-      expect(practice.incomplete_trails).to eq([trail])
-    end
+      result = practice.unstarted_trails
 
-    it "when there are started trails" do
+      expect(result.map(&:name)).to eq(["Unstarted"])
+    end
+  end
+
+  describe "#in_progress_trails" do
+    it "returns trails the user has started" do
       user = build_stubbed(:user)
-      trail = create(:trail, :published)
-      create(:status, completeable: trail, user: user)
+      started_trail = create(:trail, :published, name: "Started")
+      create(:status, completeable: started_trail, user: user)
+      create(:trail, :published, name: "Unstarted")
       practice = Practice.new(user)
 
-      expect(practice.incomplete_trails).to eq([trail])
-    end
+      result = practice.in_progress_trails
 
-    it "when there are completed trails" do
-      user = build_stubbed(:user)
-      trail = create(:trail, :published)
-      Timecop.travel(1.week.ago) do
-        create(:status, :completed, completeable: trail, user: user)
-      end
-      practice = Practice.new(user)
-
-      expect(practice.incomplete_trails).to be_empty
-    end
-
-    context "sorting" do
-      it "returns all started trails before any unstarted trails" do
-        user = build_stubbed(:user)
-        started_trail = create(:trail, :published, name: "Started")
-        create(:status, completeable: started_trail, user: user)
-        create(:trail, :published, name: "Unstarted")
-        practice = Practice.new(user)
-
-        result = practice.incomplete_trails
-
-        expect(result.map(&:name)).to eq(["Started", "Unstarted"])
-      end
+      expect(result.map(&:name)).to eq(["Started"])
     end
   end
 end

--- a/spec/views/practice/show.html.erb_spec.rb
+++ b/spec/views/practice/show.html.erb_spec.rb
@@ -50,7 +50,8 @@ describe "practice/show.html" do
         "Practice",
         shows: [],
         topics: [],
-        incomplete_trails: [],
+        in_progress_trails: [],
+        unstarted_trails: [],
         just_finished_trails: [],
         has_completed_trails?: completed
       )


### PR DESCRIPTION
Rather than partitioning incomplete trails by whether they're
in-progress or not, this change splits the retrieval into two methods.
This is a preparatory refactoring for adding ordering to both unstarted
and in-progress trails.
