### PR TITLE
Revert Capybara.ignore_hidden setting to true

### DIFF
--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -18,7 +18,7 @@ describe "Videos" do
 
       visit show_url(show)
 
-      expect(page).to have_css("link[href*='the-weekly-iteration.rss']")
+      expect(page).to have_rss_link
 
       visit show_url(show, format: "rss")
 
@@ -101,5 +101,9 @@ describe "Videos" do
 
       expect_page_to_have_title("#{show.title} | Upcase")
     end
+  end
+
+  def have_rss_link
+    have_css("link[href*='the-weekly-iteration.rss']", visible: false)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,7 @@ Delayed::Worker.delay_jobs = false
 Capybara.javascript_driver = :webkit
 Capybara.configure do |config|
   config.match = :prefer_exact
-  config.ignore_hidden_elements = false
+  config.ignore_hidden_elements = true
 end
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/html.rb
+++ b/spec/support/html.rb
@@ -1,13 +1,13 @@
 def expect_page_to_have_meta_description(expected_description)
-  meta_tag = page.find('meta[name=Description]')
+  meta_tag = page.find("meta[name=Description]", visible: false)
   expect(meta_tag['content']).to eq expected_description
 end
 
 def expect_page_to_have_meta_keywords(expected_keywords)
-  meta_tag = page.find('meta[name=Keywords]')
+  meta_tag = page.find("meta[name=Keywords]", visible: false)
   expect(meta_tag['content']).to eq expected_keywords
 end
 
 def expect_page_to_have_title(expected_page_title)
-  expect(page).to have_css('title', text: expected_page_title)
+  expect(page).to have_css("title", text: expected_page_title, visible: false)
 end

--- a/spec/views/twitter_player_cards/_meta.html.erb_spec.rb
+++ b/spec/views/twitter_player_cards/_meta.html.erb_spec.rb
@@ -27,7 +27,11 @@ describe "twitter_player_cards/_meta.html.erb" do
       "player:stream:content_type" => "video/mp4",
     }.each do |key, content|
       expect(rendered).
-        to have_css("meta[name='twitter:#{key}'][content='#{content}']")
+        to have_css(twitter_meta_tag(key, content), visible: false)
     end
+  end
+
+  def twitter_meta_tag(key, content)
+    "meta[name='twitter:#{key}'][content='#{content}']"
   end
 end


### PR DESCRIPTION
In a previous upgrade the `Capybara.ignore_hidden_elements` setting was
switched to `false` which has the effect of letting Capybara `find` elements on
the page that a user would not see. This looks to be associated to an upgrade
of Rspec and was likely used as a temporary fix to get the suite back to green.

This update reverts the configuration to once again have Capybara ignore hidden
elements. This more closely models a user interacting with the page and is thus
a good default. When needed, Capybara finders and matchers can use the
`visible: false` option to explicitly find hidden elements such as meta tags
and RSS feed links.
