### PR TITLE
Instruct spring to watch additional routes files

### DIFF
--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,1 +1,3 @@
 require 'spring/commands/rspec'
+
+Spring.watch("config/routes")


### PR DESCRIPTION
We are defining our routes in multiple files that are required into the main
config/routes.rb file, but Spring is unaware of this. This means Spring needs
to be restarted to pick up changes not in the main routes file.

This commit updates the Spring configuration to also watch all files in the
`config/routes/` directory. It does so at startup, so new routes files will not
be picked up, but at least new routes in existing files will be.
