### PR TITLE
Build out initial quiz & question admin flows

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-ui
+//= require jquery.ba-throttle-debounce
 //= require prettify/prettify
 //= require prettyprint
 //= require jquery.jsPlumb-1.4.0-all-min

--- a/app/assets/stylesheets/_questions-admin.scss
+++ b/app/assets/stylesheets/_questions-admin.scss
@@ -1,0 +1,47 @@
+$row-highlight: #eee;
+$light-gray-border: #ccc;
+
+.questions-list {
+  border-collapse: collapse;
+  border-spacing: 1px;
+  margin: 10px 0;
+}
+
+tr {
+  &:nth-child(2n) {
+    background: $row-highlight;
+  }
+}
+
+td {
+  border: 1px solid $light-gray-border;
+  padding: 2px 5px;
+  text-align: left;
+}
+
+.question-admin {
+  form {
+    float: left;
+    max-width: 350px;
+
+  }
+
+  input,
+  textarea {
+    width: 350px;
+  }
+
+  .preview-wrapper {
+    float: right;
+  }
+
+  .question-preview {
+    border: 1px solid $light-gray-border;
+    border-radius: 2px;
+    height: 568px;
+    -webkit-overflow-scrolling: touch;
+    overflow-y: scroll;
+    padding: 0.5em;
+    width: 320px;
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -52,6 +52,7 @@
 @import "topic-label";
 @import "teachers";
 @import "results-show";
+@import "questions-admin";
 
 @import "landing/pages";
 @import "landing/nav";

--- a/app/controllers/admin/question_previews_controller.rb
+++ b/app/controllers/admin/question_previews_controller.rb
@@ -1,0 +1,19 @@
+class Admin::QuestionPreviewsController < ApplicationController
+  def create
+    @quiz = find_quiz
+    @question = @quiz.questions.new(question_params)
+    @reviewing = true
+
+    render "questions/show", layout: false
+  end
+
+  private
+
+  def find_quiz
+    Quiz.find(params[:quiz_id])
+  end
+
+  def question_params
+    params.require(:question).permit(:title, :prompt, :answer, :position)
+  end
+end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,0 +1,41 @@
+class Admin::QuestionsController < ApplicationController
+  def new
+    @quiz = find_quiz
+    @question = @quiz.questions.new
+  end
+
+  def create
+    @quiz = find_quiz
+    @question = @quiz.questions.create(question_params)
+
+    if @question.save
+      redirect_to admin_quiz_path(@quiz)
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @quiz = find_quiz
+    @question = @quiz.questions.find(params[:id])
+  end
+
+  def update
+    @quiz = find_quiz
+    @question = @quiz.questions.find(params[:id])
+
+    @question.update(question_params)
+
+    redirect_to admin_quiz_path(@quiz)
+  end
+
+  private
+
+  def find_quiz
+    Quiz.find(params[:quiz_id])
+  end
+
+  def question_params
+    params.require(:question).permit(:title, :prompt, :answer, :position)
+  end
+end

--- a/app/controllers/admin/quizzes_controller.rb
+++ b/app/controllers/admin/quizzes_controller.rb
@@ -1,0 +1,36 @@
+class Admin::QuizzesController < ApplicationController
+  def index
+    @quizzes = Quiz.all
+  end
+
+  def new
+    @quiz = Quiz.new
+  end
+
+  def create
+    @quiz = build_quiz
+    if @quiz.save
+      redirect_to admin_quiz_path(@quiz)
+    else
+      render :new
+    end
+  end
+
+  def show
+    @quiz = find_quiz
+  end
+
+  private
+
+  def find_quiz
+    Quiz.find(params[:id])
+  end
+
+  def build_quiz
+    Quiz.new(quiz_params)
+  end
+
+  def quiz_params
+    params.require(:quiz).permit(:title)
+  end
+end

--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -1,0 +1,36 @@
+<div class="question-admin">
+  <h2><%= link_to quiz.title, admin_quiz_path(quiz) %></h2>
+
+  <%= semantic_form_for([:admin, quiz, question]) do |f| %>
+    <%= f.input :title %>
+    <%= f.input :position %>
+    <%= f.input :prompt %>
+    <%= f.input :answer %>
+    <%= f.submit %>
+  <% end %>
+
+  <div class="preview-wrapper">
+    <p>Note -- the title will not be displayed in the preview</p>
+    <div class="question-preview"></div>
+
+    <% content_for :javascript do %>
+      <script type="text/javascript">
+        $(function() {
+          var previewUrl = "<%= admin_quiz_question_preview_path(quiz) %>";
+          var $questionForm = $("form.question");
+          var $questionPreview = $(".question-preview");
+
+          var loadPreview = $.debounce(300, function() {
+            var previewFetched = $.post(previewUrl, $questionForm.serialize());
+            previewFetched.done(function(response) {
+              $questionPreview.html(response);
+            });
+          });
+
+          $questionForm.on("keyup", loadPreview);
+          loadPreview();
+        });
+      </script>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", quiz: @quiz, question: @question %>

--- a/app/views/admin/questions/new.html.erb
+++ b/app/views/admin/questions/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", quiz: @quiz, question: @question %>

--- a/app/views/admin/quizzes/index.html.erb
+++ b/app/views/admin/quizzes/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Quizzes List</h1>
+
+<ul class="quizzes-list">
+  <% @quizzes.each do |quiz| %>
+    <li class="quiz">
+      <%= link_to quiz.title, admin_quiz_path(quiz) %>
+    </li>
+  <% end %>
+</ul>
+
+<%= link_to "Add Quiz", new_admin_quiz_path %>

--- a/app/views/admin/quizzes/new.html.erb
+++ b/app/views/admin/quizzes/new.html.erb
@@ -1,0 +1,4 @@
+<%= semantic_form_for [:admin, @quiz] do |f| %>
+  <%= f.input :title %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/quizzes/show.html.erb
+++ b/app/views/admin/quizzes/show.html.erb
@@ -1,0 +1,17 @@
+<%= link_to "< all quizzes", admin_quizzes_path %>
+
+<h1><%= @quiz.title %></h1>
+
+<h3>Questions:</h3>
+<table class="questions-list">
+  <% @quiz.questions.each do |question| %>
+    <tr class="question" data-id="<%= question.id %>">
+      <td><%= question.position %></td>
+      <td class="title"><%= question.title %></td>
+      <td><%= link_to "Edit", edit_admin_quiz_question_path(@quiz, question) %></td>
+      <td><%= link_to "View", quiz_question_path(@quiz, question) %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= link_to "Add Question", new_admin_quiz_question_path(@quiz) %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -5,4 +5,14 @@ scope module: 'admin' do
   resource :masquerade, only: :destroy
 end
 
+constraints Clearance::Constraints::SignedIn.new(&:admin?) do
+  namespace :admin do
+    resources :quizzes, only: [:new, :create, :show, :index] do
+      resources :questions, only: [:new, :create, :edit, :update]
+      resource :question_preview, only: [:create]
+      patch :question_preview, to: "question_previews#create"
+    end
+  end
+end
+
 mount RailsAdmin::Engine => "/admin", as: :admin

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -486,7 +486,7 @@ FactoryGirl.define do
   end
 
   factory :question do
-    title "Null object pattern"
+    sequence(:title) { |n| "Question Title #{n}" }
     prompt "How could you avoid testing for nil in these lines"
     answer "Use the Null Object pattern!"
     quiz

--- a/spec/features/admin_creates_quiz_spec.rb
+++ b/spec/features/admin_creates_quiz_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+feature "Admin creates a quiz" do
+  scenario "is redirected away if not an admin" do
+    visit new_admin_quiz_path(as: create(:subscriber))
+
+    expect(current_path).to eq(practice_path)
+  end
+
+  scenario "successfully" do
+    visit admin_quizzes_path(as: create(:admin))
+
+    create_quiz_with_title("A new quiz")
+
+    visit admin_quizzes_path
+
+    expect(page).to have_css(".quiz", count: 1, text: "A new quiz")
+  end
+
+  scenario "and adds a question" do
+    quiz = create(:quiz)
+    question = build_stubbed(:question)
+
+    visit admin_quiz_path(quiz, as: create(:admin))
+    click_on "Add Question"
+    submit_question_form_for question
+
+    expect(current_path).to eq(admin_quiz_path(quiz))
+    expect(page).to have_css(".question", text: question.title)
+  end
+
+  scenario "and can see a live preview of the question", js: true do
+    quiz = create(:quiz)
+
+    visit new_admin_quiz_question_path(quiz, as: create(:admin))
+    fill_in "Prompt", with: "Hello **world**"
+
+    expect(question_preview).to have_css("strong", text: "world")
+  end
+
+  scenario "and edits a question", js: true do
+    edit_question_as_admin
+
+    fill_in "Title", with: "Updated Question Title"
+    click_on "Update Question"
+
+    expect(page).to have_css(".question", text: "Updated Question Title")
+  end
+
+  def expect_first_listed_question_to_be(question)
+    expect(page).
+      to have_css(".question:first-child .title", text: question.title)
+  end
+
+  def edit_question_position_to_be(question, position)
+    edit_question(question)
+    fill_in "Position", with: position
+    click_on "Update Question"
+  end
+
+  def edit_question_as_admin(question = create(:question))
+    visit admin_quiz_path(question.quiz, as: create(:admin))
+    edit_question(question)
+  end
+
+  def edit_question(question)
+    within "tr[data-id='#{question.id}']" do
+      click_on "Edit"
+    end
+  end
+
+  def submit_question_form_for(question)
+    fill_in "Title", with: question.title
+    fill_in "Prompt", with: question.prompt
+    fill_in "Answer", with: question.answer
+    click_on "Create Question"
+  end
+
+  def question_preview
+    find(".question-preview")
+  end
+
+  def create_quiz_with_title(title)
+    click_on "Add Quiz"
+    fill_in "Title", with: title
+    click_on "Create Quiz"
+  end
+end

--- a/vendor/assets/javascripts/jquery.ba-throttle-debounce.js
+++ b/vendor/assets/javascripts/jquery.ba-throttle-debounce.js
@@ -1,0 +1,252 @@
+/*!
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+
+// Script: jQuery throttle / debounce: Sometimes, less is more!
+//
+// *Version: 1.1, Last updated: 3/7/2010*
+// 
+// Project Home - http://benalman.com/projects/jquery-throttle-debounce-plugin/
+// GitHub       - http://github.com/cowboy/jquery-throttle-debounce/
+// Source       - http://github.com/cowboy/jquery-throttle-debounce/raw/master/jquery.ba-throttle-debounce.js
+// (Minified)   - http://github.com/cowboy/jquery-throttle-debounce/raw/master/jquery.ba-throttle-debounce.min.js (0.7kb)
+// 
+// About: License
+// 
+// Copyright (c) 2010 "Cowboy" Ben Alman,
+// Dual licensed under the MIT and GPL licenses.
+// http://benalman.com/about/license/
+// 
+// About: Examples
+// 
+// These working examples, complete with fully commented code, illustrate a few
+// ways in which this plugin can be used.
+// 
+// Throttle - http://benalman.com/code/projects/jquery-throttle-debounce/examples/throttle/
+// Debounce - http://benalman.com/code/projects/jquery-throttle-debounce/examples/debounce/
+// 
+// About: Support and Testing
+// 
+// Information about what version or versions of jQuery this plugin has been
+// tested with, what browsers it has been tested in, and where the unit tests
+// reside (so you can test it yourself).
+// 
+// jQuery Versions - none, 1.3.2, 1.4.2
+// Browsers Tested - Internet Explorer 6-8, Firefox 2-3.6, Safari 3-4, Chrome 4-5, Opera 9.6-10.1.
+// Unit Tests      - http://benalman.com/code/projects/jquery-throttle-debounce/unit/
+// 
+// About: Release History
+// 
+// 1.1 - (3/7/2010) Fixed a bug in <jQuery.throttle> where trailing callbacks
+//       executed later than they should. Reworked a fair amount of internal
+//       logic as well.
+// 1.0 - (3/6/2010) Initial release as a stand-alone project. Migrated over
+//       from jquery-misc repo v0.4 to jquery-throttle repo v1.0, added the
+//       no_trailing throttle parameter and debounce functionality.
+// 
+// Topic: Note for non-jQuery users
+// 
+// jQuery isn't actually required for this plugin, because nothing internal
+// uses any jQuery methods or properties. jQuery is just used as a namespace
+// under which these methods can exist.
+// 
+// Since jQuery isn't actually required for this plugin, if jQuery doesn't exist
+// when this plugin is loaded, the method described below will be created in
+// the `Cowboy` namespace. Usage will be exactly the same, but instead of
+// $.method() or jQuery.method(), you'll need to use Cowboy.method().
+
+(function(window,undefined){
+  '$:nomunge'; // Used by YUI compressor.
+  
+  // Since jQuery really isn't required for this plugin, use `jQuery` as the
+  // namespace only if it already exists, otherwise use the `Cowboy` namespace,
+  // creating it if necessary.
+  var $ = window.jQuery || window.Cowboy || ( window.Cowboy = {} ),
+    
+    // Internal method reference.
+    jq_throttle;
+  
+  // Method: jQuery.throttle
+  // 
+  // Throttle execution of a function. Especially useful for rate limiting
+  // execution of handlers on events like resize and scroll. If you want to
+  // rate-limit execution of a function to a single time, see the
+  // <jQuery.debounce> method.
+  // 
+  // In this visualization, | is a throttled-function call and X is the actual
+  // callback execution:
+  // 
+  // > Throttled with `no_trailing` specified as false or unspecified:
+  // > ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+  // > X    X    X    X    X    X        X    X    X    X    X    X
+  // > 
+  // > Throttled with `no_trailing` specified as true:
+  // > ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+  // > X    X    X    X    X             X    X    X    X    X
+  // 
+  // Usage:
+  // 
+  // > var throttled = jQuery.throttle( delay, [ no_trailing, ] callback );
+  // > 
+  // > jQuery('selector').bind( 'someevent', throttled );
+  // > jQuery('selector').unbind( 'someevent', throttled );
+  // 
+  // This also works in jQuery 1.4+:
+  // 
+  // > jQuery('selector').bind( 'someevent', jQuery.throttle( delay, [ no_trailing, ] callback ) );
+  // > jQuery('selector').unbind( 'someevent', callback );
+  // 
+  // Arguments:
+  // 
+  //  delay - (Number) A zero-or-greater delay in milliseconds. For event
+  //    callbacks, values around 100 or 250 (or even higher) are most useful.
+  //  no_trailing - (Boolean) Optional, defaults to false. If no_trailing is
+  //    true, callback will only execute every `delay` milliseconds while the
+  //    throttled-function is being called. If no_trailing is false or
+  //    unspecified, callback will be executed one final time after the last
+  //    throttled-function call. (After the throttled-function has not been
+  //    called for `delay` milliseconds, the internal counter is reset)
+  //  callback - (Function) A function to be executed after delay milliseconds.
+  //    The `this` context and all arguments are passed through, as-is, to
+  //    `callback` when the throttled-function is executed.
+  // 
+  // Returns:
+  // 
+  //  (Function) A new, throttled, function.
+  
+  $.throttle = jq_throttle = function( delay, no_trailing, callback, debounce_mode ) {
+    // After wrapper has stopped being called, this timeout ensures that
+    // `callback` is executed at the proper times in `throttle` and `end`
+    // debounce modes.
+    var timeout_id,
+      
+      // Keep track of the last time `callback` was executed.
+      last_exec = 0;
+    
+    // `no_trailing` defaults to falsy.
+    if ( typeof no_trailing !== 'boolean' ) {
+      debounce_mode = callback;
+      callback = no_trailing;
+      no_trailing = undefined;
+    }
+    
+    // The `wrapper` function encapsulates all of the throttling / debouncing
+    // functionality and when executed will limit the rate at which `callback`
+    // is executed.
+    function wrapper() {
+      var that = this,
+        elapsed = +new Date() - last_exec,
+        args = arguments;
+      
+      // Execute `callback` and update the `last_exec` timestamp.
+      function exec() {
+        last_exec = +new Date();
+        callback.apply( that, args );
+      };
+      
+      // If `debounce_mode` is true (at_begin) this is used to clear the flag
+      // to allow future `callback` executions.
+      function clear() {
+        timeout_id = undefined;
+      };
+      
+      if ( debounce_mode && !timeout_id ) {
+        // Since `wrapper` is being called for the first time and
+        // `debounce_mode` is true (at_begin), execute `callback`.
+        exec();
+      }
+      
+      // Clear any existing timeout.
+      timeout_id && clearTimeout( timeout_id );
+      
+      if ( debounce_mode === undefined && elapsed > delay ) {
+        // In throttle mode, if `delay` time has been exceeded, execute
+        // `callback`.
+        exec();
+        
+      } else if ( no_trailing !== true ) {
+        // In trailing throttle mode, since `delay` time has not been
+        // exceeded, schedule `callback` to execute `delay` ms after most
+        // recent execution.
+        // 
+        // If `debounce_mode` is true (at_begin), schedule `clear` to execute
+        // after `delay` ms.
+        // 
+        // If `debounce_mode` is false (at end), schedule `callback` to
+        // execute after `delay` ms.
+        timeout_id = setTimeout( debounce_mode ? clear : exec, debounce_mode === undefined ? delay - elapsed : delay );
+      }
+    };
+    
+    // Set the guid of `wrapper` function to the same of original callback, so
+    // it can be removed in jQuery 1.4+ .unbind or .die by using the original
+    // callback as a reference.
+    if ( $.guid ) {
+      wrapper.guid = callback.guid = callback.guid || $.guid++;
+    }
+    
+    // Return the wrapper function.
+    return wrapper;
+  };
+  
+  // Method: jQuery.debounce
+  // 
+  // Debounce execution of a function. Debouncing, unlike throttling,
+  // guarantees that a function is only executed a single time, either at the
+  // very beginning of a series of calls, or at the very end. If you want to
+  // simply rate-limit execution of a function, see the <jQuery.throttle>
+  // method.
+  // 
+  // In this visualization, | is a debounced-function call and X is the actual
+  // callback execution:
+  // 
+  // > Debounced with `at_begin` specified as false or unspecified:
+  // > ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+  // >                          X                                 X
+  // > 
+  // > Debounced with `at_begin` specified as true:
+  // > ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+  // > X                                 X
+  // 
+  // Usage:
+  // 
+  // > var debounced = jQuery.debounce( delay, [ at_begin, ] callback );
+  // > 
+  // > jQuery('selector').bind( 'someevent', debounced );
+  // > jQuery('selector').unbind( 'someevent', debounced );
+  // 
+  // This also works in jQuery 1.4+:
+  // 
+  // > jQuery('selector').bind( 'someevent', jQuery.debounce( delay, [ at_begin, ] callback ) );
+  // > jQuery('selector').unbind( 'someevent', callback );
+  // 
+  // Arguments:
+  // 
+  //  delay - (Number) A zero-or-greater delay in milliseconds. For event
+  //    callbacks, values around 100 or 250 (or even higher) are most useful.
+  //  at_begin - (Boolean) Optional, defaults to false. If at_begin is false or
+  //    unspecified, callback will only be executed `delay` milliseconds after
+  //    the last debounced-function call. If at_begin is true, callback will be
+  //    executed only at the first debounced-function call. (After the
+  //    throttled-function has not been called for `delay` milliseconds, the
+  //    internal counter is reset)
+  //  callback - (Function) A function to be executed after delay milliseconds.
+  //    The `this` context and all arguments are passed through, as-is, to
+  //    `callback` when the debounced-function is executed.
+  // 
+  // Returns:
+  // 
+  //  (Function) A new, debounced, function.
+  
+  $.debounce = function( delay, at_begin, callback ) {
+    return callback === undefined
+      ? jq_throttle( delay, at_begin, false )
+      : jq_throttle( delay, callback, at_begin !== false );
+  };
+  
+})(this);


### PR DESCRIPTION
Previously we relied entirely on rails admin for our admin needs. While it worked well for simple CRUD management, it quickly failed us as our workflows become more complex such as trail & exercise management. Further, we've had a number of instances where rails admin functionality has broken without us realizing leaving us scrambling when we needed to update something.

This PR introduces a distinct admin interface for the quiz & questions flow. We've implemented the main features we need and have test coverage to prevent accidental breaking. It does not cover everything, but provides a straightforward interface for the main workflows while assuming anything not implemented can be handled in the console.

The specific functionality implement is:
1. Listing quizzes
2. Creating a new quiz
3. Viewing questions for a quiz
4. Adding / editing a question (with live preview)
5. Re-ordering the questions within a quiz.

Walkthrough:

![quiz-admin](https://cloud.githubusercontent.com/assets/420113/7710303/f627fd7e-fe30-11e4-9725-cd61ab5bcd1d.gif)
