### PR TITLE
Only show quizzes with questions

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,6 +1,6 @@
 class QuizzesController < ApplicationController
   def index
-    @quizzes = Quiz.all
+    @quizzes = Quiz.with_questions
   end
 
   def show

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -3,6 +3,10 @@ class Quiz < ActiveRecord::Base
 
   has_many :questions, -> { order(position: :asc) }, dependent: :destroy
 
+  def self.with_questions
+    all.select { |quiz| quiz.questions.any? }
+  end
+
   def first_question
     questions.first
   end

--- a/spec/models/quiz_spec.rb
+++ b/spec/models/quiz_spec.rb
@@ -5,6 +5,16 @@ describe Quiz do
 
   it { should have_many(:questions).dependent(:destroy) }
 
+  describe ".with_questions" do
+    it "returns only quizzes with questions" do
+      first_quiz, second_quiz = create_pair(:quiz)
+
+      question = create(:question, quiz: first_quiz)
+
+      expect(Quiz.with_questions).to eq([first_quiz])
+    end
+  end
+
   describe "#first_question" do
     it "returns the first question" do
       quiz = create(:quiz)


### PR DESCRIPTION
Currently we redirect to a quizzes first question for the `#show` action, which errors out if there are no questions. This adds a scope to the `Quiz` model that is used to build the list displayed on the quiz index.
