### PR TITLE
Show users questions on which they were not confident

### DIFF
--- a/app/assets/stylesheets/_questions-show.scss
+++ b/app/assets/stylesheets/_questions-show.scss
@@ -3,7 +3,19 @@
     display: none;
   }
 
+  .confidence {
+    margin-top: 30px;
+  }
+
+  .confidence-prompt {
+    margin-bottom: 25px;
+  }
+
   .confidence form {
     display: inline;
+  }
+
+  .low-rating {
+    margin-top: 25px;
   }
 }

--- a/app/assets/stylesheets/_quizzes-index.scss
+++ b/app/assets/stylesheets/_quizzes-index.scss
@@ -1,0 +1,9 @@
+.questions-needing-review {
+  margin-bottom: 30px;
+  margin-top: 20px;
+}
+
+.quizzes {
+  margin-bottom: 50px;
+  margin-top: 8px;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -53,6 +53,7 @@
 @import "teachers";
 @import "results-show";
 @import "questions-admin";
+@import "quizzes-index";
 
 @import "landing/pages";
 @import "landing/nav";

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,6 +1,7 @@
 class QuizzesController < ApplicationController
   def index
     @quizzes = Quiz.all
+    @questions_to_review = QuestionsNeedingReviewQuery.new(current_user).run
   end
 
   def show

--- a/app/helpers/quiz_helper.rb
+++ b/app/helpers/quiz_helper.rb
@@ -1,0 +1,8 @@
+module QuizHelper
+  def review_link(question)
+    link_to(
+      question.title,
+      quiz_question_path(question.quiz, question, mode: "reviewing")
+    )
+  end
+end

--- a/app/models/null_attempt.rb
+++ b/app/models/null_attempt.rb
@@ -1,5 +1,5 @@
 class NullAttempt
   def confidence
-    "-"
+    0
   end
 end

--- a/app/models/questions_needing_review_query.rb
+++ b/app/models/questions_needing_review_query.rb
@@ -1,0 +1,15 @@
+class QuestionsNeedingReviewQuery
+  CONFIDENCE_THRESHOLD = 4
+
+  def initialize(user)
+    @user = user
+  end
+
+  def run
+    Question.
+      all.
+      map { |q| q.most_recent_attempt_for(@user) }.
+      select { |a| a.confidence > 0 && a.confidence < CONFIDENCE_THRESHOLD }.
+      map(&:question)
+  end
+end

--- a/app/views/questions/_hidden_answer.html.erb
+++ b/app/views/questions/_hidden_answer.html.erb
@@ -5,12 +5,14 @@
   <%= format_markdown question.answer %>
 
   <div class="confidence">
-    <h4><%= t(".confidence-prompt") %></h4>
+    <h5 class="confidence-prompt"><%= t(".confidence-prompt") %></h5>
 
     <% (1..5).each do |confidence| %>
       <%= render partial: "attempts/confidence_button",
         locals: { question: question, confidence: confidence } %>
     <% end %>
+
+    <h4 class="low-rating"><%= t(".low-rating-adds-to-review-queue") %></h4>
   </div>
 </div>
 

--- a/app/views/questions/_needing_review.html.erb
+++ b/app/views/questions/_needing_review.html.erb
@@ -1,0 +1,9 @@
+<% if @questions_to_review.present? %>
+  <h3><%= t(".review-queue") %></h3>
+
+  <ul>
+    <% @questions_to_review.each do |question| %>
+      <li><%= review_link(question) %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,4 +1,10 @@
-<h2><%= t('.title') %></h2>
+<h3><%= t('.title') %></h3>
+
 <section class="quizzes">
   <%= render @quizzes %>
+
+</section>
+
+<section class="questions-needing-review">
+  <%= render "questions/needing_review" %>
 </section>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -11,8 +11,7 @@
   <% @quiz.questions.each do |question| %>
     <tr class="attempt" data-question="<%= question.id %>">
       <td>
-        <%= link_to question.title,
-          quiz_question_path(question.quiz, question, mode: "reviewing") %>
+        <%= review_link(question) %>
       </td>
       <td class="confidence">
         <%= question.most_recent_attempt_for(current_user).confidence %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,12 +70,15 @@ en:
   questions:
     hidden_answer:
       confidence-prompt: "How confident did you feel with this topic? (5 is best)"
+      low-rating-adds-to-review-queue: Ratings below 4 will add this question to your review queue.
       reveal-answer: Reveal Answer
     show:
       answer: Answer
       next-question: Next Question
       numbered-title: Question %{position} of %{total}
       return-to-results: Return to Quiz Results
+    needing_review:
+      review-queue: Question Review Queue
   quizzes:
     index:
       title: Quizzes

--- a/spec/features/subscriber_views_quizzes_spec.rb
+++ b/spec/features/subscriber_views_quizzes_spec.rb
@@ -57,6 +57,18 @@ feature "Subscriber views quizzes" do
 
       expect(current_path).to eq(quiz_results_path(question.quiz))
     end
+
+    scenario "and marks a question as needing review" do
+      question = create(:question)
+
+      navigate_to_quiz(question.quiz)
+      mark_confidence_as(2)
+      visit quizzes_path
+
+      within(".questions-needing-review") do
+        expect(page).to have_link(question.title)
+      end
+    end
   end
 
   def navigate_to_quiz(quiz)

--- a/spec/models/null_attempt_spec.rb
+++ b/spec/models/null_attempt_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe NullAttempt do
   describe "#confidence" do
-    it "should be a '-' to signify the user not having attempted" do
-      expect(NullAttempt.new.confidence).to eq("-")
+    it "should be a 0 to signify the user not having attempted" do
+      expect(NullAttempt.new.confidence).to eq(0)
     end
   end
 end

--- a/spec/models/questions_needing_review_query_spec.rb
+++ b/spec/models/questions_needing_review_query_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe QuestionsNeedingReviewQuery do
+  describe "#run" do
+    it "returns questions whose last attempt had low confidence" do
+      user = create(:user)
+      low_confidence_question = create(:question)
+      create(
+        :attempt,
+        question: low_confidence_question,
+        user: user,
+        confidence: 1
+      )
+      question = create(:question)
+      create(:attempt, question: question, user: user, confidence: 1)
+      create(:attempt, question: question, user: user, confidence: 5)
+
+      result = QuestionsNeedingReviewQuery.new(user).run
+
+      expect(result).to eq([low_confidence_question])
+    end
+  end
+end


### PR DESCRIPTION
When a user rates their confidence at a 3 or lower, add it to a list of
questions that need to be reviewed, displayed on the quiz index.

This makes it easy for users to review questions with which they
struggled. This is particularly nice because they can review supporting
material outside of the quiz session itself (and possibly on a
non-mobile device).

If a user re-answers a question and rates it a 4 or 5, it will be
removed from the review list.

![example](https://cloud.githubusercontent.com/assets/46677/7714766/8c6b7572-fe4f-11e4-9709-e15b051cc273.gif)
