### PR TITLE
Hide the nav on question and quiz pages

### DIFF
--- a/app/assets/stylesheets/_questions-show.scss
+++ b/app/assets/stylesheets/_questions-show.scss
@@ -1,3 +1,17 @@
+.questions,
+.quizzes,
+.results {
+  #header-wrapper {
+    margin: 0 auto;
+
+    @include body-mobile {
+      nav {
+        display: none;
+      }
+    }
+  }
+}
+
 .questions-show {
   .hidden {
     display: none;


### PR DESCRIPTION
The nav links in the header take up a considerable amount of the vertical space
on mobile. On most pages this is fine, but on the quiz pages it means needing
to scroll down on every single question to see the content.

This change hides all navigation elements other than the primary "Upcase" link
when users are viewing a quiz, question, or the results page.

![image](https://cloud.githubusercontent.com/assets/420113/7729534/58440a54-fee3-11e4-85b8-f1571994ef99.png)
