### PR TITLE
Force push deploys via bin/deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -20,7 +20,7 @@ if [ -z "$1" ]; then
   printf "You must provide an environment (staging|production).\n"
   exit 1
 else
-  git push "$1" "$branch:master"
+  git push --force "$1" "$branch:master"
   heroku run rake db:migrate --remote "$1"
   heroku restart --remote "$1"
 


### PR DESCRIPTION
Often we want to push an in-work feature branch to staging in order to test it
out in a more production-like environment. If this is done and the branch is
later squashed and merged into master, the eventually deploy via bin/deploy
will fail as it cannot push a non fast-forward change to heroku.

This updates the bin/deploy script to use `git push --force`. For staging, this
feels like the right default as the act of deploying is saying "I want this
code on staging". For production this should be a non-issue as we should only
ever deploy master, and we never change history on master.
