### PR TITLE
Record customer acquisition channel on User

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -35,7 +35,12 @@ class CheckoutsController < ApplicationController
   end
 
   def build_checkout(arguments)
-    plan.checkouts.build(arguments.merge(default_params))
+    plan.checkouts.build(
+      arguments.
+        merge(default_params).
+        merge(coupon_param).
+        merge(campaign_param)
+    )
   end
 
   def default_params
@@ -44,12 +49,25 @@ class CheckoutsController < ApplicationController
         user: current_user,
         github_username: current_user.github_username,
         stripe_customer_id: current_user.stripe_customer_id,
-        stripe_coupon_id: session[:coupon]
       }
     else
+      {}
+    end
+  end
+
+  def coupon_param
+    {
+      stripe_coupon_id: session[:coupon]
+    }
+  end
+
+  def campaign_param
+    if session[:campaign_params]
       {
-        stripe_coupon_id: session[:coupon]
+        utm_source: session[:campaign_params][:utm_source]
       }
+    else
+      {}
     end
   end
 

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -10,6 +10,7 @@ class Checkout < ActiveRecord::Base
     organization
     password
     state
+    utm_source
     zip_code
   )
 

--- a/db/migrate/20150601224106_add_utm_souce_to_users.rb
+++ b/db/migrate/20150601224106_add_utm_souce_to_users.rb
@@ -1,0 +1,5 @@
+class AddUtmSouceToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :utm_source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150520133739) do
+ActiveRecord::Schema.define(version: 20150601224106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -342,6 +342,7 @@ ActiveRecord::Schema.define(version: 20150520133739) do
     t.integer  "mentor_id"
     t.integer  "team_id"
     t.boolean  "has_quiz_access",                default: false, null: false
+    t.string   "utm_source"
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -89,6 +89,24 @@ describe CheckoutsController do
 
       expect(session[:coupon]).to be_nil
     end
+
+    context "with customer acquisition channel saved in session" do
+      it "records channel as utm_source" do
+        session[:campaign_params] = { utm_source: "adwords" }
+        user = create(:user, utm_source: nil)
+        stub_current_user_with user
+        plan = create(:plan)
+        stripe_token = "token"
+
+        post(
+          :create,
+          checkout: customer_params(stripe_token),
+          plan: plan
+        )
+
+        expect(user.reload.utm_source).to eq "adwords"
+      end
+    end
   end
 
   def customer_params(token = "stripe token")


### PR DESCRIPTION
Why? Per-customer acquisition channel, better track:
- Activation / Onboarding
- Retention / LTV
- Referral / K-factor

What:
- Add `User#utm_source` database column / ActiveRecord attribute.
- Record `utm_source` on User during checkout,
  taking advantage of existing `before_filter :capture_campaign_params`.
