### PR TITLE
Highlight the virtual cursor position used in vim deck

### DIFF
--- a/app/assets/stylesheets/_questions-show.scss
+++ b/app/assets/stylesheets/_questions-show.scss
@@ -10,5 +10,9 @@
       }
     }
   }
+
+  .cursor {
+    background: $gray-3;
+  }
 }
 


### PR DESCRIPTION
Lets us do questions like this:

![screen shot 2015-06-02 at 1 26 07 pm](https://cloud.githubusercontent.com/assets/46677/7942245/f3c82036-092a-11e5-807a-10c296bf030c.png)
