### PR TITLE
Indicate if a question was saved for review on results

### DIFF
--- a/app/assets/stylesheets/_flashcard-list.scss
+++ b/app/assets/stylesheets/_flashcard-list.scss
@@ -1,6 +1,6 @@
-.flashcard-teaser {
+.flashcard-about {
   font-size: $font-size-smallest;
-  padding-left: 2.85rem;
+  padding-left: 3rem;
   width: 100%;
 }
 
@@ -19,7 +19,7 @@
 }
 
 .to-flashcard {
-  @include align-items(center);
+  @include align-items(baseline);
   @include display(flex);
   @include flex-wrap(wrap);
 
@@ -30,12 +30,13 @@
 
   &::before {
     @extend %flashcard-colors;
-    @include size(2rem 1.35rem);
+    @include size(2.25rem 1.35rem);
     color: $flashcard-border-color;
-    content: "?";
+    content: "card";
     display: inline-block;
+    font-size: $font-size-smallest;
     font-weight: bold;
-    line-height: 1.5;
+    line-height: 1.75;
     margin-bottom: 0;
     margin-right: 0.5rem;
     text-align: center;
@@ -52,4 +53,27 @@
       }
     }
   }
+
+  a {
+    @include flex(1);
+  }
+}
+
+.kept-flashcard {
+  &::before {
+    border-color: $upcase-green;
+    color: $upcase-green;
+    content: "saved";
+  }
+
+  &:hover::before {
+    border-color: darken($upcase-green, 10%);
+    color: darken($upcase-green, 10%);
+  }
+}
+
+.saved-for-review {
+  color: $gray-3;
+  font-size: 0.9em;
+  padding-left: 10px;
 }

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,0 +1,9 @@
+module ResultsHelper
+  def saved_class_for(current_user, question)
+    if question.saved_for_review?(current_user)
+      "kept-flashcard"
+    else
+      ""
+    end
+  end
+end

--- a/app/models/attempt.rb
+++ b/app/models/attempt.rb
@@ -5,4 +5,11 @@ class Attempt < ActiveRecord::Base
 
   belongs_to :question
   belongs_to :user
+
+  LOW_CONFIDENCE = 1
+  HIGH_CONFIDENCE = 5
+
+  def low_confidence?
+    confidence == LOW_CONFIDENCE
+  end
 end

--- a/app/models/null_attempt.rb
+++ b/app/models/null_attempt.rb
@@ -2,4 +2,8 @@ class NullAttempt
   def confidence
     0
   end
+
+  def low_confidence?
+    false
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -19,4 +19,8 @@ class Question < ActiveRecord::Base
   def quiz_title
     quiz.title
   end
+
+  def saved_for_review?(user)
+    most_recent_attempt_for(user).low_confidence?
+  end
 end

--- a/app/views/questions/_hidden_answer.html.erb
+++ b/app/views/questions/_hidden_answer.html.erb
@@ -11,12 +11,12 @@
   clicking "<%= t(".next-flashcard") %>" will remove it.)</p>
 
   <%= form_for [question, question.attempts.new] do |f| %>
-    <%= f.hidden_field :confidence, value: 1 %>
+    <%= f.hidden_field :confidence, value: Attempt::LOW_CONFIDENCE %>
     <%= f.submit t(".save-for-review_html"), class: "keep-flashcard" %>
   <% end %>
 
   <%= form_for [question, question.attempts.new] do |f| %>
-    <%= f.hidden_field :confidence, value: 5 %>
+    <%= f.hidden_field :confidence, value: Attempt::HIGH_CONFIDENCE %>
     <%= f.submit t(".next-flashcard_html"), class: "next-flashcard" %>
   <% end %>
 </div>

--- a/app/views/questions/_needing_review.html.erb
+++ b/app/views/questions/_needing_review.html.erb
@@ -5,7 +5,7 @@
     <% @questions_to_review.each do |question| %>
       <li class="to-flashcard">
         <%= link_to question.title, quiz_question_path(question.quiz, question) %>
-        <p class="flashcard-teaser"><%= t("quiz-title-teaser", title: question.quiz_title) %></p>
+        <p class="flashcard-about"><%= t("quiz-title-teaser", title: question.quiz_title) %></p>
       </li>
     <% end %>
   </ul>

--- a/app/views/results/_question.html.erb
+++ b/app/views/results/_question.html.erb
@@ -1,0 +1,6 @@
+<li class="to-flashcard <%= saved_class_for(current_user, question) %>" data-question="<%= question.id %>">
+  <%= review_link(question) %>
+  <% if question.saved_for_review?(current_user) %>
+    <p class="flashcard-about"><%= t(".saved_for_review") %></p>
+  <% end %>
+</li>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -4,9 +4,5 @@
 <p><%= t(".explanation") %> or <%= link_to t(".back-to-all-quizzes"), quizzes_path %>.</p>
 
 <ul class="kept-flashcards">
-  <% @quiz.questions.each do |question| %>
-    <li class="to-flashcard" data-question="<%= question.id %>">
-      <%= review_link(question) %>
-    </li>
-  <% end %>
+  <%= render collection: @quiz.questions, partial: "results/question" %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
   repository:
     view_repository: View this Repository
   results:
+    question:
+      saved_for_review: Saved for review
     show:
       back-to-all-quizzes: return to all quizzes
       complete: 'Great job! You completed:'

--- a/spec/models/attempt_spec.rb
+++ b/spec/models/attempt_spec.rb
@@ -7,4 +7,26 @@ describe Attempt do
 
   it { should belong_to(:question) }
   it { should belong_to(:user) }
+
+  describe "#low_confidence?" do
+    context "when the confidence is low" do
+      it "returns true" do
+        attempt = build_stubbed(:attempt, confidence: Attempt::LOW_CONFIDENCE)
+
+        result = attempt.low_confidence?
+
+        expect(result).to be_truthy
+      end
+    end
+
+    context "when the confidence is high" do
+      it "returns false" do
+        attempt = build_stubbed(:attempt, confidence: Attempt::HIGH_CONFIDENCE)
+
+        result = attempt.low_confidence?
+
+        expect(result).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/null_attempt_spec.rb
+++ b/spec/models/null_attempt_spec.rb
@@ -6,4 +6,10 @@ describe NullAttempt do
       expect(NullAttempt.new.confidence).to eq(0)
     end
   end
+
+  describe "#low_confidence?" do
+    it "returns false" do
+      expect(NullAttempt.new.low_confidence?).to be_falsey
+    end
+  end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -66,4 +66,34 @@ describe Question do
       end
     end
   end
+
+  describe "#saved_for_review?" do
+    context "when the user saved it for review" do
+      it "returns true" do
+        question = create(:question)
+        attempt = create(
+          :attempt,
+          question: question,
+          confidence: Attempt::LOW_CONFIDENCE
+        )
+        user = attempt.user
+
+        expect(question.saved_for_review?(user)).to be_truthy
+      end
+    end
+
+    context "when the user did not save it for review" do
+      it "returns false" do
+        question = create(:question)
+        attempt = create(
+          :attempt,
+          question: question,
+          confidence: Attempt::HIGH_CONFIDENCE
+        )
+        user = attempt.user
+
+        expect(question.saved_for_review?(user)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/views/results/_question.html.erb_spec.rb
+++ b/spec/views/results/_question.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "results/_question.html.erb" do
+  context "when the user saved it for review" do
+    it "indicates that the question was saved for review" do
+      user = double("user")
+      question = build_stubbed(:question)
+      allow(question).to receive(:saved_for_review?).with(user).and_return(true)
+
+      render "results/question", question: question, current_user: user
+
+      expect(rendered).to include I18n.t("results.question.saved_for_review")
+      expect(rendered).to have_css(".kept-flashcard")
+    end
+  end
+
+  context "when the user did not saved it for review" do
+    it "does not indicate that the question was saved for review" do
+      user = double("user")
+      question = build_stubbed(:question)
+      allow(question).to(
+        receive(:saved_for_review?).
+        with(user).
+        and_return(false)
+      )
+
+      render "results/question", question: question, current_user: user
+
+      expect(rendered).not_to(
+        include I18n.t("results.question.saved_for_review")
+      )
+      expect(rendered).to_not have_css(".kept-flashcard")
+    end
+  end
+end


### PR DESCRIPTION
It's probably useful for a user to see which questions he/she saved for
review on the results page.

Note the "Saved for review" text below.

@conchan I could also see taking this a different direction and having a visual indicator instead of text. Either way, this could use a design pass. Thanks!

![screen shot 2015-06-03 at 2 28 45 pm](https://cloud.githubusercontent.com/assets/46677/7968149/e0de6930-09fc-11e5-90b5-94a60b21240c.png)
