### PR TITLE
Syntax highlight in the admin preview

### DIFF
--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -24,6 +24,9 @@
             var previewFetched = $.post(previewUrl, $questionForm.serialize());
             previewFetched.done(function(response) {
               $questionPreview.html(response);
+              $questionPreview.find("code").each(function(_, block) {
+                hljs.highlightBlock(block);
+              });
             });
           });
 


### PR DESCRIPTION
The hljs initializer in application.js hooks into the page load event and as
such only fires once. Since the preview content is dynamically loaded in after
page load, and is re-populated on all changes, it is never highlighted.

This change hooks into the update event to trigger the highlighting after the
content is replaced.

![admin-syntax-highlighting](https://cloud.githubusercontent.com/assets/420113/7985129/7344eaac-0a9c-11e5-9f95-1301df86f223.gif)
