### PR TITLE
Explain flash cards more fully on index view

### DIFF
--- a/app/views/questions/_needing_review.html.erb
+++ b/app/views/questions/_needing_review.html.erb
@@ -1,6 +1,6 @@
-<% if @questions_to_review.present? %>
-  <span class="divider"><h4 class="text"><%= t(".review-queue") %></h4></span>
+<span class="divider"><h4 class="text"><%= t(".review-queue") %></h4></span>
 
+<% if @questions_to_review.present? %>
   <ul class="kept-flashcards">
     <% @questions_to_review.each do |question| %>
       <li class="to-flashcard">
@@ -9,4 +9,7 @@
       </li>
     <% end %>
   </ul>
+<% else %>
+  <p><%= t(".blank-state-explanation", save_for_review_text:
+           t("questions.hidden_answer.save-for-review")) %></p>
 <% end %>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,6 +1,10 @@
 <section class="root-quizzes">
   <h3><%= t('.title') %></h3>
 
+  <h4><%= t(".subhead") %></h4>
+
+  <p><%= t('.feature_description') %></p>
+
   <section class="decks">
     <%= render @quizzes %>
   </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,9 @@ en:
       next-flashcard_html: 'next flashcard &rarr;'
     needing_review:
       review-queue: Saved Flashcards
+      blank-state-explanation: If you encounter a card that you want to return
+        to (like if its answer has interesting links that you'd like to read
+        later), just click "%{save_for_review_text}" and it will appear here.
     show:
       answer: 'Answer:'
       next-question: Next Question
@@ -84,7 +87,13 @@ en:
   quiz-title-teaser: 'From: %{title}'
   quizzes:
     index:
-      title: Quiz Decks
+      title: Flashcards
+      subhead: Become a better programmer, even if you've only got five minutes.
+      feature_description: Flashcards are short quizzes with questions and
+        answers provided. They're mobile-friendly, and a perfect fit for
+        commutes, waiting rooms, and coffee breaks. They cover the bite-sized
+        topics, code smells, patterns, and anti-patterns that experts know and
+        intermediates ought to learn.
     quiz:
       number_of_questions: '%{length} flashcards'
   repository:


### PR DESCRIPTION
### Add explanatory copy on quizzes#index.

What are flash cards? Why should you use them? Where?

![screen shot 2015-06-04 at 4 00 48 pm](https://cloud.githubusercontent.com/assets/46677/7993301/3db3987a-0ad3-11e5-8825-7ba99450dd87.png)
### Add explanatory text to the Review Queue when it's empty.

![screen shot 2015-06-04 at 4 00 44 pm](https://cloud.githubusercontent.com/assets/46677/7993300/3db34eb0-0ad3-11e5-8bd2-c417947cb375.png)
