### PR TITLE
Display videos behind trail step tooltips

### DIFF
--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -5,7 +5,9 @@
  * http://wistia.com/doc/video-foam
  */
 .wistia-wrapper {
+  position: relative;
   width: 100%;
+  z-index: 0;
 }
 
 .assets-wrapper {


### PR DESCRIPTION
Currently, the tooltips that appear when hovering over a trail step
appear partially obscured behind the Wistia player. This commit adds a
`z-index` to the Wistia wrapper so that the tooltips appear over videos.

Before: 
![screen shot 2015-06-09 at 3 40 54 pm](https://cloud.githubusercontent.com/assets/7756801/8067903/c2b6da70-0ebe-11e5-8f38-e21feaa84ac6.png)

After:
![screen shot 2015-06-09 at 3 40 41 pm](https://cloud.githubusercontent.com/assets/7756801/8067910/cb456620-0ebe-11e5-93e9-ac1d56e92c46.png)
