### PR TITLE
Don't open the newrelic addon during deploys

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -34,7 +34,6 @@ else
 
   if [ "$1" = "production" ]; then
     open https://upcase.com
-    heroku addons:open newrelic --remote "$1"
 
     if command -v watch >/dev/null; then
       watch heroku ps --remote "$1"


### PR DESCRIPTION
I haven't found this to be particularly useful, since I usually just
keep an eye on incoming Airbake emails for error tracking.
