### PR TITLE
Change copy on /practice

### DIFF
--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -9,11 +9,17 @@
   <div class="content">
     <section class="trails-progress">
       <section class="subject">
-        <h1>Welcome, <%= current_user.first_name %>.</h1>
-        <h2>
-          These new trails are focused exercises targeting your interests. They
-          help you learn by doing and keep your skillset sharp.
-        </h2>
+        <h1>Trails</h1>
+        <p>
+        These are trails, the perfect thing to tackle on a Saturday or a wide-open
+        evening when you're ready to write some code or watch longer videos.
+        </p>
+
+        <p>
+          Some trails consist of videos, like our tmux trail. Others use our
+          <strong>exercise system</strong>. In those, you'll clone down a git
+          repo and <strong>write code on your own machine</strong>.
+        </p>
       </section>
 
       <section class="incomplete-trails">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,16 +11,16 @@
         <% if signed_in? %>
           <% if onboarding_policy.onboarded? %>
             <li class="practice">
-              <%= link_to t("shared.header.practice"), practice_path %>
+              <%= link_to t("shared.header.trails"), practice_path %>
             </li>
             <li>
               <%= link_to t("shared.header.flashcards"), decks_path %>
             </li>
             <li class="explore">
-              <%= link_to t("shared.header.explore"), explore_path %>
+              <%= link_to t("shared.header.weekly_iteration"), show_path("the-weekly-iteration") %>
             </li>
             <li class="discuss">
-              <%= link_to t("shared.header.discuss"), Forum.url %>
+              <%= link_to t("shared.header.forum"), Forum.url %>
             </li>
             <% if show_upgrade_to_annual_cta? %>
               <li class="annual">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,11 +116,11 @@ en:
   shared:
     header:
       contact_your_mentor: Contact your mentor, %{mentor_name}
-      discuss: Discuss
-      explore: Explore
+      forum: Forum
+      weekly_iteration: Weekly Iteration
+      trails: Trails
       flashcards: Flashcards
       help-link: Help
-      practice: Practice
     subscription:
       name: Upcase
     subscriptions:

--- a/spec/features/user_accepts_team_invitation_spec.rb
+++ b/spec/features/user_accepts_team_invitation_spec.rb
@@ -50,7 +50,7 @@ feature "Accept team invitations" do
       fill_in "Password", with: "secret"
       click_on "Create an account"
 
-      expect(page).to have_content(I18n.t("pages.welcome.headline"))
+      expect(page).to have_content(I18n.t("shared.header.trails"))
     end
   end
 


### PR DESCRIPTION
- Describe trails using the same language as the welcome page.
- Update header to use nouns instead of verbs.
