### PR TITLE
Add button to seek video point for headings

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -10,6 +10,7 @@ $upcase-green: #57C75C;
 
 $red: #ad141e;
 $off-white: darken(white, 1.5);
+$white: #fff;
 $lightwarmgray: #F5F5F0;
 $warmgray: #D9D4CC;
 $darkwarmgray: #555;

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -39,6 +39,27 @@
   float: right;
 }
 
+.seek-button-template {
+  display: none;
+}
+
+.seek-marker {
+  background: $white;
+  border: 1px solid $upcase-blue;
+  color: $upcase-blue;
+  font-size: 9px;
+  margin-left: 12px;
+
+  @include dashboard-small-only {
+    display: none;
+  }
+
+  &:hover {
+    color: $white;
+    background-color: $upcase-blue;
+  }
+}
+
 .text-box {
   clear: left;
   margin-top: 1em;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   def format_markdown(markdown)
     if markdown.present?
       renderer = Redcarpet::Markdown.new(
-        Redcarpet::Render::HTML,
+        Redcarpet::Render::HTML.new(with_toc_data: true),
         autolink: true,
         tables: true,
         fenced_code_blocks: true

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -1,0 +1,10 @@
+class Marker < ActiveRecord::Base
+  belongs_to :video
+
+  validates :anchor, presence: true
+  validates :time, presence: true
+
+  def as_json(_options)
+    super(only: [:anchor, :time])
+  end
+end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,6 +3,7 @@ class Video < ActiveRecord::Base
 
   belongs_to :watchable, polymorphic: true
   has_many :classifications, as: :classifiable
+  has_many :markers, dependent: :destroy
   has_many :statuses, as: :completeable, dependent: :destroy
   has_many :teachers, dependent: :destroy
   has_many :topics, through: :classifications

--- a/app/views/videos/_seek_buttons.html.erb
+++ b/app/views/videos/_seek_buttons.html.erb
@@ -1,0 +1,45 @@
+<div class="seek-button-template">
+  <button class="seek-marker">
+    <%= t(".jump-to-topic-in-video") %>
+  </button>
+</div>
+
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    $(function() {
+      var markers = $(".video-notes").data("markers");
+
+      var scrollPageToShowVideo = function() {
+        $(".wistia-wrapper").get(0).scrollIntoViewIfNeeded();
+      };
+
+      var setUrlHashToSectionAnchor = function(anchor) {
+        window.location.hash = anchor;
+      };
+
+      var bindClickToSeek = function(seekButton, marker) {
+        seekButton.on("click", function(event) {
+          wistiaEmbed.time(marker.time);
+          setUrlHashToSectionAnchor(marker.anchor);
+          scrollPageToShowVideo();
+          wistiaEmbed.play();
+        });
+      };
+
+      var headerForAnchorId = function(anchor) {
+        var specialCharacters = /(:|\.|\[|\]|,|'|\&)/g
+        var escapedAnchorString = anchor.replace(specialCharacters, "\\$1" );
+        return $("#" + escapedAnchorString);
+      }
+
+      var attachSeekButton = function(marker) {
+        var headerForMarker = headerForAnchorId(marker.anchor);
+        var seekButton = $(".seek-button-template button").clone();
+        bindClickToSeek(seekButton, marker);
+        headerForMarker.append(seekButton);
+      };
+
+      markers.forEach(attachSeekButton);
+    });
+  </script>
+<% end %>

--- a/app/views/videos/_watch_video.html.erb
+++ b/app/views/videos/_watch_video.html.erb
@@ -10,11 +10,13 @@
 
 <% if video.has_notes? %>
   <div class="text-box">
-    <section class='video-notes'>
+    <section class='video-notes' data-markers="<%= video.markers.to_json %>">
       <h3>Notes</h3>
       <%= format_markdown(video.notes) %>
     </section>
   </div>
 <% end %>
+
+<%= render "seek_buttons" %>
 
 <%= render "comments", video: video %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -164,12 +164,21 @@ RailsAdmin.config do |config|
         field :position
         field :published_on
         field :users
+        field :markers
       end
 
       group :wistia do
         field :wistia_id
         field :preview_wistia_id
       end
+    end
+  end
+
+  config.model Marker do
+    field :video
+    field :anchor
+    field :time do
+      label "Time (seconds)"
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,9 +86,9 @@ en:
         subject: Welcome to Upcase! I'm your new mentor
   pages:
     welcome:
-      complete-welcome: "Dismiss this page (for now)"
+      complete-welcome: Dismiss this page (for now)
       headline: Read this to write better code.
-      post-welcome-message: "All content unlocked. Enjoy!"
+      post-welcome-message: All content unlocked. Enjoy!
   plans:
     forum: Private Discourse Forum
     mentoring: 1-1 Mentoring
@@ -116,11 +116,11 @@ en:
   shared:
     header:
       contact_your_mentor: Contact your mentor, %{mentor_name}
-      forum: Forum
-      weekly_iteration: Weekly Iteration
-      trails: Trails
       flashcards: Flashcards
+      forum: Forum
       help-link: Help
+      trails: Trails
+      weekly_iteration: Weekly Iteration
     subscription:
       name: Upcase
     subscriptions:
@@ -195,6 +195,8 @@ en:
       in-progress: In Progress
       next-up: Video
       unstarted: Video
+    seek_buttons:
+      jump-to-topic-in-video: Jump to Topic In Video
   watchables:
     preview:
       cta: This video is a preview. <a href="%{subscribe_url}">Subscribe to Upcase</a>

--- a/db/migrate/20150703154842_create_markers.rb
+++ b/db/migrate/20150703154842_create_markers.rb
@@ -1,0 +1,12 @@
+class CreateMarkers < ActiveRecord::Migration
+  def change
+    create_table :markers do |t|
+      t.string :anchor, null: false
+      t.integer :time, null: false
+      t.references :video, index: true, null: false
+
+      t.timestamps null: false
+    end
+    add_foreign_key :markers, :videos, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150612142911) do
+ActiveRecord::Schema.define(version: 20150703154842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,16 @@ ActiveRecord::Schema.define(version: 20150612142911) do
 
   add_index "invitations", ["code"], name: "index_invitations_on_code", using: :btree
   add_index "invitations", ["team_id"], name: "index_invitations_on_team_id", using: :btree
+
+  create_table "markers", force: :cascade do |t|
+    t.string   "anchor",     null: false
+    t.integer  "time",       null: false
+    t.integer  "video_id",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "markers", ["video_id"], name: "index_markers_on_video_id", using: :btree
 
   create_table "mentors", force: :cascade do |t|
     t.integer "user_id",                                                              null: false
@@ -422,4 +432,5 @@ ActiveRecord::Schema.define(version: 20150612142911) do
 
   add_foreign_key "attempts", "flashcards", on_delete: :cascade
   add_foreign_key "attempts", "users", on_delete: :cascade
+  add_foreign_key "markers", "videos", on_delete: :cascade
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -508,4 +508,9 @@ FactoryGirl.define do
     flashcard
     user
   end
+
+  factory :marker do
+    anchor "configuration-options"
+    time 322
+  end
 end

--- a/spec/features/subscriber_views_video_spec.rb
+++ b/spec/features/subscriber_views_video_spec.rb
@@ -21,6 +21,18 @@ feature "subscriber views video trail" do
     end
   end
 
+  scenario "and can seek to a specific point in the video", js: true do
+    video = create(:video, wistia_id: "hello", notes: "# Hello\n\n## Topic")
+    marker = create(:marker, video: video, anchor: "topic")
+
+    visit video_path(video, as: create(:subscriber))
+    within "#topic" do
+      click_jump_to_topic_in_video_button
+    end
+
+    expect(current_url).to include("#" + marker.anchor)
+  end
+
   def first_video
     find(".exercise:first-of-type")
   end
@@ -39,6 +51,10 @@ feature "subscriber views video trail" do
 
   def trail_steps_list
     ".exercises-container"
+  end
+
+  def click_jump_to_topic_in_video_button
+    click_on I18n.t("videos.seek_buttons.jump-to-topic-in-video")
   end
 
   def create_video_trail

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Marker do
+  it { should belong_to(:video) }
+  it { should validate_presence_of(:anchor) }
+  it { should validate_presence_of(:time) }
+
+  describe "#to_json" do
+    it "returns only the anchor and the time" do
+      marker = build_stubbed(:marker)
+
+      json_keys = JSON.parse(marker.to_json).keys
+
+      expect(json_keys).to match(["anchor", "time"])
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Video do
   it { should belong_to(:watchable) }
   it { should have_many(:classifications) }
+  it { should have_many(:markers) }
   it { should have_many(:statuses).dependent(:destroy) }
   it { should have_many(:teachers).dependent(:destroy) }
   it { should have_many(:topics).through(:classifications) }


### PR DESCRIPTION
These links make it easy for users to return to specific sections of the videos for reference. You can see the interation in the following gif, or poke around with it on staging: https://staging.upcase.com/videos/onramp-to-vim-surviving-your-first-week.

![in-video-links](https://cloud.githubusercontent.com/assets/420113/8603200/bcf884b0-2644-11e5-8f11-ee4ed66dbb8b.gif)
- Update the markdown rendered to include anchor IDs for each header
- Create marker model which connects an anchor ID to a timestamp within the video
- Inject the buttons alongside the relevant header

When a button is clicked, the following happen:
1. Seek the time for the header in the video
2. Update the URL to include the anchor of the section
3. Scroll the video player into the viewport
4. Play / unpause the video
