### PR TITLE
Redirect new subscribers to the welcome page

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -85,7 +85,7 @@ class CheckoutsController < ApplicationController
     if @checkout.plan_includes_team?
       edit_team_path
     else
-      practice_path
+      onboarding_policy.root_path
     end
   end
 

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -47,7 +47,7 @@ feature "User creates a subscription" do
 
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
-    expect(current_path).to be_the_practice_page
+    expect(current_path).to be_the_welcome_page
     expect_to_see_checkout_success_flash_for(@plan.name)
     expect(FakeStripe.last_coupon_used).to eq "5OFF"
   end
@@ -80,7 +80,7 @@ feature "User creates a subscription" do
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
     expect_to_see_checkout_success_flash_for(@plan.name)
-    expect(current_path).to be_the_practice_page
+    expect(current_path).to be_the_welcome_page
     expect(Checkout.last.stripe_coupon_id).to eq "50OFF"
     expect(FakeStripe.last_coupon_used).to eq "50OFF"
   end

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -13,7 +13,7 @@ feature 'Visitor signs up for a subscription' do
     fill_out_account_creation_form
     fill_out_credit_card_form_with_valid_credit_card
 
-    expect(current_path).to be_the_practice_page
+    expect(current_path).to be_the_welcome_page
     expect_to_see_checkout_success_flash_for(@plan.name)
   end
 
@@ -49,7 +49,7 @@ feature 'Visitor signs up for a subscription' do
     fill_out_account_creation_form
     fill_out_subscription_form_with_valid_credit_card
 
-    expect(current_path).to be_the_practice_page
+    expect(current_path).to be_the_welcome_page
     expect_to_see_checkout_success_flash_for(@plan.name)
   end
 
@@ -89,7 +89,7 @@ feature 'Visitor signs up for a subscription' do
 
     fill_out_credit_card_form_with_valid_credit_card
 
-    expect(current_path).to be_the_practice_page
+    expect(current_path).to be_the_welcome_page
     expect_to_see_checkout_success_flash_for(@plan.name)
   end
 

--- a/spec/support/path_helpers.rb
+++ b/spec/support/path_helpers.rb
@@ -3,6 +3,10 @@ module PathHelpers
     eq(practice_path)
   end
 
+  def be_the_welcome_page
+    eq(page_path("welcome"))
+  end
+
   def be_the_checkouts_page
     match(/checkouts/)
   end


### PR DESCRIPTION
Previously users were directed to the /practice page after checking out. They
should go to the Welcome page to see the on-boarding message, but this was
missed in the initial implementation of the welcome page.
