### PR TITLE
Publicize a track method for analytics

### DIFF
--- a/app/controllers/forum_sessions_controller.rb
+++ b/app/controllers/forum_sessions_controller.rb
@@ -37,6 +37,6 @@ class ForumSessionsController < ApplicationController
   end
 
   def track_forum_access
-    Analytics.new(current_user).track_forum_access
+    Analytics.new(current_user).track(event: "Logged into Forum")
   end
 end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -48,7 +48,12 @@ class Cancellation
   end
 
   def track_cancelled
-    Analytics.new(@subscription.user).track_cancelled(reason)
+    Analytics.
+      new(@subscription.user).
+      track(
+        event: "Cancelled",
+        properties: { reason: reason }
+      )
   end
 
   def record_scheduled_cancellation_date(stripe_customer)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -8,16 +8,8 @@ class Analytics
     @user = user
   end
 
-  def track_cancelled(reason)
-    track(event: "Cancelled", properties: { reason: reason, email: user.email })
-  end
-
   def track_updated
     backend.identify(user_id: user.id, traits: identify_hash(user))
-  end
-
-  def track_forum_access
-    track(event: "Logged into Forum", properties: {})
   end
 
   def track_status_created(completable, state)
@@ -36,15 +28,15 @@ class Analytics
     end
   end
 
-  private
-
-  attr_reader :user
-
-  def track(event:, properties:)
+  def track(event:, properties: {})
     backend.track(
       event: event,
       user_id: user.id,
       properties: properties
     )
   end
+
+  private
+
+  attr_reader :user
 end

--- a/spec/controllers/forum_sessions_controller_spec.rb
+++ b/spec/controllers/forum_sessions_controller_spec.rb
@@ -10,9 +10,7 @@ describe ForumSessionsController do
         stub_current_user_with(user)
         discourse_sso = discourse_sso_stub
         allow(DiscourseSignOn).to receive(:parse).and_return(discourse_sso)
-        analytics = double("analytics")
-        allow(analytics).to receive(:track_forum_access)
-        allow(Analytics).to receive(:new).and_return(analytics)
+        analytics = stub_analytics
 
         get :new, sso: "ssohash", sig: "sig"
 
@@ -34,7 +32,10 @@ describe ForumSessionsController do
         expect(discourse_sso).to have_received(:sso_secret=).with(
           ENV["DISCOURSE_SSO_SECRET"]
         )
-        expect(analytics).to have_received(:track_forum_access)
+        expect(analytics).to(
+          have_received(:track).
+          with(event: "Logged into Forum")
+        )
       end
     end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -1,21 +1,6 @@
 require "rails_helper"
 
 describe Analytics do
-  describe "#track_cancelled" do
-    it "sends cancelled event to backend" do
-      user = build(:user)
-      user_analytics = Analytics.new(user)
-
-      user_analytics.track_cancelled("reason")
-
-      expect(analytics).to(
-        have_tracked("Cancelled").
-        for_user(user).
-        with_properties(reason: "reason", email: user.email)
-      )
-    end
-  end
-
   describe "#track_updated" do
     it "sends updated identify event to backend" do
       user = build_stubbed(:user)
@@ -25,17 +10,6 @@ describe Analytics do
 
       expect(analytics).to have_identified(user).
         with_properties(user_analytics.identify_hash(user))
-    end
-  end
-
-  describe "#track_forum_access" do
-    it "sends updated identify event to backend" do
-      user = build_stubbed(:user)
-      user_analytics = Analytics.new(user)
-
-      user_analytics.track_forum_access
-
-      expect(analytics).to have_tracked("Logged into Forum").for_user(user)
     end
   end
 

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -2,4 +2,10 @@ module AnalyticsHelper
   def analytics
     Analytics.backend
   end
+
+  def stub_analytics
+    double("Analytics", track: true).tap do |analytics|
+      allow(Analytics).to receive(:new).and_return(analytics)
+    end
+  end
 end


### PR DESCRIPTION
We wrap Segment's analytics library so we can swap it out during testing
and see what events we sent.

However, this wrapping encouraged developers to make single-use methods
like track_forum_access and track_cancelled, one for each event they
wanted to send.

This commit exposes a single `track` method that lets the call sites
specify what event they're tracking.

This should make tracking future events easier (since we won't need to
add a new method on the wrapper for each event).

This also allowed the deletion of `track_forum_access` and
`track_forum_access` once they were inlined.
