### PR TITLE
Instruct wistiaEmbed to prefer HTML5 player

### DIFF
--- a/app/assets/javascripts/wistia_helper.js.coffee
+++ b/app/assets/javascripts/wistia_helper.js.coffee
@@ -20,6 +20,7 @@ class @WistiaHelper
     window.wistiaEmbed = Wistia.embed hashedId,
       controlsVisibleOnLoad: true
       videoFoam: true
+      playerPreference: "html5"
     wistiaEmbed.bind "play", ->
       unless wistiaEmbed.started
         $.post "/api/v1/videos/#{hashedId}/status",


### PR DESCRIPTION
Many users were getting the Flash player despite having a browser capable of
playing HTML5 video. The flash player has a number of limitations and drawbacks
when compared to the HTML5 player, notably in the player control API.

This sets an explicit preference for the HTML5 player when embedding, but will
still fallback to Flash in cases where HTML5 video is not supported.
