### PR TITLE
Simplify header anchor special char escaping

### DIFF
--- a/app/views/videos/_seek_buttons.html.erb
+++ b/app/views/videos/_seek_buttons.html.erb
@@ -27,7 +27,7 @@
       };
 
       var headerForAnchorId = function(anchor) {
-        var specialCharacters = /(:|\.|\[|\]|,|'|\&)/g
+        var specialCharacters = /(\W)/g;
         var escapedAnchorString = anchor.replace(specialCharacters, "\\$1" );
         return $("#" + escapedAnchorString);
       }


### PR DESCRIPTION
The existing implementation used a blacklist of known special chars and escaped
those. Unfortunately the list was incomplete and needed regular updates.

Instead, this implementation uses a whitelist of word, numberic, and dash
characters, escaping all others.
