### PR TITLE
Update <code> background colors for readability

### DIFF
--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -66,7 +66,7 @@ pre code {
 }
 
 code {
-  background-color: darken($off-white, 7%);
+  background-color: $code-block-brackground;
   border-radius: 3px;
   font-family: monaco;
   font-size: $font-size-smallest;
@@ -79,6 +79,10 @@ code {
   .cursor {
     background: darken($off-white, 25%);
   }
+}
+
+:not(pre) code {
+  background-color: $inline-code-background;
 }
 
 // negate brs inserted into posts

--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -45,6 +45,11 @@ $flash-color: #04659B;
 $footer-background: rgba(46, 48, 58, 0.96);
 $footer-link-color: #7a7a7a;
 
+$code-block-brackground: #f7f7f7;
+$inline-code-background: hsla(0, 0, 0, 0.07);
+$light-gray-border: #ccc;
+$row-highlight: #f9f9f9;
+
 $max-width: 1100px;
 $navigation-height: 60px;
 $button-padding: 0.75em 1em;

--- a/app/assets/stylesheets/_flashcards-admin.scss
+++ b/app/assets/stylesheets/_flashcards-admin.scss
@@ -1,6 +1,3 @@
-$row-highlight: #eee;
-$light-gray-border: #ccc;
-
 .flashcards-list {
   border-collapse: collapse;
   border-spacing: 1px;


### PR DESCRIPTION
The previous background-color for code blocks was too close to the table row
striping and was causing the inline code blocks to be hidden. This updates the
relevant background-colors to improve the contrast and help with readability.

Before:
<img width="258" alt="before-code-background" src="https://cloud.githubusercontent.com/assets/420113/8986393/05e85f68-36aa-11e5-9caa-fddc0c637845.png">

After:
<img width="252" alt="after-code-background" src="https://cloud.githubusercontent.com/assets/420113/8986398/0cd7b2f6-36aa-11e5-81d5-e86e798ed7f7.png">
