### PR TITLE
Add Explore menu to signed-out header

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "predef": [
+    "Headhesive",
     "hljs"
   ]
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,16 +10,13 @@
 //= require autoresize
 //= require wistia_helper
 //= require headhesive.min.js
+//= require header-setup
 //= require fastclick
 
 $(function() {
   hljs.initHighlightingOnLoad();
 
   $('textarea').autosize();
-
-  if ($('.landing #header-wrapper').length) {
-    var header = new Headhesive('.landing #header-wrapper', { offset: 500 });
-  }
 
   FastClick.attach(document.body);
 });

--- a/app/assets/javascripts/header-setup.js
+++ b/app/assets/javascripts/header-setup.js
@@ -1,0 +1,45 @@
+var setupTableOfContents = function() {
+  var $tocToggle = $('[data-role="table-of-contents-toggle"]');
+  var $tocClose = $('[data-role="table-of-contents-close"]');
+  var $toc = $('[data-role="table-of-contents"]');
+  var $body = $('body');
+
+  var closeToc = function() {
+    $toc.removeClass('slide-down');
+    $tocToggle.removeClass('is-open');
+    $body.removeClass('has-table-of-contents');
+  };
+
+  var openToc = function() {
+    $toc.addClass('slide-down');
+    $tocToggle.addClass('is-open');
+    $body.addClass('has-table-of-contents');
+  };
+
+  $tocToggle.click(function() {
+    if ($(this).hasClass('is-open')) {
+      closeToc();
+    } else {
+      openToc();
+    }
+    return false;
+  });
+
+  $tocClose.click(function() {
+    closeToc();
+    return false;
+  });
+};
+
+$(function() {
+  setupTableOfContents();
+  var header = '.landing [data-role="header"]';
+
+  if ($(header).length) {
+    new Headhesive(header, {
+      offset:  500,
+      onStick: setupTableOfContents,
+      onUnstick: setupTableOfContents,
+    });
+  }
+});

--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -22,6 +22,7 @@ $exercise-color: #9cc0ed;
 $repository-color: #8D70C3;
 $video-tutorial-color: #FF633C;
 $weekly-iteration-color: #9C313E;
+$hero-green: #4dd1aa;
 
 $light-yellow: #FFF5C2;
 $light-brown: #EDDAA5;
@@ -79,3 +80,9 @@ $not-started-dot-color: #D8D8D8;
 $flashcard-transition: all 0.25s $ease-in-quad;
 
 $z-flashcard-deck: -1;
+$z-header: 20;
+$z-hero: 10;
+$z-headhesive: 30;
+$z-table-of-contents: $z-headhesive + 1;
+
+$unicode-down-triangle: "\25BE";

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -62,6 +62,7 @@
 @import "landing/topics-grid";
 @import "landing/features";
 @import "landing/price";
+@import "landing/table-of-contents";
 @import "landing/testimonials";
 @import "welcome-page";
 

--- a/app/assets/stylesheets/landing/_hero.scss
+++ b/app/assets/stylesheets/landing/_hero.scss
@@ -1,5 +1,3 @@
-$hero-green: #4dd1aa;
-
 .hero {
   @include background-image(
     linear-gradient(180deg, rgba($upcase-blue-1, 0.888), rgba($upcase-blue-2, 0.888)),
@@ -12,7 +10,7 @@ $hero-green: #4dd1aa;
   padding: 6em 2em 3em;
   position: relative;
   text-align: center;
-  z-index: 10;
+  z-index: $z-hero;
 
   @include marketing-fullsize {
     padding-top: 6em;

--- a/app/assets/stylesheets/landing/_nav.scss
+++ b/app/assets/stylesheets/landing/_nav.scss
@@ -1,6 +1,6 @@
 .landing #header-wrapper {
   margin-bottom: 0;
-  z-index: 20;
+  z-index: $z-header;
 
   @include marketing-fullsize {
     padding: 0 2em;
@@ -38,7 +38,7 @@
     @include position(fixed, 0em 0em 0 0em);
     @include transform(translateY(-100%));
     @include transition(transform 0.2s);
-    z-index: 30;
+    z-index: $z-headhesive;
 
     @include dashboard-small-only {
       display: none;

--- a/app/assets/stylesheets/landing/_table-of-contents.scss
+++ b/app/assets/stylesheets/landing/_table-of-contents.scss
@@ -1,0 +1,73 @@
+.has-table-of-contents {
+  overflow: hidden;
+}
+
+.table-of-contents {
+  @include position(fixed, 3.75rem 0px 0px 0px);
+  background-color: $white;
+  display: none;
+  -webkit-overflow-scrolling: touch;
+  overflow-y: scroll;
+  padding: 2em;
+  z-index: $z-table-of-contents;
+
+  &.slide-down {
+    @include animation(reveal-answer 0.25s ease);
+    @include animation-fill-mode(both);
+    display: block;
+  }
+}
+
+.table-of-contents-container {
+  @include outer-container;
+  padding: 2em 0;
+  position: relative;
+
+  ul {
+    margin-bottom: 3em;
+    padding-left: 4em;
+    position: relative;
+
+    @include marketing-small {
+      @include omega(2n);
+      @include span-columns(6);
+    }
+
+    @include marketing-fullsize {
+      @include omega-reset(2n);
+      @include omega(3n);
+      @include span-columns(4);
+    }
+  }
+
+  img {
+    @include position(absolute, -0.5em 0 0 0px);
+    @include size(3em);
+  }
+}
+
+.table-of-contents-close {
+  @include position(absolute, 0px 0px 0 0);
+  color: $gray-3;
+  font-size: 2em;
+
+  &:hover,
+  &:focus {
+    color: $upcase-green;
+  }
+}
+
+.table-of-contents-toggle {
+  &::after {
+    @include transition;
+    content: $unicode-down-triangle;
+    display: inline-block;
+    margin-left: 6px;
+    position: relative;
+  }
+
+  &.is-open::after {
+    @include transform(rotate(180deg));
+    top: 2px;
+  }
+}

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -5,7 +5,9 @@
   </head>
 
   <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
-    <section id="header-wrapper" class="<%= "subscriber" if current_user_has_active_subscription? %>">
+    <section id="header-wrapper"
+      class="<%= "subscriber" if current_user_has_active_subscription? %>"
+      data-role="header">
       <div class="header-container">
         <h1 class="small-logo">
           <%= link_to root_path do %>
@@ -14,6 +16,11 @@
         </h1>
         <nav>
           <ul>
+            <li>
+              <%= link_to t("shared.header.explore"), '#',
+                class: "table-of-contents-toggle",
+                data: { role: "table-of-contents-toggle" } %>
+            </li>
             <li class="view-plans">
               <%= link_to t("subscriptions.join_cta"), "#price" %>
             </li>
@@ -42,5 +49,6 @@
 
     <%= render 'shared/footer' %>
     <%= render 'shared/javascript' %>
+    <%= render "shared/table_of_contents" %>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,6 @@
-<section id="header-wrapper" class="<%= "subscriber" if current_user_has_active_subscription? %>">
+<section id="header-wrapper"
+  class="<%= "subscriber" if current_user_has_active_subscription? %>"
+  data-role="header">
   <div class="header-container">
     <h1 class="small-logo">
       <%= link_to root_path do %>
@@ -47,6 +49,10 @@
           </li>
           <%= render "shared/masquerade_link" if masquerading? %>
         <% else %>
+          <li>
+            <%= link_to t("shared.header.explore"), '#', class: "table-of-contents-toggle",
+              data: { role: "table-of-contents-toggle" } %>
+          </li>
           <li class="view-plans">
             <%= link_to t("subscriptions.join_cta"), new_subscription_path %>
           </li>
@@ -56,3 +62,5 @@
     </nav>
   </div>
 </section>
+
+<%= render "shared/table_of_contents" %>

--- a/app/views/shared/_table_of_contents.html.erb
+++ b/app/views/shared/_table_of_contents.html.erb
@@ -1,0 +1,148 @@
+<section class="table-of-contents" data-role="table-of-contents">
+  <div class="table-of-contents-container">
+    <ul>
+      <li>
+        <%= image_tag "topics/clean-code.svg" %>
+        <h3>Clean Code</h3>
+      </li>
+      <li>
+        <%= link_to "Refactoring", "/refactoring" %>
+      </li>
+      <li>
+        <%= link_to "Form Objects", "/videos/form_objects" %>
+      </li>
+      <li>
+        <%= link_to "Ruby Science: Move Method", "/videos/ruby-science-move-method" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/workflow.svg" %>
+        <h3>Workflow</h3>
+      </li>
+      <li>
+        <%= link_to "tmux", "/tmux" %>
+      </li>
+      <li>
+        <%= link_to "Git Workflow", "/videos/git-workflow" %>
+      </li>
+      <li>
+        <%= link_to "Part 4: Vim Integration", "/videos/tmux-vim-integration" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/vim.svg" %>
+        <h3>Vim</h3>
+      </li>
+      <li>
+        <%= link_to "Navigating Ruby Files with Vim", "/navigating-ruby-files-with-vim" %>
+      </li>
+      <li>
+        <%= link_to "The Art of Vim", "/the-art-of-vim" %>
+      </li>
+      <li>
+        <%= link_to "Onramp to Vim", "/onramp-to-vim" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/rails.svg" %>
+        <h3>Ruby on Rails</h3>
+      </li>
+      <li>
+        <%= link_to "Intermediate Rails", "/intermediate-ruby-on-rails" %>
+      </li>
+      <li>
+        <%= link_to "Test-Driven Rails", "/test-driven-rails" %>
+      </li>
+      <li>
+        <%= link_to "Form Objects", "/videos/form_objects" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/ios.svg" %>
+        <h3>iOS</h3>
+      </li>
+      <li>
+        <%= link_to "You got your Objective-C in My Swift!", "/videos/you-got-your-objective-c-in-my-swift" %>
+      </li>
+      <li>
+        <%= link_to "Property-Based Testing in Swift", "/videos/property-based-testing-in-swift" %>
+      </li>
+      <li>
+        <%= link_to "Swift First Impressions", "/videos/swift-first-impressions" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/haskell.svg" %>
+        <h3>Haskell</h3>
+      </li>
+      <li>
+        <%= link_to "Haskell: Intro to Functions", "/videos/haskell-intro-functions" %>
+      </li>
+      <li>
+        <%= link_to "Haskell: Intro to Types", "/videos/haskell-intro-to-types" %>
+      </li>
+      <li>
+        <%= link_to "Haskell: Pattern Matching", "/videos/haskell-pattern-matching" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/testing.svg" %>
+        <h3>Testing</h3>
+      </li>
+      <li>
+        <%= link_to "Testing Fundamentals", "/testing-fundamentals" %>
+      </li>
+      <li>
+        <%= link_to "Test Doubles", "/test-doubles" %>
+      </li>
+      <li>
+        <%= link_to "Route, Controller, Action", "/videos/route-controller-action" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/javascript.svg" %>
+        <h3>Javascript</h3>
+      </li>
+      <li>
+        <%= link_to "Intro to React", "/videos/intro-to-react" %>
+      </li>
+      <li>
+        <%= link_to "Intro to Ember", "/videos/intro-to-ember" %>
+      </li>
+      <li>
+        <%= link_to "Unit Testing JavaScript", "/videos/unit-testing-javascript" %>
+      </li>
+    </ul>
+
+    <ul>
+      <li>
+        <%= image_tag "topics/design.svg" %>
+        <h3>Design</h3>
+      </li>
+      <li>
+        <%= link_to "Design for Developers", "/design-for-developers" %>
+      </li>
+      <li>
+        <%= link_to "The Playbook: Video Edition", "/the-playbook-video-edition" %>
+      </li>
+      <li>
+        <%= link_to "Serving Your Front-End", "/videos/serving-your-front-end" %>
+      </li>
+    </ul>
+    <a href="#" class="table-of-contents-close" data-role="table-of-contents-close">&times;</a>
+  </div>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
   shared:
     header:
       contact_your_mentor: Contact your mentor, %{mentor_name}
+      explore: Explore
       flashcards: Flashcards
       forum: Forum
       help-link: Help


### PR DESCRIPTION
![mega-menu](https://cloud.githubusercontent.com/assets/2317604/9047272/b290804a-39fe-11e5-8fe3-eef7790c372d.gif)

Exposing all of the content from a mega-dropdown in the nav bar lets potential users see both the volume of material and the quality of topics. This could persuade potential users to sign up.

**Updated:**

I tried horizontal bands with their respective topic colors (see the top of https://upcase.com/design, for example), but it was hideous.

Ended up here, keeping it simple:
![mega-menu](https://cloud.githubusercontent.com/assets/2317604/9064998/3bdfeef0-3a9d-11e5-8d9a-b22fd96b7e5e.gif)
