### PR TITLE
Make the header's sign-up link more pronounced

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -7,6 +7,7 @@ $upcase-blue-1: #487BF6;
 $upcase-blue-2: #0093CB;
 
 $upcase-green: #57C75C;
+$hero-green: #4dd1aa;
 
 $red: #ad141e;
 $off-white: darken(white, 1.5);
@@ -53,6 +54,7 @@ $row-highlight: #f9f9f9;
 
 $max-width: 1100px;
 $navigation-height: 60px;
+$navigation-cta-offset: 10px;
 $button-padding: 0.75em 1em;
 $card-height: 370px;
 $card-padding: 30px;

--- a/app/assets/stylesheets/landing/_nav.scss
+++ b/app/assets/stylesheets/landing/_nav.scss
@@ -27,6 +27,7 @@
 
         a {
           border-left: none;
+          border-right: none;
           height: 44px;
           padding: 0.5rem 1.5rem;
         }

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -3,6 +3,30 @@
   margin: 0 auto 40px;
   width: 100%;
   flex: none;
+
+  &.headhesive--stick,
+  &.without-hero {
+    .header-cta {
+      padding: $navigation-cta-offset;
+
+      &:hover {
+        background-color: inherit;
+      }
+    }
+
+    .header-cta-link {
+      background-color: $hero-green;
+      border-radius: 3px;
+      height: $navigation-height - ($navigation-cta-offset * 2);
+      line-height: $navigation-height - ($navigation-cta-offset * 2);
+      padding: 0 1rem;
+
+      &:hover,
+      &:focus {
+        background-color: lighten($hero-green, 5%);
+      }
+    }
+  }
 }
 
 .header-container {
@@ -137,6 +161,7 @@
 
     li a {
       border-left: 1px solid darken($upcase-blue, 5);
+      border-right: 1px solid darken($upcase-blue, 5);
       color: white;
       float: left;
       font-family: $sans-serif;

--- a/app/views/layouts/landing_pages.html.erb
+++ b/app/views/layouts/landing_pages.html.erb
@@ -21,15 +21,15 @@
                 class: "table-of-contents-toggle",
                 data: { role: "table-of-contents-toggle" } %>
             </li>
-            <li class="view-plans">
-              <%= link_to t("subscriptions.join_cta"), "#price" %>
-            </li>
             <li>
               <% if signed_in? %>
                 <%= link_to 'Account', my_account_path %>
               <% else %>
                 <%= link_to 'Sign In', sign_in_path %>
               <% end %>
+            </li>
+            <li class="header-cta">
+              <%= link_to t("subscriptions.join_cta"), "#price", class: "header-cta-link" %>
             </li>
           </ul>
         </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <section id="header-wrapper"
-  class="<%= "subscriber" if current_user_has_active_subscription? %>"
+  class="without-hero <%= "subscriber" if current_user_has_active_subscription? %>"
   data-role="header">
   <div class="header-container">
     <h1 class="small-logo">
@@ -53,10 +53,10 @@
             <%= link_to t("shared.header.explore"), '#', class: "table-of-contents-toggle",
               data: { role: "table-of-contents-toggle" } %>
           </li>
-          <li class="view-plans">
-            <%= link_to t("subscriptions.join_cta"), new_subscription_path %>
-          </li>
           <li><%= link_to "Sign in", sign_in_path %></li>
+          <li class="header-cta">
+            <%= link_to t("subscriptions.join_cta"), new_subscription_path, class: "header-cta-link" %>
+          </li>
         <% end %>
       </ul>
     </nav>


### PR DESCRIPTION
![cta](https://cloud.githubusercontent.com/assets/2317604/9069137/9b44fbb6-3ab5-11e5-808f-ad86b42a0ffd.gif)

Emphasizing the header's CTA ("Start Leveling Up") could improve conversion rates. It should only be highlighted when the primary CTA in the hero isn't already visible.
