### PR TITLE
Make team plan featured

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -179,7 +179,7 @@ namespace :dev do
   end
 
   def create_team_plan
-    FactoryGirl.create(:plan, :team)
+    FactoryGirl.create(:plan, :team, :featured)
   end
 
   def create_topics


### PR DESCRIPTION
The /team view is broken without this because there are no featured team
plans to show.
