### PR TITLE
Create a new checkout flow

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -76,7 +76,7 @@ class CheckoutsController < ApplicationController
 
     redirect_to(
       success_url,
-      notice: t("checkout.flashes.success", name: @checkout.plan_name),
+      notice: t("checkout.flashes.success"),
       flash: { purchase_amount: @checkout.price }
     )
   end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,0 +1,38 @@
+class SignupsController < ApplicationController
+  def create
+    stripe_customer = create_stripe_customer
+    fulfill(stripe_customer.subscriptions.first.id)
+
+    flash[:notice] = I18n.t("checkout.flashes.success")
+    redirect_to onboarding_policy.root_path
+  rescue Stripe::CardError => error
+    flash[:error] = error.message
+    redirect_to page_path("join")
+  end
+
+  private
+
+  def create_stripe_customer
+    Stripe::Customer.create(
+      source: params[:stripe_token],
+      email: current_user.email,
+      description: "Created using new checkout flow",
+      plan: professional_plan.sku,
+    )
+  end
+
+  def fulfill(stripe_subscription_id)
+    professional_plan.fulfill(
+      checkout_duck(stripe_subscription_id),
+      current_user,
+    )
+  end
+
+  def checkout_duck(stripe_subscription_id)
+    OpenStruct.new(stripe_subscription_id: stripe_subscription_id)
+  end
+
+  def professional_plan
+    Plan.popular
+  end
+end

--- a/app/views/pages/_payment.html.erb
+++ b/app/views/pages/_payment.html.erb
@@ -1,0 +1,40 @@
+Oh boy, it's time to give us money!
+
+<script src="https://checkout.stripe.com/checkout.js"></script>
+
+<button id="customButton">Pay with credit card</button>
+
+<% content_for :javascript do %>
+  <script>
+    var submitToken = function(token) {
+      $("#stripe_token").val(token.id);
+      $(".payment-form").submit();
+    };
+
+    var handler = StripeCheckout.configure({
+      key: 'pk_IUggbBONd079p5jCloGEijOFRBDnq',
+      image: 'https://s3.amazonaws.com/stripe-uploads/ZZmGCK8MYKr0FHOuop7OzJe7Spmxk7nrmerchant-icon-1415719897983-twitter-icon-2-2.png',
+      token: submitToken
+    });
+
+    $('#customButton').on('click', function(e) {
+      handler.open({
+        name: 'Upcase',
+        description: 'Monthly Subscription',
+        amount: <%= Plan.popular.price_in_dollars * 100 %>,
+        email: "<%= current_user.email %>",
+        allowRememberMe: false,
+        panelLabel: "Subscribe for {{amount}}"
+      });
+      e.preventDefault();
+    });
+
+    $(window).on('popstate', function() {
+      handler.close();
+    });
+  </script>
+<% end %>
+
+<%= form_tag signups_path, class: "payment-form" do %>
+  <%= hidden_field_tag "stripe_token" %>
+<% end %>

--- a/app/views/pages/_sign_in_with_github.html.erb
+++ b/app/views/pages/_sign_in_with_github.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Sign up with GitHub", github_auth_path %>

--- a/app/views/pages/join.html.erb
+++ b/app/views/pages/join.html.erb
@@ -1,0 +1,5 @@
+<% if signed_in? %>
+  <%= render 'payment' %>
+<% else %>
+  <%= render 'sign_in_with_github' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
     flashes:
       already_subscribed: You are already subscribed. You can change your plan.
       plan_not_found: We have a new subscription plan for you.
-      success: Thank you for subscribing to %{name}. We will email you your receipt
+      success: Thank you for subscribing to Upcase! We will email you your receipt
         shortly.
     problem_with_card: "There was a problem processing your credit card: %{message}"
   coupons:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Upcase::Application.routes.draw do
   resource :annual_billing, only: :new
   resource :credit_card, only: [:update]
   resource :forum_sessions, only: :new
+  resources :signups, only: [:create]
   resource :subscription, only: [:new, :edit, :update]
   resources :coupons, only: :show
   resources :topics, only: :index, constraints: { format: "css" }

--- a/spec/features/user_creates_team_subscription_spec.rb
+++ b/spec/features/user_creates_team_subscription_spec.rb
@@ -11,7 +11,7 @@ feature "User creates a team subscription" do
 
     expect(current_path).to eq after_sign_up_path
     expect(page).
-      to have_content(I18n.t("checkout.flashes.success", name: plan.name))
+      to have_content(I18n.t("checkout.flashes.success"))
     expect(settings_page).to have_subscription_to(plan.name)
     expect(FakeStripe.customer_plan_quantity).to eq plan.minimum_quantity.to_s
   end
@@ -42,12 +42,6 @@ feature "User creates a team subscription" do
   def subscribe_with_valid_credit_card
     visit_team_plan_checkout_page
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
-  end
-
-  def subscribe_with_invalid_credit_card
-    visit_team_plan_checkout_page
-    FakeStripe.failure = true
-    fill_out_subscription_form_with "bad cc number"
   end
 
   def plan

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -48,7 +48,7 @@ feature "User creates a subscription" do
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
     expect(current_path).to be_the_welcome_page
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
     expect(FakeStripe.last_coupon_used).to eq "5OFF"
   end
 
@@ -63,7 +63,7 @@ feature "User creates a subscription" do
 
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
     expect(FakeStripe.last_coupon_used).to eq "THREEFREE"
   end
 
@@ -79,7 +79,7 @@ feature "User creates a subscription" do
 
     fill_out_subscription_form_with VALID_SANDBOX_CREDIT_CARD_NUMBER
 
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
     expect(current_path).to be_the_welcome_page
     expect(Checkout.last.stripe_coupon_id).to eq "50OFF"
     expect(FakeStripe.last_coupon_used).to eq "50OFF"

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -14,7 +14,7 @@ feature 'Visitor signs up for a subscription' do
     fill_out_credit_card_form_with_valid_credit_card
 
     expect(current_path).to be_the_welcome_page
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
   end
 
   scenario "Visitor signs in with email and password while checking out" do
@@ -50,7 +50,7 @@ feature 'Visitor signs up for a subscription' do
     fill_out_subscription_form_with_valid_credit_card
 
     expect(current_path).to be_the_welcome_page
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
   end
 
   scenario "without specifying a GitHub username" do
@@ -90,7 +90,7 @@ feature 'Visitor signs up for a subscription' do
     fill_out_credit_card_form_with_valid_credit_card
 
     expect(current_path).to be_the_welcome_page
-    expect_to_see_checkout_success_flash_for(@plan.name)
+    expect_to_see_checkout_success_flash
   end
 
   scenario "visitor attempts to subscribe, signs in with github, but is already subscribed" do

--- a/spec/features/visitor_purchases_team_subscription_spec.rb
+++ b/spec/features/visitor_purchases_team_subscription_spec.rb
@@ -6,7 +6,7 @@ feature 'Visitor can purchase a subscription for their team' do
     fill_out_account_creation_form email: 'user@fabtabulous.com'
     fill_out_credit_card_form_with_valid_credit_card
 
-    expect_to_see_checkout_success_flash_for(team_plan.name)
+    expect_to_see_checkout_success_flash
 
     my_account_link.click
 

--- a/spec/features/visitor_signs_up_using_new_checkout_flow_spec.rb
+++ b/spec/features/visitor_signs_up_using_new_checkout_flow_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+feature "Visitor signs up for a subscription", js: true do
+  include CheckoutHelpers
+
+  scenario "using the new checkout flow" do
+    create_plan
+    token = "abc123"
+
+    sign_up(token)
+
+    expect_to_see_checkout_success_flash
+    expect(FakeStripe.last_token).to eq("abc123")
+    expect(User.last).to have_active_subscription
+    expect(current_path).to eq(welcome_path)
+  end
+
+  scenario "and the charge fails" do
+    make_stripe_fake_decline_charge
+    create_plan
+
+    sign_up
+
+    expect(User.last).not_to have_active_subscription
+    expect(page).to have_content("Your credit card was declined")
+    expect(current_path).to eq(page_path("join"))
+  end
+
+  def sign_up(token = "fake-token")
+    visit "/pages/join"
+    click_link "Sign up with GitHub"
+    click_button "Pay with credit card"
+    page.execute_script("submitToken({ id: '#{token}' })")
+  end
+
+  def make_stripe_fake_decline_charge
+    FakeStripe.failure = true
+  end
+
+  def create_plan
+    create(:plan, sku: Plan::PROFESSIONAL_SKU)
+  end
+end

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -48,7 +48,7 @@ module CheckoutHelpers
     expect(page.find("#checkout_submit_action input").value).to include text
   end
 
-  def expect_to_see_checkout_success_flash_for(plan_name)
-    expect(page).to have_content(I18n.t("checkout.flashes.success", name: plan_name))
+  def expect_to_see_checkout_success_flash
+    expect(page).to have_content(I18n.t("checkout.flashes.success"))
   end
 end

--- a/spec/support/fake_stripe.rb
+++ b/spec/support/fake_stripe.rb
@@ -98,12 +98,19 @@ class FakeStripe < Sinatra::Base
 
   post "/v1/customers" do
     @@last_customer_email = params[:email]
-    @@last_token = params[:card]
+    @@last_token = params[:source]
     content_type :json
 
     if failure
       status 402
-      { type: "card_error", message: "card declined" }.to_json
+      {
+        error: {
+          message: "Your credit card was declined",
+          type: "card_error",
+          param: "number",
+          code: "incorrect_number",
+        },
+      }.to_json
     else
       {
         object: "customer",


### PR DESCRIPTION
The motivation here is to make signing up simpler, which will hopefully
convince more people to do it.

This commit does not remove the existing checkout flow, as we plan to
A/B test the two against each other.

Note that this checkout flow isn't linked to from anywhere, so can be
deployed even though there are placeholder pages.

Major changes in the new flow:
- Users _must_ signup using GitHub OAuth.
- Credit card details are entered using Stripe Checkout, not our own
  form.

Known issues:
- Users will not be able to _re_subscribe using this flow.
- The join page and the payment page are both placeholders.
