### PR TITLE
Fix padding in mobile navigation

### DIFF
--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -36,6 +36,11 @@
   padding: 0 $side-padding;
   position: relative;
 
+  @include dashboard-small-only {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .branding {
     float: left;
     padding: 1rem 0;


### PR DESCRIPTION
https://github.com/thoughtbot/upcase/commit/464febd8454ff4140cfb834eccd45d55a43baf7d
introduced padding in the header-container on narrow screen sizes. This
removes the padding, so the links extend across the full width of the device.

before:
![screen shot 2015-08-07 at 3 35 31 pm](https://cloud.githubusercontent.com/assets/2317604/9144307/075aea84-3d1a-11e5-8e7a-3626d4ed9a4b.png)

after:
![screen shot 2015-08-07 at 3 35 41 pm](https://cloud.githubusercontent.com/assets/2317604/9144310/0afbbb1e-3d1a-11e5-8eac-adc9f2b51f1a.png)
