### PR TITLE
Sanitize the excerpt query

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,7 +1,7 @@
 class SearchesController < ApplicationController
   def show
     @query = get_query
-    @results = results_with_highlights
+    @results = results_with_excerpts
   end
 
   def create
@@ -10,30 +10,11 @@ class SearchesController < ApplicationController
 
   private
 
+  def results_with_excerpts
+    Search.new(@query).results
+  end
+
   def get_query
     params[:query]
-  end
-
-  def search_results
-    @_search_results ||= PgSearch.multisearch(@query)
-  end
-
-  def results_with_highlights
-    results = search_results
-    delimiter = "<br>"
-    highlights = search_results.select(<<-HEADLINE_QUERY.strip_heredoc
-      ts_headline(
-        pg_search_documents.content,
-        plainto_tsquery('#{@query}'),
-        'MaxFragments=2,
-        MinWords=5,
-        MaxWords=15,
-        FragmentDelimiter=\" ...#{delimiter} \",
-        StartSel=\"<span class=highlight>\",
-        StopSel=\"</span>\"'
-      ) AS excerpt
-      HEADLINE_QUERY
-    )
-    results.zip(highlights.map(&:excerpt))
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,48 @@
+class Search
+  def initialize(query)
+    @raw_query = query
+  end
+
+  def results
+    model_and_excerpt_pairs.map do |model, excerpt|
+      SearchResult.new(model, excerpt)
+    end
+  end
+
+  private
+
+  def model_and_excerpt_pairs
+    matching_models.zip(excerpts)
+  end
+
+  def matching_models
+    search_results.map(&:searchable)
+  end
+
+  def excerpts
+    search_results.select(excerpt_query).map(&:excerpt)
+  end
+
+  def search_results
+    @_search_results ||= PgSearch.multisearch(@raw_query)
+  end
+
+  def sanitized_query
+    ActiveRecord::Base::sanitize(@raw_query)
+  end
+
+  def excerpt_query
+    <<-EXCERPT_QUERY.strip_heredoc
+      ts_headline(
+        pg_search_documents.content,
+        plainto_tsquery(#{sanitized_query}),
+        'MaxFragments=2,
+        MinWords=5,
+        MaxWords=15,
+        FragmentDelimiter=\"...<br/>\",
+        StartSel=\"<span class=highlight>\",
+        StopSel=\"</span>\"'
+      ) AS excerpt
+    EXCERPT_QUERY
+  end
+end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -1,0 +1,23 @@
+class SearchResult < SimpleDelegator
+  attr_reader :excerpt
+
+  def initialize(model, excerpt)
+    @model = model
+    @excerpt = excerpt
+    super(@model)
+  end
+
+  def to_partial_path
+    "searches/#{_model_name}"
+  end
+
+  def to_model
+    self
+  end
+
+  private
+
+  def _model_name
+    @model.class.to_s.downcase
+  end
+end

--- a/app/views/searches/_flashcard.html.erb
+++ b/app/views/searches/_flashcard.html.erb
@@ -1,12 +1,12 @@
 <li class="search-result">
   <%= fa_icon "files-o", title: "Flashcard" %>
   <p class="title">
-    <%= review_link(searchable) %>
+    <%= review_link(flashcard) %>
   </p>
   <p class="source">
-    from <%= link_to searchable.deck.title, deck_results_path(searchable.deck) %>
+    from <%= link_to flashcard.deck.title, deck_results_path(flashcard.deck) %>
   </p>
   <p>
-    <%= cleaned_search_excerpt(highlight.html_safe) %>
+    <%= cleaned_search_excerpt(flashcard.excerpt) %>
   </p>
 </li>

--- a/app/views/searches/_trail.html.erb
+++ b/app/views/searches/_trail.html.erb
@@ -1,9 +1,9 @@
 <li class="search-result">
   <%= fa_icon "road", title: "Trail" %>
   <p class="title">
-    <%= link_to searchable.name, searchable %>
+    <%= link_to trail.name, trail %>
   </p>
   <p>
-    <%= cleaned_search_excerpt(highlight) %>
+    <%= cleaned_search_excerpt(trail.excerpt) %>
   </p>
 </li>

--- a/app/views/searches/_video.html.erb
+++ b/app/views/searches/_video.html.erb
@@ -1,12 +1,12 @@
 <li class="search-result">
   <%= fa_icon "film", title: "Video" %>
   <p class="title">
-    <%= link_to searchable.name, searchable %>
+    <%= link_to video.name, video %>
   </p>
   <p class="source">
-    from <%= link_to searchable.watchable.name, searchable.watchable %>
+    from <%= link_to video.watchable.name, video.watchable %>
   </p>
   <p>
-    <%= cleaned_search_excerpt(highlight) %>
+    <%= cleaned_search_excerpt(video.excerpt) %>
   </p>
 </li>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -17,12 +17,6 @@
   </span>
 
   <ul>
-    <% @results.each do |result, highlight| %>
-      <%=
-        render "searches/#{result.searchable_type.downcase}",
-        searchable: result.searchable, highlight: highlight
-      %>
-      <hr />
-    <% end %>
+    <%= render @results %>
   </ul>
 <% end %>

--- a/spec/features/subscriber_searches_for_content_spec.rb
+++ b/spec/features/subscriber_searches_for_content_spec.rb
@@ -24,8 +24,4 @@ feature "subscriber searches for content" do
   def click_on_search_result
     find(".search-result").find(".title a").click
   end
-
-  def populate_search_index
-    PgSearch::Multisearch.rebuild(Trail)
-  end
 end

--- a/spec/models/search_result_spec.rb
+++ b/spec/models/search_result_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe SearchResult do
+  describe "#to_partial_path" do
+    it "returns a partial path based on the model type" do
+      video = build_stubbed(:video)
+      result = build_search_result(model: video)
+
+      expect(result.to_partial_path).to eq("searches/video")
+    end
+  end
+
+  describe "delegation" do
+    it "should delegate methods to the model" do
+      video = build_stubbed(:video, name: "tmux adventures")
+      result = build_search_result(model: video)
+
+      expect(result.name).to eq(video.name)
+    end
+  end
+
+  def build_search_result(model:, excerpt: "sample excerpt")
+    SearchResult.new(model, excerpt)
+  end
+end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Search do
+  describe "#results_with_excerpts" do
+    it "returns relevant search results" do
+      hello_video = create(:video, notes: "Hello world")
+      other_video = create(:video, notes: "other video")
+      populate_search_index
+
+      results = run_search_for("hello")
+
+      expect(results).to include(hello_video)
+      expect(results).not_to include(other_video)
+    end
+
+    it "highlights the query in the excerpt" do
+      create(:video, notes: "Hello world")
+      populate_search_index
+
+      results = run_search_for("hello")
+
+      expect(rendered_excerpt(results)).to have_css(".highlight", text: "Hello")
+    end
+
+    it "sanitizes the query" do
+      expect { run_search_for("hackers'); DROP TABLE users;") }.
+        not_to raise_error
+    end
+  end
+
+  def run_search_for(query)
+    Search.new(query).results
+  end
+
+  def rendered_excerpt(results)
+    Capybara.string(excerpts_for(results).first)
+  end
+
+  def matching_models_from(results)
+    results.map(&:model)
+  end
+
+  def excerpts_for(results)
+    results.map(&:excerpt)
+  end
+end

--- a/spec/support/search_helpers.rb
+++ b/spec/support/search_helpers.rb
@@ -1,0 +1,9 @@
+module SearchHelpers
+  def populate_search_index
+    [Video, Flashcard, Trail].each do |model|
+      PgSearch::Multisearch.rebuild(model)
+    end
+  end
+end
+
+RSpec.configure { |config| config.include SearchHelpers }


### PR DESCRIPTION
The previous version was interpolating the query string directly into the headline subquery, opening the search up to a potential SQL injection.

This updates to sanitize the search query string when used with the headline subquery.
