### PR TITLE
Remove header and footer on payment page

### DIFF
--- a/app/assets/stylesheets/_payment.scss
+++ b/app/assets/stylesheets/_payment.scss
@@ -1,0 +1,5 @@
+.payments-new {
+  .payment-form {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -56,6 +56,7 @@
 @import "flashcard-list";
 @import "searches";
 @import "search-result";
+@import "payment";
 
 @import "landing/centered-section";
 @import "landing/features";

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,4 +1,6 @@
 class PaymentsController < ApplicationController
+  layout "payment"
+
   def new
     @github_user = Octokit.user(current_user.github_username)
   end

--- a/app/views/layouts/payment.html.erb
+++ b/app/views/layouts/payment.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head prefix="og: http://ogp.me/ns#">
+    <%= render 'application/head_contents' %>
+  </head>
+
+  <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
+    <section id="header-wrapper" data-role="header">
+      <div class="header-container">
+        <%= link_to root_path, class: "branding" do %>
+          <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg") %></h1>
+          <span class="header-tagline"><%= t("shared.header.tagline") %></span>
+        <% end %>
+        </h1>
+      </div>
+    </section>
+
+    <div class="header-flash">
+      <%= render "shared/flashes" %>
+    </div>
+
+    <section class="content">
+      <%= yield %>
+    </section>
+
+    <%= render 'shared/javascript' %>
+  </body>
+</html>


### PR DESCRIPTION
We want to focus people on the CTA, not encourage them to keep poking
around.
## Before

![before](https://cloud.githubusercontent.com/assets/46677/9394163/d601489e-4754-11e5-96f3-2301279d0679.png)
## After

![after](https://cloud.githubusercontent.com/assets/46677/9394162/d600b460-4754-11e5-81b0-c470235c94f2.png)
