### PR TITLE
Use only one green color for buttons

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -6,8 +6,8 @@ $upcase-blue: #2387E0;
 $upcase-blue-1: #487BF6;
 $upcase-blue-2: #0093CB;
 
-$upcase-green: #57C75C;
 $hero-green: #4dd1aa;
+$upcase-green: $hero-green;
 
 $red: #ad141e;
 $off-white: darken(white, 1.5);


### PR DESCRIPTION
The light teal tone feels more professional with the rest of the color palette. Using the green-green would make the app look a bit more quirky.

![image](https://cloud.githubusercontent.com/assets/2095625/9521828/6d7ae942-4cd1-11e5-9c9d-b6fb304c69c0.png)
