### PR TITLE
Change prefixer mixin rules to non-prefixed rules

### DIFF
--- a/app/assets/stylesheets/_base-forms.css.scss
+++ b/app/assets/stylesheets/_base-forms.css.scss
@@ -103,8 +103,8 @@ form {
       border: 1px solid darken($warmgray, 5%);
       border-radius: 4px;
       box-shadow: none;
+      box-sizing: border-box;
       font-family: $sans-serif;
-      @include box-sizing(border-box);
       font-size: 1rem;
       margin: .25em 0;
       padding: .75rem 1em;

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -1,9 +1,9 @@
 .resources-container {
-  @include flex-flow(wrap);
-  @include justify-content(space-around);
   @include transition (all 0.3s ease-in-out);
   background: white;
   display: flex;
+  flex-flow: wrap;
+  justify-content: space-around;
   padding: em(30) em(20);
 
   header {

--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -194,7 +194,7 @@ body.checkouts-new, body.checkouts-create {
         select {
           border: 1px solid darken($warmgray, 5%);
           box-shadow: none;
-          @include box-sizing(border-box);
+          box-sizing: border-box;
           float: left;
           font: 1rem $sans-serif;
           height: 45px;

--- a/app/assets/stylesheets/_flashcard-decks.scss
+++ b/app/assets/stylesheets/_flashcard-decks.scss
@@ -1,6 +1,6 @@
 .decks {
-  @include flex-wrap(wrap);
   display: flex;
+  flex-wrap: wrap;
 }
 
 .deck {
@@ -68,9 +68,9 @@
     text-align: center;
 
     a {
-      @include align-items(center);
-      @include justify-content(center);
+      align-items: center;
       display: flex;
+      justify-content: center;
       min-height: 8em;
     }
   }

--- a/app/assets/stylesheets/_flashcard-list.scss
+++ b/app/assets/stylesheets/_flashcard-list.scss
@@ -7,9 +7,9 @@
 .kept-flashcards {
   .root-decks & {
     @include dashboard-medium {
-      @include align-items(baseline);
-      @include flex-wrap(wrap);
+      align-items: baseline;
       display: flex;
+      flex-wrap: wrap;
     }
   }
 
@@ -19,9 +19,9 @@
 }
 
 .to-flashcard {
-  @include align-items(baseline);
-  @include flex-wrap(wrap);
+  align-items: baseline;
   display: flex;
+  flex-wrap: wrap;
 
   &:hover::before {
     border-color: $flashcard-hover-color;
@@ -55,7 +55,7 @@
   }
 
   a {
-    @include flex(1);
+    flex: 1;
   }
 }
 

--- a/app/assets/stylesheets/_subscriptions-new.scss
+++ b/app/assets/stylesheets/_subscriptions-new.scss
@@ -29,16 +29,16 @@ $yellow: #F3E86B;
     }
 
     li {
-      @include align-items(center);
-      @include justify-content(center);
+      align-items: center;
       display: flex;
       height: 46px;
+      justify-content: center;
     }
   }
 
   header {
-    @include align-items(center);
     @include clearfix;
+    align-items: center;
     display: flex;
     width: 100%;
 

--- a/app/assets/stylesheets/_teachers.scss
+++ b/app/assets/stylesheets/_teachers.scss
@@ -3,13 +3,13 @@
   margin: 2rem 0 0;
 
   li {
-    @include flex-direction(column);
     display: flex;
+    flex-direction: column;
   }
 
   .teacher-info {
-    @include flex-direction(row);
     display: flex;
+    flex-direction: row;
   }
 
   .teacher-name {

--- a/app/assets/stylesheets/_tile.scss
+++ b/app/assets/stylesheets/_tile.scss
@@ -1,18 +1,18 @@
 .tiles ul,
 .tiles-container {
-  @include flex-wrap(wrap);
-  @include justify-content(space-around);
   display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
   margin-bottom: 2em;
   width: 100%;
 
   .tile {
-    @include flex-basis(22em);
-    @include flex-grow(1);
-    @include flex-shrink(1);
     border-radius: 0 0 3px 3px;
     border-top: 10px solid $gray-5;
     box-shadow: 0 0 0 1px $gray-4;
+    flex-basis: 22em;
+    flex-grow: 1;
+    flex-shrink: 1;
     height: 280px;
     margin: 0 1em 2em;
     overflow: hidden;

--- a/app/assets/stylesheets/_topics-list.scss
+++ b/app/assets/stylesheets/_topics-list.scss
@@ -6,10 +6,10 @@
   }
 
   .topics-list {
-    @include flex-direction(row);
-    @include flex-wrap(wrap);
-    @include justify-content(space-around);
     display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
   }
 
   .topic-link {
@@ -74,8 +74,8 @@
   }
 
   .topic-tile {
-    @include flex-direction(row);
     display: flex;
+    flex-direction: row;
     margin: 0;
 
     ul {

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -138,13 +138,13 @@ $not-started-dot-color: #D8D8D8;
     }
 
     .progress {
-      @include align-items(center);
       @include background-image(linear-gradient(#FBFBFB, #F3F3F3));
-      @include justify-content(space-around);
+      align-items: center;
       border: 1px solid $not-started-dot-color;
       border-radius: 60px;
       display: flex;
       height: 58px;
+      justify-content: space-around;
       padding: 0 10px;
 
       &.just-finished {
@@ -161,9 +161,9 @@ $not-started-dot-color: #D8D8D8;
     }
 
     .step {
-      @include flex(1);
-      @include justify-content(center);
       display: flex;
+      flex: 1;
+      justify-content: center;
       position: relative;
 
       &:last-of-type {
@@ -299,7 +299,7 @@ $not-started-dot-color: #D8D8D8;
       }
 
       .step {
-        @include justify-content(flex-start);
+        justify-content: flex-start;
 
         .dot {
           margin: 0;
@@ -326,10 +326,10 @@ $not-started-dot-color: #D8D8D8;
   // Complete Trail
   ///////////////////////////////////////////////////////////////////////////
   .trails-complete {
-    @include flex-direction(row);
-    @include flex-wrap(wrap);
-    @include justify-content(space-around);
     display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
   }
 
   .complete {

--- a/app/assets/stylesheets/landing/_cta-button.scss
+++ b/app/assets/stylesheets/landing/_cta-button.scss
@@ -34,8 +34,8 @@
   
   .hero-aside &,
   .centered-section & {
-    @include align-items(center);
     @include linear-gradient($hero-green, shade($hero-green, 5%));
+    align-items: center;
     border-radius: $base-border-radius;
     box-shadow: $heavy-box-shadow;
     color: $off-white;
@@ -62,6 +62,6 @@
 }
 
 .cta-button-text {
-  @include flex(1);
+  flex: 1;
   text-align: center;
 }

--- a/app/assets/stylesheets/landing/_features.scss
+++ b/app/assets/stylesheets/landing/_features.scss
@@ -3,7 +3,7 @@
   position: relative;
 
   .feature {
-    @include justify-content(flex-end);
+    justify-content: flex-end;
     padding: 0 10px;
   }
 

--- a/app/assets/stylesheets/landing/_price.scss
+++ b/app/assets/stylesheets/landing/_price.scss
@@ -130,13 +130,13 @@ $price-width: em(864);
 }
 
 .price-cta {
-  @include flex-wrap(wrap);
   display: flex;
+  flex-wrap: wrap;
 
   a {
-    @include flex-basis(4em);
-    @include flex-shrink(0);
-    @include flex-grow(1);
+    flex-basis: 4em;
+    flex-grow: 1;
+    flex-shrink: 0;
   }
 }
 

--- a/app/assets/stylesheets/landing/_selling-point.scss
+++ b/app/assets/stylesheets/landing/_selling-point.scss
@@ -58,12 +58,12 @@
 }
 
 .selling-point-block {
-  @include align-items(center);
-  @include flex-direction(column);
+  align-items: center;
   display: flex;
+  flex-direction: column;
 
   @include marketing-fullsize {
-    @include flex-direction(row);
+    flex-direction: row;
   }
 }
 

--- a/app/assets/stylesheets/landing/_testimonials.scss
+++ b/app/assets/stylesheets/landing/_testimonials.scss
@@ -103,8 +103,8 @@
 
   .supporting-quotes {
     @include outer-container;
-    @include flex-wrap(wrap);
     display: flex;
+    flex-wrap: wrap;
 
     img {
       @include size(70px);
@@ -115,9 +115,9 @@
     }
 
     .supporting-quote {
-      @include flex-basis(12em);
-      @include flex-grow(1);
-      @include flex-shrink(0);
+      flex-basis: 12em;
+      flex-grow: 1;
+      flex-shrink: 0;
       margin: 0 1em 50px;
 
       // @include marketing-fullsize {

--- a/app/assets/stylesheets/landing/_topics-grid.scss
+++ b/app/assets/stylesheets/landing/_topics-grid.scss
@@ -23,8 +23,8 @@
   position: relative;
 
   ol {
-    @include flex-wrap(wrap);
     display: flex;
+    flex-wrap: wrap;
     margin: 0 auto;
     max-width: 1116px;
   }


### PR DESCRIPTION
The autoprefixer-rails gem was introduced in #1383 to automatically add any necessary vendor prefixes to the css rules. That PR was kept to a minimum, only fixing the original bug and removing warnings introduced by having added the autoprefixer-rails gem.

This PR continues the conversion to autoprefixer-rails by changing any styles using bourbon prefixer mixins (flex-flow, justify-content, align-items, etc) to non-prefixed rules.
