### PR TITLE
Tighten up spacing on landing and checkout

### DIFF
--- a/app/assets/stylesheets/landing/_centered-section.scss
+++ b/app/assets/stylesheets/landing/_centered-section.scss
@@ -1,12 +1,12 @@
 .centered-section {
   background-color: $base-background-2;
   border-bottom: 1px solid $base-border-color-1;
-  padding-bottom: 3em;
-  padding-top: 3em;
+  padding-bottom: 2em;
+  padding-top: 2em;
 
   @include marketing-fullsize {
-    padding-bottom: 8em;
-    padding-top: 8em;
+    padding-bottom: 6em;
+    padding-top: 6em;
     text-align: center;
   }
 

--- a/app/assets/stylesheets/landing/_hero.scss
+++ b/app/assets/stylesheets/landing/_hero.scss
@@ -75,8 +75,8 @@
   padding: 5em 1em 4em;
 
   @include dashboard-large {
-    padding-bottom: 8em;
-    padding-top: 11em;
+    padding-bottom: 6em;
+    padding-top: 8em;
   }
 }
 

--- a/app/assets/stylesheets/landing/_selling-point.scss
+++ b/app/assets/stylesheets/landing/_selling-point.scss
@@ -2,12 +2,12 @@
   border-bottom: 1px solid $base-border-color-1;
   color: $base-font-color;
   font-size: 1.25em;
-  padding-bottom: 3em;
-  padding-top: 3em;
+  padding-bottom: 2em;
+  padding-top: 2em;
 
   @include marketing-fullsize {
-    padding-bottom: 8em;
-    padding-top: 8em;
+    padding-bottom: 6em;
+    padding-top: 6em;
   }
 
   &.deconstructed {
@@ -20,9 +20,9 @@
 }
 
 .selling-point-title {
-  color: $blue-trail;
-  font-size: 1.5em;
-  font-weight: 300;
+  color: $darkwarmgray;
+  font-size: 1.75em;
+  font-weight: 500;
 
   @include marketing-fullsize {
     font-size: 2em;


### PR DESCRIPTION
We want the page to flow nicely, and to have the CTA on the checkout
page a bit higher so it's not hidden.
## Before

![screen shot 2015-09-02 at 11 02 52 am](https://cloud.githubusercontent.com/assets/46677/9635043/54ecc2e8-5162-11e5-93b9-50c5eab696a4.png)

![screen shot 2015-09-02 at 11 02 46 am](https://cloud.githubusercontent.com/assets/46677/9635044/54f2484e-5162-11e5-9a61-6eeca2eb429d.png)
## After

![screen shot 2015-09-02 at 11 03 09 am](https://cloud.githubusercontent.com/assets/46677/9635042/54eae0f4-5162-11e5-8a91-ed45c0077902.png)

![screen shot 2015-09-02 at 11 03 04 am](https://cloud.githubusercontent.com/assets/46677/9635041/54e984c0-5162-11e5-902b-600a009a9567.png)
