### PR TITLE
Remove the recursion limit on StripeCustomerCollection

### DIFF
--- a/app/services/stripe_customer_collection.rb
+++ b/app/services/stripe_customer_collection.rb
@@ -1,6 +1,4 @@
 class StripeCustomerCollection
-  REMAINING = 200
-
   include Enumerable
 
   def initialize(per_page:)
@@ -8,20 +6,19 @@ class StripeCustomerCollection
   end
 
   def each(&block)
-    fetch({ limit: per_page }, remaining: REMAINING, block: block)
+    fetch({ limit: per_page }, block: block)
   end
 
   private
 
-  def fetch(options, remaining:, block:)
+  def fetch(options, block:)
     customers = Stripe::Customer.all(options).to_a
 
-    if customers.any? && remaining > 0
+    if customers.any?
       customers.each(&block)
       fetch(
         options.merge(starting_after: customers.last["id"]),
         block: block,
-        remaining: remaining - 1,
       )
     end
   end

--- a/spec/services/stripe_customer_collection_spec.rb
+++ b/spec/services/stripe_customer_collection_spec.rb
@@ -12,17 +12,5 @@ describe StripeCustomerCollection do
 
       expect(result.map { |customer| customer["id"] }).to eq(customer_ids)
     end
-
-    it "doesn't call recursively more than `remaining` times" do
-      customers_count = StripeCustomerCollection::REMAINING + 1
-      customer_ids = customers_count.times.map { generate(:uuid) }
-      FakeStripe.customer_ids = customer_ids
-      collection = StripeCustomerCollection.new(per_page: 1)
-      result = []
-
-      collection.each { |yielded| result << yielded }
-
-      expect(result.count).to eq(customers_count - 1)
-    end
   end
 end


### PR DESCRIPTION
This appears to exist just to prevent a "stack level too deep" issue if
someone used a very small per_page limit and we had thousands of
customers and not very much memory.

Currently, the only code that uses this uses a per_page value of 100, so
I think the risk is low.

This also happens to delete our costliest test, in terms of time (3
seconds) since we create hundreds of uuids and do lots of iteration.
