### PR TITLE
Clarify distinction between canceling and deactivating subscriptions

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -11,7 +11,7 @@ module AnalyticsHelper
       mentor_name: user.mentor_name,
       name: user.name,
       plan: user.plan_name,
-      scheduled_for_cancellation_on: user.scheduled_for_cancellation_on,
+      scheduled_for_deactivation_on: user.scheduled_for_deactivation_on,
       stripe_customer_url: StripeCustomer.new(user).url,
       subscribed_at: user.subscribed_at,
       username: user.github_username,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -38,8 +38,8 @@ class Subscription < ActiveRecord::Base
     deactivated_on.nil?
   end
 
-  def scheduled_for_cancellation?
-    scheduled_for_cancellation_on.present?
+  def scheduled_for_deactivation?
+    scheduled_for_deactivation_on.present?
   end
 
   def deactivate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ActiveRecord::Base
   delegate :first_name, to: :mentor, prefix: true, allow_nil: true
   delegate :name, to: :mentor, prefix: true, allow_nil: true
   delegate :plan, to: :subscription, allow_nil: true
-  delegate :scheduled_for_cancellation_on, to: :subscription, allow_nil: true
+  delegate :scheduled_for_deactivation_on, to: :subscription, allow_nil: true
 
   before_save :clean_github_username
 

--- a/app/views/subscriptions/_management.html.erb
+++ b/app/views/subscriptions/_management.html.erb
@@ -1,5 +1,5 @@
 <% if subscription.owner?(current_user) %>
-  <% if subscription.active? && !subscription.scheduled_for_cancellation? %>
+  <% if subscription.active? && !subscription.scheduled_for_deactivation? %>
     <%= link_to t('subscriptions.change_plan'), edit_subscription_path %>
     <%= link_to t('subscriptions.cancel'), new_subscriber_cancellation_path, class: 'cancel' %>
   <% end %>

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -1,8 +1,8 @@
 <li class="subscription">
   <% if subscription.active? %>
     <p><strong><%= subscription.plan.name %></strong> <br /> Active since <%= subscription.created_at.to_s(:simple) %></p>
-    <% if subscription.scheduled_for_cancellation? %>
-      <p><%= t('subscriptions.cancellation_scheduled_on', date: subscription.scheduled_for_cancellation_on.to_s(:simple)) %></p>
+    <% if subscription.scheduled_for_deactivation? %>
+      <p><%= t('subscriptions.deactivation_scheduled_on', date: subscription.scheduled_for_deactivation_on.to_s(:simple)) %></p>
     <% end %>
   <% else %>
     <p>Canceled on <%= subscription.deactivated_on.to_s(:simple) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
   subscriptions:
     accept_discounted_annual_subscription: Yes! I want to save $$$ and keep learning
     cancel: Cancel
-    cancellation_scheduled_on: Scheduled for cancellation on %{date}
+    deactivation_scheduled_on: Scheduled for deactivation on %{date}
     change_plan: Change plan
     choose_plan: Switch Plan
     confirm_cancel: Yes, cancel my subscription

--- a/db/migrate/20150911152034_add_date_user_decided_to_cancel_to_subscriptions.rb
+++ b/db/migrate/20150911152034_add_date_user_decided_to_cancel_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddDateUserDecidedToCancelToSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :subscriptions, :user_clicked_cancel_button_on, :date
+  end
+end

--- a/db/migrate/20150911153011_rename_scheduled_for_cancellation.rb
+++ b/db/migrate/20150911153011_rename_scheduled_for_cancellation.rb
@@ -1,0 +1,9 @@
+class RenameScheduledForCancellation < ActiveRecord::Migration
+  def change
+    rename_column(
+      :subscriptions,
+      :scheduled_for_cancellation_on,
+      :scheduled_for_deactivation_on,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150720161005) do
+ActiveRecord::Schema.define(version: 20150911153011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -280,12 +280,13 @@ ActiveRecord::Schema.define(version: 20150720161005) do
     t.datetime "created_at",                                                           null: false
     t.datetime "updated_at",                                                           null: false
     t.date     "deactivated_on"
-    t.date     "scheduled_for_cancellation_on"
+    t.date     "scheduled_for_deactivation_on"
     t.integer  "plan_id",                                                              null: false
     t.string   "plan_type",                     limit: 255, default: "IndividualPlan", null: false
     t.decimal  "next_payment_amount",                       default: 0.0,              null: false
     t.date     "next_payment_on"
     t.string   "stripe_id",                     limit: 255
+    t.date     "user_clicked_cancel_button_on"
   end
 
   add_index "subscriptions", ["plan_id", "plan_type"], name: "index_subscriptions_on_plan_id_and_plan_type", using: :btree

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -28,7 +28,7 @@ describe AnalyticsHelper do
         mentor_name: user.mentor_name,
         name: user.name,
         plan: user.plan_name,
-        scheduled_for_cancellation_on: nil,
+        scheduled_for_deactivation_on: nil,
         stripe_customer_url: StripeCustomer.new(user).url,
         subscribed_at: user.subscribed_at,
         username: user.github_username,

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -57,19 +57,19 @@ describe Subscription do
     end
   end
 
-  describe "#scheduled_for_cancellation?" do
-    it "returns false if scheduled_for_cancellation_on is nil" do
-      subscription = Subscription.new(scheduled_for_cancellation_on: nil)
+  describe "#scheduled_for_deactivation?" do
+    it "returns false if scheduled_for_deactivation_on is nil" do
+      subscription = Subscription.new(scheduled_for_deactivation_on: nil)
 
-      expect(subscription).not_to be_scheduled_for_cancellation
+      expect(subscription).not_to be_scheduled_for_deactivation
     end
 
-    it "returns true if scheduled_for_cancellation_on is not nil" do
+    it "returns true if scheduled_for_deactivation_on is not nil" do
       subscription = Subscription.new(
-        scheduled_for_cancellation_on: Time.zone.today
+        scheduled_for_deactivation_on: Time.zone.today
       )
 
-      expect(subscription).to be_scheduled_for_cancellation
+      expect(subscription).to be_scheduled_for_deactivation
     end
   end
 


### PR DESCRIPTION
When a user wishes to cancel her subscription, there are two distinct
events:
1. The user clicks cancel in the app. They can continue to access all
   content until their current billing cycle ends.
2. Their billing cycle ends, and they can no longer access any content.

Currently, we are not tracking the date at which #1 occurs.

Subscription has a scheduled_for_cancellation_on field, which tracks
that date at which #2 will happen. We use this to tell the user "you can
keep using Upcase until #{date}".

It also has a deactivated_on field, which tracks when #2 actually
happens.

These two fields will be the same for nearly all users. (The exception
is if we refund a user, their account is deactivated immediately. We
also deactivate immediately if we move them to a team plan.)

There are two problems with the current approach.
1. We are using inconsistent language to refer to the same thing:
   "cancel" vs. "deactivate".
2. We aren't tracking the date at which the user decides to cancel and
   clicks the cancel button. (We can technically determine this data from
   the date we send the "Cancel" event to analytics, but I'd like to have
   this data in our db as well.")

This commit addresses both issues.

First, we now consistently refer to the loss of content access as
deactivation.

Second, we now store the date a user clicked cancel in a
user_clicked_cancel_button_on field.

And all was right with the world.
