### PR TITLE
Use timezone-aware methods in cancellation spec

### DIFF
--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -98,7 +98,7 @@ describe Cancellation do
 
   describe "#schedule" do
     it "schedules a cancellation with Stripe" do
-      Timecop.freeze(Time.now) do
+      Timecop.freeze(Time.current) do
         cancellation = build_cancellation(subscription: subscription)
         allow(Stripe::Customer).to(
           receive(:retrieve).and_return(stripe_customer),
@@ -113,7 +113,7 @@ describe Cancellation do
         expect(subscription.scheduled_for_deactivation_on).
           to eq Time.zone.at(billing_period_end).to_date
         expect(subscription.user_clicked_cancel_button_on).
-          to eq Date.today
+          to eq Date.current
         expect(analytics).to(
           have_received(:track).
           with(event: "Cancelled", properties: { reason: "reason" }),


### PR DESCRIPTION
The date under test is stored in the application timezone, UTC. The test, however, used `Time.now` and `Date.today`, both of which use the system timezone. This caused a comparison between my system timezone (EDT) and the application timezone (UTC) resulting in the test failure.

This PR changes `Time.now` and `Date.today` to user their application timezone equivalents, `Time.current` and `Date.current`. This passes the test by ensuring the date comparison is UTC to UTC.
