### PR TITLE
Restore styles lost during refactoring

### DIFF
--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -115,3 +115,7 @@
     padding: 0;
   }
 }
+
+.parent-collection a {
+  font-size: 1.2em;
+}

--- a/app/views/trails/_incomplete_trail.html.erb
+++ b/app/views/trails/_incomplete_trail.html.erb
@@ -12,7 +12,8 @@
     <%= render "trails/step_dots", trail: trail %>
 
     <% if trail.steps.present? %>
-      <%= completeable_link url_for(trail.steps.first.completeable), class: "cta-button small-button" do %>
+      <%= completeable_link url_for(trail.steps.first.completeable),
+        class: "start-trail cta-button small-button" do %>
         Start trail
       <% end %>
     <% end %>

--- a/app/views/videos/show_for_subscribers.html.erb
+++ b/app/views/videos/show_for_subscribers.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :subject_block do %>
   <h1><%= @video.name %></h1>
-  <h2 class="tagline">
+  <h2 class="parent-collection">
     <%= link_to @video.watchable_name, @video.watchable %>
   </h2>
 <% end %>


### PR DESCRIPTION
The start trail buttons on active trails had lost the "start-trail" class and
thus weren't being hidden.

Likewise, the collection link on video pages (linking back to the Trail or
Weekly Iteration pages) was too large.
### Was:

![image](https://cloud.githubusercontent.com/assets/420113/9888977/1bc53af4-5bc6-11e5-9574-9d96ccc293c3.png)

![collection-title-size](https://cloud.githubusercontent.com/assets/420113/9888985/28068d4a-5bc6-11e5-91c3-5979abb8c1b4.png)
### Now Is:

![image](https://cloud.githubusercontent.com/assets/420113/9889017/5e3ab47c-5bc6-11e5-9920-cbd867b0b2d0.png)

![image](https://cloud.githubusercontent.com/assets/420113/9889010/53e490a6-5bc6-11e5-8bdc-72ff521d94d6.png)
