### PR TITLE
fix welcome page typo:  'this' --> 'thing'

### DIFF
--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -139,7 +139,7 @@
     </p>
 
     <p>
-      Remember: <strong>the most important this is to try something.</strong>
+      Remember: <strong>the most important thing is to try something.</strong>
       Use the question mark in the bottom right if feel like you don't know
       where to start.
     </p>


### PR DESCRIPTION
Hi, I found a typo on the Upcase welcome page, last paragraph (bold text).  This pull request is just to fix that typo.
