### PR TITLE
Link to Twitter, not email for testimonial

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -121,7 +121,7 @@
       schedule</strong>.</p>
 
       <cite>
-        <span class="centered-section-quoter">carlisia@grokkingtech.io</span>
+        <span class="centered-section-quoter"><%= link_to "@carlisia", "https://twitter.com/carlisia" %></span>
         <span class="centered-section-position">Senior Software Engineer at VerveMobile</span>
       </cite>
     </blockquote>


### PR DESCRIPTION
This was her email address before (?)

She requested we link to her Twitter profile instead.

![screen shot 2015-09-17 at 10 35 50 am](https://cloud.githubusercontent.com/assets/46677/9935999/e646b958-5d27-11e5-9516-fb0c40c16ac0.png)
