### PR TITLE
Add Touched Video analytics event

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -13,19 +13,12 @@ class Analytics
   end
 
   def track_video_finished(name:, watchable_name:)
-    track(
-      "Finished video",
-      name: name,
-      watchable_name: watchable_name,
-    )
+    track("Finished video", name: name, watchable_name: watchable_name)
   end
 
   def track_video_started(name:, watchable_name:)
-    track(
-      "Started video",
-      name: name,
-      watchable_name: watchable_name,
-    )
+    track("Started video", name: name, watchable_name: watchable_name)
+    track_touched_video(name: name, watchable_name: watchable_name)
   end
 
   def track_searched(query:, results_count:)
@@ -55,11 +48,16 @@ class Analytics
       watchable_name: watchable_name,
       download_type: download_type,
     )
+    track_touched_video(name: name, watchable_name: watchable_name)
   end
 
   private
 
   attr_reader :user
+
+  def track_touched_video(name:, watchable_name:)
+    track("Touched Video", name: name, watchable_name: watchable_name)
+  end
 
   def track(event, properties = {})
     backend.track(

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -18,14 +18,30 @@ describe Analytics do
       video = build_stubbed(:video)
 
       analytics_instance.track_video_started(
-        name: video.slug,
+        name: video.name,
         watchable_name: video.watchable_name,
       )
 
       expect(analytics).to have_tracked("Started video").
         for_user(user).
         with_properties(
-          name: video.slug,
+          name: video.name,
+          watchable_name: video.watchable_name,
+        )
+    end
+
+    it "also tracks video touched event" do
+      video = build_stubbed(:video)
+
+      analytics_instance.track_video_started(
+        name: video.name,
+        watchable_name: video.watchable_name,
+      )
+
+      expect(analytics).to have_tracked("Touched Video").
+        for_user(user).
+        with_properties(
+          name: video.name,
           watchable_name: video.watchable_name,
         )
     end
@@ -36,14 +52,14 @@ describe Analytics do
       video = build_stubbed(:video)
 
       analytics_instance.track_video_finished(
-        name: video.slug,
+        name: video.name,
         watchable_name: video.watchable_name,
       )
 
       expect(analytics).to have_tracked("Finished video").
         for_user(user).
         with_properties(
-          name: video.slug,
+          name: video.name,
           watchable_name: video.watchable_name,
         )
     end
@@ -117,6 +133,22 @@ describe Analytics do
       expect(analytics).to have_tracked("Downloaded Video").
         for_user(user).
         with_properties(download_properties)
+    end
+
+    it "also tracks video touched event" do
+      video = build_stubbed(:video)
+
+      analytics_instance.track_video_started(
+        name: video.name,
+        watchable_name: video.watchable_name,
+      )
+
+      expect(analytics).to have_tracked("Touched Video").
+        for_user(user).
+        with_properties(
+          name: video.name,
+          watchable_name: video.watchable_name,
+        )
     end
   end
 end


### PR DESCRIPTION
This event will server as the aggregate event to track initial interactions
with videos, combining streaming views and downloads.
