### PR TITLE
Fix bug where Start Trail would choose wrong first step

### DIFF
--- a/app/controllers/practice_controller.rb
+++ b/app/controllers/practice_controller.rb
@@ -2,6 +2,14 @@ class PracticeController < ApplicationController
   before_action :require_login
 
   def show
-    @practice = Practice.new(current_user)
+    @practice = Practice.new(trails)
+  end
+
+  private
+
+  def trails
+    TrailsForPracticePageQuery.
+      call.
+      map { |trail| TrailWithProgress.new(trail, user: current_user) }
   end
 end

--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -80,4 +80,8 @@ class Trail < ActiveRecord::Base
   def topic_name
     topic.name
   end
+
+  def first_completeable
+    steps.order(:position).first.completeable
+  end
 end

--- a/app/models/trails_for_practice_page_query.rb
+++ b/app/models/trails_for_practice_page_query.rb
@@ -1,0 +1,12 @@
+class TrailsForPracticePageQuery
+  def self.call
+    new.call
+  end
+
+  def call
+    Trail.
+      published.
+      by_topic.
+      includes(:steps)
+  end
+end

--- a/app/services/practice.rb
+++ b/app/services/practice.rb
@@ -1,6 +1,6 @@
 class Practice
-  def initialize(user)
-    @user = user
+  def initialize(trails)
+    @trails = trails
   end
 
   def has_completed_trails?
@@ -21,15 +21,7 @@ class Practice
 
   private
 
-  attr_reader :user
-
-  def trails
-    Trail.
-      published.
-      by_topic.
-      includes(:steps).
-      map { |trail| TrailWithProgress.new(trail, user: user) }
-  end
+  attr_reader :trails
 
   def completed_trails
     trails.select(&:complete?)

--- a/app/views/trails/_incomplete_trail.html.erb
+++ b/app/views/trails/_incomplete_trail.html.erb
@@ -10,7 +10,7 @@
     <%= render "trails/step_dots", trail: trail %>
 
     <% if trail.steps.present? %>
-      <%= completeable_link url_for(trail.steps.first.completeable),
+      <%= completeable_link url_for(trail.first_completeable),
         class: "start-trail cta-button small-button" do %>
         Start trail
       <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -477,6 +477,10 @@ FactoryGirl.define do
       published true
     end
 
+    trait :unpublished do
+      published false
+    end
+
     trait :completed do
       after :create do |instance|
         Timecop.travel(1.week.ago) do

--- a/spec/features/subscriber_follows_trail_spec.rb
+++ b/spec/features/subscriber_follows_trail_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "subscriber follows trail" do
+feature "subscriber starts a trail" do
   scenario "clicks into exercise" do
     exercises = [
       create(:exercise, name: "First Exercise"),
@@ -9,7 +9,7 @@ feature "subscriber follows trail" do
     create(:trail, :published, name: "Baby Exercises", exercises: exercises)
 
     sign_in_as_user_with_subscription
-    click_on "First Exercise"
+    click_on "Start trail"
 
     expect(page).to have_content("Exercise: First Exercise")
   end

--- a/spec/models/trail_spec.rb
+++ b/spec/models/trail_spec.rb
@@ -284,6 +284,31 @@ describe Trail do
     end
   end
 
+  describe "#first_completeable" do
+    it "returns the completeable associated with the first step in the trail" do
+      trail = build_stubbed(:trail)
+      create(:step, trail: trail, position: 3)
+      create(:step, trail: trail, position: 2)
+      step = create(:step, trail: trail, position: 1)
+
+      result = trail.first_completeable
+
+      expect(result).to eq(step.completeable)
+    end
+
+    context "when steps are included and there are other ORDER BY clauses" do
+      it "still orders by step position" do
+        trail = create(:trail)
+        create(:step, trail: trail, position: 2)
+        step = create(:step, trail: trail, position: 1)
+
+        result = Trail.by_topic.includes(:steps).first.first_completeable
+
+        expect(result).to eq(step.completeable)
+      end
+    end
+  end
+
   def trail_with_exercise_states(user, *states)
     exercises =
       states.map { |state| create_exercise_with_state(state, user: user) }

--- a/spec/models/trails_for_practice_page_query_spec.rb
+++ b/spec/models/trails_for_practice_page_query_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe TrailsForPracticePageQuery do
+  describe "#call" do
+    it "returns only published trails" do
+      create(:trail, :published, name: "published-trail")
+      create(:trail, :unpublished, name: "unpublished-trail")
+
+      result = run_query.map(&:name)
+
+      expect(result).to eq(["published-trail"])
+    end
+
+    it "returns trails sorted by topic name" do
+      create(:trail, :published, topic: create(:topic, name: "ZZZ"))
+      create(:trail, :published, topic: create(:topic, name: "AAA"))
+
+      result = run_query.map(&:topic_name)
+
+      expect(result).to eq(["AAA", "ZZZ"])
+    end
+
+    def run_query
+      TrailsForPracticePageQuery.call
+    end
+  end
+end

--- a/spec/services/practice_spec.rb
+++ b/spec/services/practice_spec.rb
@@ -2,68 +2,66 @@ require "rails_helper"
 
 describe Practice do
   describe "#has_completed_trails?" do
-    it "returns false if it has no completed trails" do
-      user = build_stubbed(:user)
-      practice = Practice.new(user)
+    it "returns false if there are no completed trails" do
+      practice = Practice.new([])
 
       expect(practice).not_to have_completed_trails
     end
 
-    it "returns true if it has completed published trails" do
-      user = create(:user)
-      trail = create(:trail, :published)
-      create(:status, :completed, completeable: trail, user: user)
-      practice = Practice.new(user)
+    it "returns true if it has completed trails" do
+      trail = double("trail", complete?: true)
+      practice = Practice.new([trail])
 
       expect(practice).to have_completed_trails
     end
   end
 
   describe "#just_finished_trails" do
-    it "when there are recently completed trails" do
-      user = create(:user)
-      trail = create(:trail, :published)
-      create(:status, :completed, completeable: trail, user: user)
-      practice = Practice.new(user)
+    context "when there are recently-completed trails" do
+      it "returns those trails" do
+        trail = double("trail", just_finished?: true)
 
-      expect(practice.just_finished_trails).to eq([trail])
+        result = Practice.new([trail]).just_finished_trails
+
+        expect(result).to eq([trail])
+      end
     end
 
-    it "when there are incomplete trails" do
-      user = create(:user)
-      trail = create(:trail, :published)
-      create(:status, completeable: trail, user: user)
-      practice = Practice.new(user)
+    context "when the only trails are incomplete" do
+      it "returns nothing" do
+        trail = double("trail", just_finished?: false)
 
-      expect(practice.just_finished_trails).to be_empty
+        result = Practice.new([trail]).just_finished_trails
+
+        expect(result).to be_empty
+      end
     end
   end
 
   describe "#unstarted_trails" do
     it "returns trails that the user hasn't started" do
-      user = build_stubbed(:user)
-      started_trail = create(:trail, :published, name: "Started")
-      create(:status, completeable: started_trail, user: user)
-      create(:trail, :published, name: "Unstarted")
-      practice = Practice.new(user)
+      started_trail = double("started-trail", unstarted?: false)
+      unstarted_trail = double("unstarted-trail", unstarted?: true)
 
-      result = practice.unstarted_trails
+      result = Practice.new([unstarted_trail, started_trail]).unstarted_trails
 
-      expect(result.map(&:name)).to eq(["Unstarted"])
+      expect(result).to eq([unstarted_trail])
     end
   end
 
   describe "#in_progress_trails" do
     it "returns trails the user has started" do
-      user = build_stubbed(:user)
-      started_trail = create(:trail, :published, name: "Started")
-      create(:status, completeable: started_trail, user: user)
-      create(:trail, :published, name: "Unstarted")
-      practice = Practice.new(user)
+      in_progress_trail =
+        double("in-progress-trail", in_progress?: true)
+      not_in_progress_trail =
+        double("not-in-progress-trail", in_progress?: false)
 
-      result = practice.in_progress_trails
+      result =
+        Practice.
+          new([in_progress_trail, not_in_progress_trail]).
+          in_progress_trails
 
-      expect(result.map(&:name)).to eq(["Started"])
+      expect(result).to eq([in_progress_trail])
     end
   end
 end

--- a/spec/views/trails/_incomplete_trail.html.erb_spec.rb
+++ b/spec/views/trails/_incomplete_trail.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "trails/_incomplete_trail.html" do
   context "for a trail with only videos" do
     it "renders a Start Trail link" do
-      render_trail completeables: [build_stubbed(:video)]
+      render_trail completeables: [create(:video)]
 
       expect(rendered).to have_start_trail_link
     end
@@ -11,7 +11,7 @@ describe "trails/_incomplete_trail.html" do
 
   context "for a trail with only exercises" do
     it "renders a Start Trail link" do
-      render_trail completeables: [build_stubbed(:exercise)]
+      render_trail completeables: [create(:exercise)]
 
       expect(rendered).to have_start_trail_link
     end
@@ -28,16 +28,18 @@ describe "trails/_incomplete_trail.html" do
   def render_trail(*trail_args)
     view_stubs(:current_user_has_access_to?).and_return(true)
 
-    render "trails/incomplete_trail", trail: build_trail(*trail_args)
+    render "trails/incomplete_trail", trail: create_trail(*trail_args)
   end
 
-  def build_trail(completeables:)
+  def create_trail(completeables:)
+    trail = create(:trail)
+
     steps = completeables.map do |completeable|
-      build_stubbed(:step, completeable: completeable)
+      create(:step, completeable: completeable, trail: trail)
     end
 
     TrailWithProgress.new(
-      build_stubbed(:trail, steps: steps),
+      trail,
       user: build_stubbed(:user)
     )
   end


### PR DESCRIPTION
Before this commit, clicking Start Trail on some trails would load a
step that wasn't actually the first step of the trail.

This is because the `by_topic` scope was sorting the results by topic
name, overriding the ORDER BY from acts_as_list.

This commit breaks the query into two parts: first, we query for the
trails that should be displayed on the practice page (now extracted into
TrailsForPracticePageQuery). Then, when rendering the "Start Trail"
button, we perform a second query, asking the trail to return its first
completeable.
