### PR TITLE
Add an explicit size to the close button

### DIFF
--- a/app/assets/stylesheets/landing/_table-of-contents.scss
+++ b/app/assets/stylesheets/landing/_table-of-contents.scss
@@ -54,6 +54,8 @@
   @include position(absolute, 0px 0px 0 0);
   color: $gray-3;
   font-size: 2em;
+  height: 2em;
+  width: 2em;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Before this commit, the close link actually covered the entire Explore
box, so clicking anything would close it.
