### PR TITLE
Install and configure parallel_tests gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "vanity", "2.0.0.beta8"
 
 group :development do
   gem "bullet"
+  gem "parallel_tests"
   gem "quiet_assets"
   gem "spring"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,9 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
       mime-types
+    parallel (1.6.1)
+    parallel_tests (1.7.0)
+      parallel
     pg (0.17.1)
     pg_search (1.0.4)
       activerecord (>= 3.1)
@@ -406,6 +409,7 @@ DEPENDENCIES
   omniauth (~> 1.2.1)
   omniauth-github (~> 1.1.2)
   paperclip (~> 4.2.0)
+  parallel_tests
   pg
   pg_search
   pry-rails
@@ -435,3 +439,6 @@ DEPENDENCIES
   validates_email_format_of
   vanity (= 2.0.0.beta8)
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ development:
 test:
   <<: *default
   pool: 4
-  database: upcase_test
+  database: upcase_test<%= ENV['TEST_ENV_NUMBER'] %>


### PR DESCRIPTION
A normal test run on my machine takes 55s.

With parallel_test installed using 8 cores, the same run takes 26s.

The nice thing to note is that this did not require any changes to our
application code. I think I'd be against using something like this if that
weren't the case, but right now I don't see any downside to using this.

Thoughts?
