### PR TITLE
Provide email to Stripe for GitHub authed users

### DIFF
--- a/app/models/stripe_subscription.rb
+++ b/app/models/stripe_subscription.rb
@@ -43,8 +43,8 @@ class StripeSubscription
   def create_customer
     new_stripe_customer = Stripe::Customer.create(
       card: @checkout.stripe_token,
-      description: @checkout.email,
-      email: @checkout.email
+      description: @checkout.user_email,
+      email: @checkout.user_email,
     )
     @checkout.stripe_customer_id = new_stripe_customer.id
   end


### PR DESCRIPTION
If the user elects to authenticate with GitHub during checkout, then
they do not fill in the "email" field on the `Checkout` form object. We
were previously using this field when creating the customer object in
stripe, which causes the email to blank in Stripe.

All checkout objects have an associated user, so we can use the
previously-existing delegation `user_email` rather than the virtual
field that exists for the form only.
