### PR TITLE
Correct episode order in Weekly Iteration RSS feed

### DIFF
--- a/app/views/shows/show.rss.builder
+++ b/app/views/shows/show.rss.builder
@@ -6,6 +6,6 @@ xml.rss version: '2.0' do
     xml.link show_url(@show)
     xml.title @show.name
 
-    xml << render(@show.published_videos.ordered)
+    xml << render(@show.published_videos.recently_published_first)
   end
 end

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -31,7 +31,7 @@ describe "Videos" do
       unpublished_xpath = ".//item/title[text()='#{video.name}']"
       expect(channel.xpath(unpublished_xpath)).to be_empty
 
-      published_videos.each_with_index do |published_video, index|
+      published_videos.reverse.each_with_index do |published_video, index|
         item = channel.xpath(".//item")[index]
 
         expect(text_in(item, ".//title")).to eq(published_video.name)


### PR DESCRIPTION
This was being ordered by position, which makes sense for video trails,
but not the show RSS feed. This is now reverse chronological order.
