### PR TITLE
Add rack-mini-profiler in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,8 @@ gem "validates_email_format_of"
 gem "vanity", "2.0.0.beta8"
 
 group :development do
-  gem "bullet"
   gem "quiet_assets"
+  gem "rack-mini-profiler", require: false
   gem "spring"
   gem "spring-commands-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,9 +66,6 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
-    bullet (4.14.7)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -215,6 +212,8 @@ GEM
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
+    rack-mini-profiler (0.9.7)
+      rack (>= 1.1.3)
     rack-pjax (0.8.0)
       nokogiri (~> 1.5)
       rack (~> 1.1)
@@ -355,7 +354,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    uniform_notifier (1.9.0)
     validates_email_format_of (1.6.1)
       i18n
     vanity (2.0.0.beta8)
@@ -377,7 +375,6 @@ DEPENDENCIES
   autoprefixer-rails
   aws-sdk
   bourbon (~> 4.0)
-  bullet
   capybara
   capybara-webkit
   capybara_discoball!
@@ -413,6 +410,7 @@ DEPENDENCIES
   pg_search
   pry-rails
   quiet_assets
+  rack-mini-profiler
   rack-rewrite (~> 1.5.1)
   rack-ssl-enforcer (~> 0.2.4)
   rails (~> 4.2.4)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,9 +41,4 @@ Upcase::Application.configure do
 
   GITHUB_KEY = ENV['GITHUB_KEY']
   GITHUB_SECRET = ENV['GITHUB_SECRET']
-
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.console = true
-  end
 end

--- a/config/initializers/rack-mini-profiler.rb
+++ b/config/initializers/rack-mini-profiler.rb
@@ -1,0 +1,8 @@
+if Rails.env.development?
+  require "rack-mini-profiler"
+
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+
+  Rails.application.middleware.delete(Rack::MiniProfiler)
+  Rails.application.middleware.insert_after(Rack::Deflater, Rack::MiniProfiler)
+end


### PR DESCRIPTION
There are several pages in Upcase with N+1 queries that, for whatever
reason, are not being raised by bullet. rack-mini-rpofiler is an
omnipresent reminder of overall page performance and can help find N+1
issues and other problems.
