### PR TITLE
Remove the Change Plan link

### DIFF
--- a/app/views/subscriptions/_management.html.erb
+++ b/app/views/subscriptions/_management.html.erb
@@ -1,6 +1,5 @@
 <% if subscription.owner?(current_user) %>
   <% if subscription.active? && !subscription.scheduled_for_deactivation? %>
-    <%= link_to t('subscriptions.change_plan'), edit_subscription_path %>
     <%= link_to t('subscriptions.cancel'), new_subscriber_cancellation_path, class: 'cancel' %>
   <% end %>
 <% end %>

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -108,7 +108,7 @@ feature "User creates a subscription" do
 
     expect_to_see_the_current_plan(current_user.subscription.plan)
 
-    click_link I18n.t("subscriptions.change_plan")
+    visit edit_subscription_path
     within("[data-sku='#{new_plan.sku}']") do
       click_link I18n.t("subscriptions.choose_plan")
     end

--- a/spec/features/user_manages_team_subscription_spec.rb
+++ b/spec/features/user_manages_team_subscription_spec.rb
@@ -15,7 +15,6 @@ feature "User edits a team subscription" do
 
     visit my_account_path(as: owner)
 
-    expect(page).to have_content "Change plan"
     expect(page).to have_content "View all invoices"
     expect(page).to have_content "Cancel"
 
@@ -37,7 +36,6 @@ feature "User edits a team subscription" do
 
     visit my_account_path
 
-    expect(page).to_not have_content "Change plan"
     expect(page).to_not have_content "View all invoices"
     expect(page).to_not have_content "Cancel"
     expect(page).to_not have_content "Manage Users"


### PR DESCRIPTION
This is part of a larger process to simplify the plan structure such that all
subscribers have the same access. Eventually we want to remove the edit
subscription page entirely, but that would require removing the Weekly
Iteration plan and all the associated support code.

This was the simplest step we could take to remove the "Change Plan" link which
should prevent new upgrades / downgrades.
