### PR TITLE
Move `root` route to the top of the routes file

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Upcase::Application.routes.draw do
+  root to: "homes#show"
+
   use_doorkeeper
 
   get "/5by5" => redirect("/design-for-developers?utm_source=5by5")
@@ -230,8 +232,6 @@ Upcase::Application.routes.draw do
     resource :twitter_player_card, only: [:show]
     resources :completions, only: [:create], controller: "video_completions"
   end
-
-  root to: "homes#show"
 
   resource :annual_billing, only: :new
   resource :credit_card, only: [:update]


### PR DESCRIPTION
Previously, `root` was situated below dozens of other routes, which
means the router will attempt to match all of those routes first. We
know that for a root url, none of those will match. Further, some of the
routes that are ahead of it, use constraints that issue database
queries.

Moving `root` to the top of the file avoids 3 unnecessary SQL queries
and several dozens of route matches. This improved root URL response by
60-70ms in my local testing.
