### PR TITLE
Mg refactor text box aside

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "layout/footer";
 @import "layout/environment-banner";
 @import "text-box";
+@import "layout/aside";
 
 @import "tooltip";
 @import "animations";

--- a/app/assets/stylesheets/layout/_aside.scss
+++ b/app/assets/stylesheets/layout/_aside.scss
@@ -1,0 +1,74 @@
+aside {
+  @include span-columns(3);
+  box-shadow: none;
+  display: inline-block;
+  font-size: $font-size-small;
+  margin-bottom: 1em;
+  position: relative;
+
+  .cta-button {
+    margin-bottom: 2em;
+  }
+
+  hgroup {
+    margin-left: 48px;
+
+    h5, h4 {
+      font-style: normal;
+    }
+
+    h5 {
+      background-color: transparent;
+      display: block;
+      margin-top: 18px;
+      padding: 0;
+      position: relative;
+    }
+  }
+
+  h3 {
+    margin: 40px 0 10px;
+
+    &:first-child, &:only-child {
+      margin-top: 0;
+    }
+  }
+
+  &, p {
+    line-height: 1.5;
+    margin-bottom: 1em;
+  }
+
+  > div {
+    ol, ul {
+      list-style-type: none;
+    }
+  }
+
+  ul, ol {
+    margin: 0 0 2em;
+    padding: 0;
+  }
+
+  li {
+    list-style-type: none;
+    margin: 1rem 0 0;
+  }
+
+  dt p {
+    font-weight: bold;
+  }
+}
+
+@include body-mobile {
+  .content {
+    aside {
+      padding: 0;
+    }
+  }
+
+  aside {
+    @include span-columns(12);
+    margin-top: 3em;
+  }
+}

--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -20,22 +20,10 @@ section {
 
 .content {
   @include outer-container;
-  max-width: $max-width;
   flex: 1;
+  max-width: $max-width;
   padding: 1.5em $side-padding 3em;
   width: 100%;
-
-  ul, ol {
-    padding: 0;
-  }
-
-  li {
-    margin-top: 1rem;
-
-    &:first-child {
-      margin-top: 0;
-    }
-  }
 
   .text-box-wrapper {
     @include span-columns(8.5);
@@ -79,75 +67,6 @@ section {
   }
 }
 
-aside {
-  @include span-columns(3);
-  box-shadow: none;
-  display: inline-block;
-  float: right;
-  font-size: $font-size-small;
-  margin-bottom: 1em;
-  padding-left: 30px;
-  position: relative;
-
-  hgroup {
-    margin-left: 48px;
-
-    h5, h4 {
-      font-style: normal;
-    }
-
-    h5 {
-      background-color: transparent;
-      display: block;
-      margin-top: 18px;
-      padding: 0;
-      position: relative;
-    }
-  }
-
-  h3 {
-    margin: 40px 0 10px;
-
-    &:first-child, &:only-child {
-      margin-top: 0;
-    }
-  }
-
-  &, p {
-    line-height: 1.5;
-    margin-bottom: 1em;
-  }
-
-  > div {
-    ol, ul {
-      list-style-type: none;
-    }
-  }
-
-  ul, ol {
-    padding: 0;
-    margin: 0;
-  }
-
-  li {
-    list-style-type: none;
-    margin: 1rem 0 0;
-
-    a {
-      color: $darkwarmgray;
-      font-style: italic;
-    }
-  }
-
-  dt p {
-    font-weight: bold;
-  }
-}
-
-.hidden {
-  display: none;
-}
-
 @include body-mobile {
   .content {
     padding: 1.5em $side-padding 2em;
@@ -155,14 +74,9 @@ aside {
     .text-box-wrapper {
       @include span-columns(12);
     }
-
-    aside {
-      padding: 0;
-    }
   }
+}
 
-  aside {
-    @include span-columns(12);
-    margin-top: 3em;
-  }
+.hidden {
+  display: none;
 }

--- a/app/views/design_for_developers_resources/_sidebar.html.erb
+++ b/app/views/design_for_developers_resources/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <aside>
-  <%= link_to 'Take the video tutorial', design_for_developers_url, class: 'button' %>
+  <%= link_to 'Take the video tutorial', design_for_developers_url, class: 'cta-button' %>
   <div class="resource-links">
     <h3>Resource Links</h3>
     <ul>


### PR DESCRIPTION
Splitting out `aside` and `text-box` and fixes layout for resources page

from this:

![image](https://cloud.githubusercontent.com/assets/2095625/10248419/b732231a-691f-11e5-83e8-21dfec25dfaa.png)

to this:

![image](https://cloud.githubusercontent.com/assets/2095625/10248401/96c142b4-691f-11e5-818a-f828d8a307a3.png)
