### PR TITLE
Use formatted summary in RSS item description

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,12 +1,4 @@
 class VideosController < ApplicationController
-  def index
-    @videos = Video.published.recently_published_first
-
-    respond_to do |format|
-      format.rss
-    end
-  end
-
   def show
     @video = Video.find(params[:id])
     @watchable = @video.watchable

--- a/app/views/shows/show.rss.builder
+++ b/app/views/shows/show.rss.builder
@@ -6,6 +6,6 @@ xml.rss version: '2.0' do
     xml.link show_url(@show)
     xml.title @show.name
 
-    xml << render(@show.published_videos.recently_published_first)
+    xml << render(@show.published_videos.recently_published_first.first(10))
   end
 end

--- a/app/views/videos/_video.rss.builder
+++ b/app/views/videos/_video.rss.builder
@@ -1,7 +1,9 @@
 xml.item do
-  xml.description video_description(video)
+  xml.title video.name
+  xml.description type: "html" do |desc|
+    desc.cdata!(format_markdown(video.summary))
+  end
   xml.guid video_url(video)
   xml.link video_url(video)
   xml.pubDate video.created_at.to_s(:rfc822)
-  xml.title video.name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Upcase::Application.routes.draw do
   post "/vanity/add_participant"
   get "/vanity/image"
 
-  resources :videos, only: [:index, :show] do
+  resources :videos, only: [:show] do
     resource :twitter_player_card, only: [:show]
     resources :completions, only: [:create], controller: "video_completions"
   end

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -3,20 +3,6 @@ require "rails_helper"
 include StubCurrentUserHelper
 
 describe VideosController do
-  describe "#index" do
-    it "renders RSS" do
-      get :index, format: :rss
-
-      expect(response).to be_success
-    end
-
-    it "doesn't recognize other formats" do
-      expect do
-        get :index, format: :html
-      end.to raise_exception(ActionController::UnknownFormat)
-    end
-  end
-
   describe "#show when viewing a video as user with access" do
     it "renders the subscriber view so they can watch video" do
       user = create(:subscriber)

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -11,8 +11,8 @@ describe "Videos" do
       )
       notes = "a" * 251
       published_videos = [
-        create(:video, :published, watchable: show, position: 0, notes: notes),
-        create(:video, :published, watchable: show, position: 1, notes: notes),
+        create(:video, :published, watchable: show, summary: notes),
+        create(:video, :published, watchable: show, summary: notes),
       ]
       video = create(:video, watchable: show)
 
@@ -44,52 +44,8 @@ describe "Videos" do
         expect(text_in(item, ".//pubDate")).
           to eq(published_video.created_at.to_s(:rfc822))
 
-        expect(text_in(item, ".//description")).to eq(notes.truncate(250))
+        expect(text_in(item, ".//description")).to match(/#{notes}/)
       end
-    end
-
-    it "provides RSS to distribute the all videos to various channels" do
-      show = create(:show)
-      trail = create(:trail, :published)
-      notes = "a" * 251
-      show_video = create(:video, :published, watchable: show, notes: notes)
-      trail_video = create(:video, :published, watchable: nil, notes: notes)
-      create(:step, trail: trail, completeable: trail_video)
-      published_videos = [show_video, trail_video]
-      video = create(:video, watchable: show)
-
-      visit videos_url(format: "rss")
-
-      channel = Nokogiri::XML::Document.parse(page.body).xpath(".//rss/channel")
-
-      expect(text_in(channel, ".//title")).to eq("Upcase Videos")
-      expect(text_in(channel, ".//link")).to eq(root_url)
-      expect(text_in(channel, ".//description")).to eq(
-        "Improve your programming skills with focused exercises."
-      )
-
-      unpublished_xpath = ".//item/title[text()='#{video.name}']"
-      expect(channel.xpath(unpublished_xpath)).to be_empty
-
-      published_videos.each_with_index do |published_video, index|
-        item = channel.xpath(".//item")[index]
-
-        expect(text_in(item, ".//title")).to eq(published_video.name)
-        expect(text_in(item, ".//link")).
-          to eq(video_url(published_video))
-
-        expect(text_in(item, ".//guid")).
-          to eq(video_url(published_video))
-
-        expect(text_in(item, ".//pubDate")).
-          to eq(published_video.created_at.to_s(:rfc822))
-
-        expect(text_in(item, ".//description")).to eq(notes.truncate(250))
-      end
-    end
-
-    def text_in(node, xpath)
-      node.xpath(xpath).first.text
     end
 
     it "user visits The Weekly Iteration video and sees title for the show" do
@@ -101,6 +57,10 @@ describe "Videos" do
 
       expect_page_to_have_title("#{show.title} | Upcase")
     end
+  end
+
+  def text_in(node, xpath)
+    node.xpath(xpath).first.text
   end
 
   def have_rss_link


### PR DESCRIPTION
@croaky This provides the rendered summary of the videos. Should be better for all parties.

@r00k car to give a quick review?
