### PR TITLE
Only load visual website optimizer on tested pages

### DIFF
--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -10,5 +10,4 @@
 <%= render 'layouts/typekit' %>
 <%= csrf_meta_tag %>
 <%= render 'layouts/ie_shiv' %>
-<%= render 'shared/visual_website_optimizer' %>
 <%= yield :head %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%= render "shared/visual_website_optimizer" %>
+<% end %>
+
 <% content_for :additional_body_classes, "landing" %>
 
 <section class="hero tall-hero">


### PR DESCRIPTION
The Visual Website Optimizer (VWO) initialization code produces a
noticeable delay in page rendering while it waits to retreive the user's
VWO settings. I believe this is determined by the `settings_tolerance`
value in that snippet. When I set that value to `0`, the delay goes away
and you get the usual gradual page build in you'd expect.

Presumably that delay exists for a reason (so users don't get items on
the page moving around on them), so I can't just lower the value
indiscriminately.

Currently, we're only using VWO to A/B test the join page, so we can
inject this JavaScript there rather than everywhere throughout the site.
