### PR TITLE
Improve performance of subscription status methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,25 +35,27 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def current_license
+    @current_license ||= License.for(current_user)
+  end
+
   def current_user_is_subscription_owner?
-    current_user_has_active_subscription? &&
-      current_user.subscription.owner?(current_user)
+    current_license.owned_by?(current_user)
   end
   helper_method :current_user_is_subscription_owner?
 
   def current_user_has_active_subscription?
-    current_user && current_user.has_active_subscription?
+    current_license.active?
   end
   helper_method :current_user_has_active_subscription?
 
   def current_user_is_eligible_for_annual_upgrade?
-    current_user_has_active_subscription? &&
-      current_user.eligible_for_annual_upgrade?
+    current_license.eligible_for_annual_upgrade?
   end
   helper_method :current_user_is_eligible_for_annual_upgrade?
 
   def current_user_has_access_to?(feature)
-    current_user && current_user.has_access_to?(feature)
+    current_license.grants_access_to?(feature)
   end
   helper_method :current_user_has_access_to?
 
@@ -82,7 +84,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_team
 
   def onboarding_policy
-    OnboardingPolicy.new(current_user)
+    OnboardingPolicy.new(current_license)
   end
   helper_method :onboarding_policy
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,0 +1,36 @@
+class License < ActiveRecord::Base
+  NULL_LICENSE = NullLicense.new
+
+  belongs_to :plan, polymorphic: true
+  delegate :annual_plan_id, to: :plan
+
+  def self.for(user)
+    if user.present?
+      find_by(user_id: user.id) || NULL_LICENSE
+    else
+      NULL_LICENSE
+    end
+  end
+
+  def owned_by?(user)
+    owner_id == user.id
+  end
+
+  def active?
+    true
+  end
+
+  def eligible_for_annual_upgrade?
+    annual_plan_id.present?
+  end
+
+  def grants_access_to?(feature)
+    plan.public_send("includes_#{feature}")
+  end
+
+  private
+
+  def read_only?
+    true
+  end
+end

--- a/app/models/null_license.rb
+++ b/app/models/null_license.rb
@@ -1,0 +1,17 @@
+class NullLicense
+  def owned_by?(_)
+    false
+  end
+
+  def active?
+    false
+  end
+
+  def eligible_for_annual_upgrade?
+    false
+  end
+
+  def grants_access_to?(_)
+    false
+  end
+end

--- a/app/models/onboarding_policy.rb
+++ b/app/models/onboarding_policy.rb
@@ -1,6 +1,6 @@
 class OnboardingPolicy
-  def initialize(user)
-    @user = user
+  def initialize(license)
+    @license = license
   end
 
   def needs_onboarding?
@@ -23,27 +23,25 @@ class OnboardingPolicy
 
   private
 
-  attr_reader :user
+  attr_reader :license
 
   def route_helpers
     Rails.application.routes.url_helpers
   end
 
   def user_only_has_access_to_weekly_iteration?
-    user.has_active_subscription? && !user_has_trails?
+    license.active? && !licensed_for_trails?
   end
 
   def full_subscriber_with_incomplete_welcome_flow?
-    user.has_active_subscription? &&
-      user_has_trails? &&
-      welcome_flow_incomplete?
+    license.active? && licensed_for_trails? && welcome_flow_incomplete?
   end
 
-  def user_has_trails?
-    user.has_access_to?(:trails)
+  def licensed_for_trails?
+    license.grants_access_to?(:trails)
   end
 
   def welcome_flow_incomplete?
-    !user.completed_welcome?
+    !license.completed_welcome?
   end
 end

--- a/db/migrate/20151009153142_create_licenses_view.rb
+++ b/db/migrate/20151009153142_create_licenses_view.rb
@@ -1,0 +1,5 @@
+class CreateLicensesView < ActiveRecord::Migration
+  def change
+    create_view :licenses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151009144215) do
+ActiveRecord::Schema.define(version: 20151009153142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -443,6 +443,29 @@ ActiveRecord::Schema.define(version: 20151009144215) do
  FROM attempts
 ORDER BY attempts.user_id, attempts.flashcard_id, attempts.updated_at DESC;
       SQL
+
+        create_view :licenses, sql_definition:<<-SQL
+          SELECT subscriptions.id AS subscription_id,
+    subscriptions.user_id,
+    subscriptions.user_id AS owner_id,
+    subscriptions.plan_type,
+    subscriptions.plan_id,
+    users.completed_welcome
+   FROM (subscriptions
+     JOIN users ON ((users.id = subscriptions.user_id)))
+  WHERE (subscriptions.deactivated_on IS NULL)
+UNION ALL
+ SELECT subscriptions.id AS subscription_id,
+    users.id AS user_id,
+    subscriptions.user_id AS owner_id,
+    subscriptions.plan_type,
+    subscriptions.plan_id,
+    users.completed_welcome
+   FROM ((teams
+     JOIN users ON ((users.team_id = teams.id)))
+     JOIN subscriptions ON ((subscriptions.id = teams.subscription_id)))
+  WHERE (subscriptions.deactivated_on IS NULL);
+        SQL
 
         create_view :slugs, sql_definition:<<-SQL
           SELECT products.slug,

--- a/db/views/licenses_v01.sql
+++ b/db/views/licenses_v01.sql
@@ -1,0 +1,24 @@
+SELECT
+  subscriptions.id AS subscription_id,
+  subscriptions.user_id,
+  subscriptions.user_id AS owner_id,
+  subscriptions.plan_type,
+  subscriptions.plan_id,
+  users.completed_welcome
+FROM subscriptions
+  INNER JOIN users ON users.id = subscriptions.user_id
+WHERE subscriptions.deactivated_on IS NULL
+
+UNION ALL
+
+SELECT
+  subscriptions.id as subscription_id,
+  users.id AS user_id,
+  subscriptions.user_id AS owner_id,
+  subscriptions.plan_type,
+  subscriptions.plan_id,
+  users.completed_welcome
+FROM teams
+  INNER JOIN users ON users.team_id = teams.id
+  INNER JOIN subscriptions ON subscriptions.id = teams.subscription_id
+WHERE subscriptions.deactivated_on IS NULL

--- a/spec/controllers/annual_billings_controller_spec.rb
+++ b/spec/controllers/annual_billings_controller_spec.rb
@@ -25,15 +25,14 @@ describe AnnualBillingsController do
     end
 
     def subscriber(eligible_for_annual_upgrade:)
-      build_stubbed(:subscriber).tap do |user|
-        if eligible_for_annual_upgrade
-          allow(user).to receive(:plan).
-            and_return(build_stubbed(:plan, :with_annual_plan))
-          allow(user).to receive(:eligible_for_annual_upgrade?).
-            and_return(true)
-          allow(user).to receive(:has_active_subscription?).and_return(true)
-        end
-      end
+      plan = if eligible_for_annual_upgrade
+              create(:plan, :with_annual_plan)
+            else
+              create(:plan)
+            end
+
+      subscription = create(:subscription, plan: plan)
+      subscription.user
     end
   end
 end

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -11,9 +11,8 @@ describe HomesController do
 
   context "the user is logged in" do
     it "delegates to the OnboaringPolicy to determine where to send the user" do
-      user = create(:user)
-      onboarding_policy = stub_onbarding_policy(user)
-      sign_in_as user
+      onboarding_policy = stub_onbarding_policy
+      sign_in
 
       get :show
 
@@ -21,9 +20,9 @@ describe HomesController do
     end
   end
 
-  def stub_onbarding_policy(user)
+  def stub_onbarding_policy
     instance_double(OnboardingPolicy, root_path: "/my-route").tap do |policy|
-      allow(OnboardingPolicy).to receive(:new).with(user).and_return(policy)
+      allow(OnboardingPolicy).to receive(:new).and_return(policy)
     end
   end
 end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+describe License do
+  describe ".for" do
+    context "when the user has a subscription" do
+      it "returns the subscription for the user" do
+        subscription = create(:subscription)
+
+        license = License.for(subscription.user)
+
+        expect(license.subscription_id).to eq subscription.id
+      end
+    end
+
+    context "when the subscription is deactivated" do
+      it "returns the nil" do
+        subscription = create(:inactive_subscription)
+
+        license = License.for(subscription.user)
+
+        expect(license).to be_an_instance_of NullLicense
+      end
+    end
+
+    context "when they have an active subscription through a team" do
+      it "returns the team subscription for the user" do
+        team = create(:team)
+        user = create(:user, team: team)
+
+        license = License.for(user)
+
+        expect(license.subscription_id).to eq team.subscription.id
+      end
+    end
+
+    context "when they have an inactive subscription through a team" do
+      it "returns nil" do
+        subscription = create(:inactive_subscription)
+        team = create(:team, subscription: subscription)
+        user = create(:user, team: team)
+
+        license = License.for(user)
+
+        expect(license).to be_an_instance_of NullLicense
+      end
+    end
+  end
+
+  describe "#owned_by?" do
+    it "is true if the user is the subscription owner" do
+      subscription = create(:subscription)
+      owner = subscription.user
+
+      license = License.for(owner)
+
+      expect(license).to be_owned_by(owner)
+    end
+
+    it "is false otherwise" do
+      subscription = create(:subscription)
+      user = create(:user)
+
+      license = License.for(subscription.user)
+
+      expect(license).not_to be_owned_by(user)
+    end
+  end
+
+  describe "#eligible_for_annual_upgrade?" do
+    it "is true if the associated plan can be upgraded to annual billing" do
+      plan = create(:plan, :with_annual_plan)
+      subscription = create(:subscription, plan: plan)
+
+      license = License.for(subscription.user)
+
+      expect(license).to be_eligible_for_annual_upgrade
+    end
+
+    it "is false if the associated plan cannot be upgraded to annual billing" do
+      subscription = create(:subscription)
+
+      license = License.for(subscription.user)
+
+      expect(license).not_to be_eligible_for_annual_upgrade
+    end
+  end
+
+  describe "#grants_access_to?" do
+    it "delegates to the associated plan" do
+      plan = create(
+        :plan,
+        includes_forum: true,
+        includes_trails: false,
+      )
+      subscription = create(:subscription, plan: plan)
+
+      license = License.for(subscription.user)
+
+      expect(license.grants_access_to?(:forum)).to be true
+      expect(license.grants_access_to?(:trails)).to be false
+    end
+  end
+end

--- a/spec/models/onboarding_policy_spec.rb
+++ b/spec/models/onboarding_policy_spec.rb
@@ -6,7 +6,7 @@ describe OnboardingPolicy do
   describe "#needs_onboarding?" do
     context "for a user without a subscription" do
       it "returns false" do
-        onboarding_policy = OnboardingPolicy.new(build_stubbed(:user))
+        onboarding_policy = OnboardingPolicy.new(NullLicense.new)
 
         expect(onboarding_policy.needs_onboarding?).to eq(false)
       end
@@ -15,9 +15,9 @@ describe OnboardingPolicy do
     context "for a user with a subscription" do
       context "with access limited to the weekly iteration" do
         it "returns false" do
-          user = build_stubbed(:basic_subscriber)
+          license = weekly_iteration_license
 
-          onboarding_policy = OnboardingPolicy.new(user)
+          onboarding_policy = OnboardingPolicy.new(license)
 
           expect(onboarding_policy.needs_onboarding?).to eq(false)
         end
@@ -26,10 +26,9 @@ describe OnboardingPolicy do
       context "with a full subscription" do
         context "who hasn't completed the welcome onboarding flow" do
           it "returns true" do
-            user = create(:subscriber, :with_full_subscription,
-                          :needs_onboarding)
+            license = full_subscriber_license(completed_welcome: false)
 
-            onboarding_policy = OnboardingPolicy.new(user)
+            onboarding_policy = OnboardingPolicy.new(license)
 
             expect(onboarding_policy.needs_onboarding?).to eq(true)
           end
@@ -37,9 +36,9 @@ describe OnboardingPolicy do
 
         context "who has completed the onboarding welcome flow" do
           it "returns false" do
-            user = create(:subscriber, :with_full_subscription, :onboarded)
+            license = full_subscriber_license(completed_welcome: true)
 
-            onboarding_policy = OnboardingPolicy.new(user)
+            onboarding_policy = OnboardingPolicy.new(license)
 
             expect(onboarding_policy.needs_onboarding?).to eq(false)
           end
@@ -50,7 +49,7 @@ describe OnboardingPolicy do
 
   describe "#onboarded?" do
     it "returns the inverse of #needs_onboarding?" do
-      onboarding_policy = OnboardingPolicy.new(build_stubbed(:user))
+      onboarding_policy = OnboardingPolicy.new(NullLicense.new)
 
       expect(onboarding_policy.onboarded?).
         to eq(!onboarding_policy.needs_onboarding?)
@@ -60,27 +59,47 @@ describe OnboardingPolicy do
   describe "#root_path" do
     it "returns the weekly iteration path for weekly iteration subscribers" do
       stub_weekly_iteration_path
-      user = create(:basic_subscriber)
+      license = weekly_iteration_license
 
-      onboarding_policy = OnboardingPolicy.new(user)
+      onboarding_policy = OnboardingPolicy.new(license)
 
       expect(onboarding_policy.root_path).to eq(weekly_iteration_path)
     end
 
     it "returns the welcome page path for new full subscribers" do
-      user = create(:subscriber, :with_full_subscription, :needs_onboarding)
+      license = full_subscriber_license(completed_welcome: false)
 
-      onboarding_policy = OnboardingPolicy.new(user)
+      onboarding_policy = OnboardingPolicy.new(license)
 
       expect(onboarding_policy.root_path).to eq(welcome_path)
     end
 
     it "returns the pratice path for users who have completed the onboarding" do
-      user = create(:subscriber, :with_full_subscription, :onboarded)
+      license = full_subscriber_license(completed_welcome: true)
 
-      onboarding_policy = OnboardingPolicy.new(user)
+      onboarding_policy = OnboardingPolicy.new(license)
 
       expect(onboarding_policy.root_path).to eq(practice_path)
+    end
+  end
+
+  def weekly_iteration_license
+    double("License", active?: true).tap do |license|
+      allow(license).to receive(:grants_access_to?).
+        with(:trails).
+        and_return(false)
+    end
+  end
+
+  def full_subscriber_license(completed_welcome:)
+    double(
+      "License",
+      active?: true,
+      completed_welcome?: completed_welcome,
+    ).tap do |license|
+      allow(license).to receive(:grants_access_to?).
+        with(:trails).
+        and_return(true)
     end
   end
 


### PR DESCRIPTION
The shared header checks the status of the current user's subscription
along with some data from their plan. This performs 5 SQL round trips
just for this data due to how it was being queried from the user model.
It's possible the user may be subscribed personally or via team
membership, and any of those subscriptions may be active or inactive.

This change introduces the concept of a `License` which is a view of
personal and team subscription metadata. The object can answer what a
user has access to and has a corollary `NullSubscription`.

Updating the controller helpers to route through `License` rather than
`current_user` got us down to two queries. The database view cannot
eliminate the second query (for plans) very easily because the data is
represented by a polymorphic association.

In and of itself, this is a small change. The original queries weren't
overly slow, but I found tracing them through the implementation in the
user model to be confusing. They also instantiate a number of ruby
objects to do their work. Ultimately, the license concept could be
pushed forward to eliminate the feature envy methods on user that deal
strictly with `Subscription` and `Plan` data.
