### PR TITLE
Add a redirect for a podcast coupon url

### DIFF
--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -67,6 +67,9 @@ Rails.configuration.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     r301 "/products/14-prime", "/"
   end
 
+  # Coupons
+  r301 "/halfoff", "/coupons/podcast-oct"
+
   # Podcasts
   r301 "/podcast.xml", "http://podcasts.thoughtbot.com/giantrobots.xml"
   r301 "/giantrobots.xml", "http://podcasts.thoughtbot.com/giantrobots.xml"


### PR DESCRIPTION
We want a speakable, memorable URL that we can use in podcast spots.
