### PR TITLE
Revert QT / Capybara Webkit update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,14 +66,14 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
-    capybara (2.5.0)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.7.1)
-      capybara (>= 2.3.0, < 2.6.0)
+    capybara-webkit (1.3.1)
+      capybara (>= 2.0.2, < 2.5.0)
       json
     clearance (1.8.0)
       bcrypt
@@ -443,4 +443,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.10.5

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,6 @@
 test:
   pre:
     - cp .sample.env .env
-dependencies:
-  pre:
-    - sudo add-apt-repository -y ppa:beineri/opt-qt541
-    - sudo apt-get -y update -o Dir::Etc::sourcelist="sources.list.d/beineri-opt-qt541-precise.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-    - sudo apt-get -y install qt54webkit qt54declarative
-    - echo "source /opt/qt54/bin/qt54-env.sh" >> ~/.circlerc
 deployment:
   staging:
     branch: master

--- a/spec/features/subscriber_views_video_spec.rb
+++ b/spec/features/subscriber_views_video_spec.rb
@@ -26,7 +26,6 @@ feature "subscriber views video trail" do
     marker = create(:marker, video: video, anchor: "topic")
 
     visit video_path(video, as: create(:subscriber))
-
     within "#topic" do
       click_jump_to_topic_in_video_button
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,16 +44,9 @@ end
 Delayed::Worker.delay_jobs = false
 
 Capybara.javascript_driver = :webkit
-
 Capybara.configure do |config|
   config.match = :prefer_exact
   config.ignore_hidden_elements = true
-end
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-  config.allow_url("js.stripe.com")
-  config.allow_url("fast.wistia.com")
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
We were experiencing failures during install on Circle. This, combined with the
somewhat suspect pre install configuration for installing QT made this all feel
off.
