### PR TITLE
Send the user's email in the Cancelled event

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -34,7 +34,7 @@ class Analytics
   end
 
   def track_cancelled(reason:)
-    track("Cancelled", reason: reason)
+    track("Cancelled", reason: reason, email: user.email)
   end
 
   def track_flashcard_attempted(deck:, title:)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -94,12 +94,12 @@ describe Analytics do
   end
 
   describe "#track_cancelled" do
-    it "tracks that the user cancelled along with the reason" do
+    it "tracks that the user cancelled along with the reason and email" do
       analytics_instance.track_cancelled(reason: "No good")
 
       expect(analytics).to have_tracked("Cancelled").
         for_user(user).
-        with_properties(reason: "No good")
+        with_properties(reason: "No good", email: user.email)
     end
   end
 


### PR DESCRIPTION
When a user cancels, the event (along with others) is propagated to Zapier.

If the event is a cancellation and contains a cancellation reason, we
want Zapier to send an email to our Intercom support address. The body
of the email is the cancellation reason.

This change adds the user's email address to the event payload so that
Zapier knows the user's email address. This allows the email sent to
Intercom to appear to be from the user. This causes Intercom to group
the cancellation reason along with all other messages from the user, and
lets us respond to it as if the user had sent it to us directly.
