### PR TITLE
Update `bin/rake` to load the `Gemfile`

### DIFF
--- a/bin/rake
+++ b/bin/rake
@@ -1,7 +1,16 @@
 #!/usr/bin/env ruby
+
+require "pathname"
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile",
+  Pathname.new(__FILE__).realpath,
+)
+
 begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError
 end
-require 'bundler/setup'
-load Gem.bin_path('rake', 'rake')
+require "bundler/setup"
+
+load Gem.bin_path("rake", "rake")


### PR DESCRIPTION
I could not run `bin/rake` execute `rake` and have the environment
loaded.
By adding the following snipper From how `bundler` generates its
binstubs, made it work properly.

``` ruby
require "pathname"
ENV['BUNDLE_GEMFILE'] ||= File.expand_path(
   "../../Gemfile",
  Pathname.new(__FILE__).realpath,
)
```
