### PR TITLE
Enable sticky header on all visitor pages

### DIFF
--- a/app/assets/javascripts/header-setup.js
+++ b/app/assets/javascripts/header-setup.js
@@ -34,11 +34,11 @@ var setupTableOfContents = function() {
 
 $(function() {
   setupTableOfContents();
-  var header = '.landing [data-role="header"]';
+  var header = '.viewed-by-visitor [data-role="header"]';
 
   if ($(header).length) {
     new Headhesive(header, {
-      offset:  500,
+      offset:  window.stickyHeaderStart || 100,
       onStick: setupTableOfContents,
       onUnstick: setupTableOfContents,
     });

--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -58,6 +58,7 @@ $row-highlight: #f9f9f9;
 $max-width: 1100px;
 $navigation-height: 60px;
 $navigation-cta-offset: 10px;
+$header-height: $navigation-height - ($navigation-cta-offset * 2);
 $button-padding: 0.75em 1.2em;
 $button-padding-small: 0.45em 1em;
 $card-height: 370px;

--- a/app/assets/stylesheets/landing/_nav.scss
+++ b/app/assets/stylesheets/landing/_nav.scss
@@ -1,51 +1,54 @@
-.landing #header-wrapper {
-  margin-bottom: 0;
-  z-index: $z-header;
+.viewed-by-visitor {
+  margin-top: $header-height + 15px;
 
-  @include marketing-fullsize {
-    padding: 0 2em;
+  #header-wrapper {
+    margin-bottom: 0;
+    z-index: $z-header;
 
-    nav {
-      margin-right: -2em;
+    @include marketing-fullsize {
+      padding: 0 2em;
 
-      a {
-        padding: 1rem 2rem;
-      }
-    }
-
-    &:not(.headhesive) {
-      @include position(absolute, 0em 0em null 0em);
-      background: none;
-
-      nav li {
-        margin: 8px;
-
-        &:hover {
-          background: rgba(black, 0.12);
-          border-radius: 3px;
-        }
+      nav {
+        margin-right: -2em;
 
         a {
-          border-left: none;
-          height: 44px;
-          padding: 0.5rem 1.5rem;
+          padding: 1rem 2rem;
+        }
+      }
+
+      &:not(.headhesive) {
+        @include position(absolute, 0em 0em null 0em);
+
+        nav li {
+          margin: 8px;
+
+          &:hover {
+            background: rgba(black, 0.12);
+            border-radius: 3px;
+          }
+
+          a {
+            border-left: none;
+            height: 44px;
+            padding: 0.5rem 1.5rem;
+          }
         }
       }
     }
-  }
 
-  &.headhesive {
-    @include position(fixed, 0em 0em null 0em);
-    @include transform(translateY(-100%));
-    @include transition(transform 0.2s);
-    z-index: $z-headhesive;
+    &.headhesive {
+      @include position(fixed, 0em 0em null 0em);
+      @include transform(translateY(-100%));
+      @include transition(transform 0.2s);
+      z-index: $z-headhesive;
 
-    @include dashboard-small-only {
-      display: none;
+      @include dashboard-small-only {
+        display: none;
+      }
     }
-  }
 
-  &.headhesive--stick {
-    @include transform(translateY(0));
+    &.headhesive--stick {
+      @include transform(translateY(0));
+    }
   }
 }

--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -15,8 +15,8 @@
     .header-cta-link {
       @extend %button;
       font-size: 1rem;
-      height: $navigation-height - ($navigation-cta-offset * 2);
-      line-height: $navigation-height - ($navigation-cta-offset * 2);
+      height: $header-height;
+      line-height: $header-height;
       padding: 0 1rem;
 
       &:hover,
@@ -42,8 +42,8 @@
     background-color: $hero-green;
     border-radius: 3px;
     box-shadow: $heavy-box-shadow;
-    height: $navigation-height - ($navigation-cta-offset * 2);
-    line-height: $navigation-height - ($navigation-cta-offset * 2);
+    height: $header-height;
+    line-height: $header-height;
     padding: 0 1em 0 3.5em;
     position: relative;
 

--- a/app/views/layouts/visitor.html.erb
+++ b/app/views/layouts/visitor.html.erb
@@ -4,7 +4,7 @@
     <%= render "application/head_contents" %>
   </head>
 
-  <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">
+  <body class="viewed-by-visitor <%= body_class %> <%= yield(:additional_body_classes) %>">
     <section id="header-wrapper"
       data-role="header">
       <div class="header-container">
@@ -45,6 +45,12 @@
 
       <%= yield %>
     </section>
+
+    <% if content_for?(:sticky_header_height) %>
+      <script type="text/javascript">
+        window.stickyHeaderStart = <%= yield(:sticky_header_height) %>;
+      </script>
+    <% end %>
 
     <%= render "shared/footer" %>
     <%= render "shared/javascript" %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :additional_body_classes, "landing" %>
+<% content_for :sticky_header_height, '500' %>
 
 <section class="hero tall-hero">
   <div class="landing-container">


### PR DESCRIPTION
Previously the sticky header was only active on the main `/join` landing page. This change enables it on all pages for signed out users by virtue of the `signed_out` layout.
