### PR TITLE
Hide the drip widget on signed_in pages

### DIFF
--- a/app/views/layouts/_hide_drip_widget_for_signed_in_users.html.erb
+++ b/app/views/layouts/_hide_drip_widget_for_signed_in_users.html.erb
@@ -1,0 +1,5 @@
+<style>
+  .drip-tab-container {
+    display: none;
+  }
+</style>

--- a/app/views/layouts/signed_in.html.erb
+++ b/app/views/layouts/signed_in.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
   <head prefix="og: http://ogp.me/ns#">
     <%= render "application/head_contents" %>
+    <%= render "layouts/hide_drip_widget_for_signed_in_users" %>
   </head>
 
   <body class="<%= body_class %> <%= yield(:additional_body_classes) %>">


### PR DESCRIPTION
Recently we made the switch to display the Drip signup form for the Dream Job
course on all pages. While this has improved signups, it also displays the form
for signed in users.

Unfortunately there is no exposed way, either in Semgent or Drip, to configure
the display at this level (signed_in vs visitor).

This change hides the form by adding a simple style rule the `signed_in`
layout.
