### PR TITLE
Add CTA to overview page

### DIFF
--- a/app/assets/stylesheets/_exercises-and-teachers.scss
+++ b/app/assets/stylesheets/_exercises-and-teachers.scss
@@ -42,4 +42,12 @@
       margin-bottom: 2rem;
     }
   }
+  
+  .available-link {
+    border-radius: $base-border-radius;
+    border: 1px solid $upcase-green;
+    color: $upcase-green;
+    padding: 5px 10px;
+  }
 }
+

--- a/app/assets/stylesheets/_trails-show.scss
+++ b/app/assets/stylesheets/_trails-show.scss
@@ -36,6 +36,10 @@
       }
     }
 
+    .topic-title p {
+      margin-bottom: 2em;
+    }
+
     .topic-image {
       flex: none;
       margin-right: 2em;

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -18,5 +18,9 @@
   <div class="topic-title">
     <h1><%= trail.name %></h1>
     <p><%= format_markdown trail.description %></p>
+    <%= link_to "#price", class: "cta-button" do %>
+      <%= image_tag("github-white.svg", class: "logo") %>
+      <%= t("subscriptions.join_cta") %>
+    <% end %>
   </div>
 </header>


### PR DESCRIPTION
For DEV: This class can be used for exercise items that are available for non-paying users:

```
  .available-link {
    border-radius: $base-border-radius;
    border: 1px solid $upcase-green;
    color: $upcase-green;
    padding: 5px 10px;
  }
```

![image](https://cloud.githubusercontent.com/assets/2095625/10687935/f38659d8-7970-11e5-9aa1-eadc727cfa12.png)

![image](https://cloud.githubusercontent.com/assets/2095625/10687941/ffb27e94-7970-11e5-824a-890f994f12bd.png)
