### PR TITLE
Enhance legibility of topic font colors and enhance hero units

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -120,15 +120,15 @@ $topic-backgrounds: (
 
 $topic-colors: (
   analytics: #a5c236,
-  clean-code: #1dc8cf,
+  clean-code: darken(#1dc8cf, 5),
   clojure: #ed6820,
   design: #2b2f8e,
-  foundations: #77c159,
+  foundations: darken(#77c159, 5),
   haskell: #cd6fc6,
   ios: #396189,
   javascript: #d87d2f,
   rails: #d5414d,
-  testing: #34d096,
+  testing: darken(#34d096, 10),
   vim: #2192cf,
-  workflow: #f4bc15
+  workflow: darken(#f4bc15, 8)
 );

--- a/app/assets/stylesheets/_resources-index.scss
+++ b/app/assets/stylesheets/_resources-index.scss
@@ -9,9 +9,10 @@ body.topics.topics-show {
     width: 100%;
 
     .topic-header {
+      @include clearfix;
       margin: 0 auto;
       max-width: $max-width;
-      padding: 4.5rem $side-padding;
+      padding: 4.5rem $side-padding 3rem;
       position: relative;
 
       @include dashboard-small-only {
@@ -20,15 +21,26 @@ body.topics.topics-show {
       }
     }
 
+    .topic-header-text {
+      float: left;
+      
+      @include dashboard-small-only {
+        float: none;
+        margin: auto;
+      }
+    }
+
     h1 {
-      margin-bottom: 0.6rem;
+      font-size: 3em;
+      margin-bottom: 0.9rem;
     }
 
     h2 {
-      font-size: 1.125em;
-      font-weight: normal;
+      font-size: 1.6em;
+      font-weight: 200;
       line-height: 1.6em;
       margin-bottom: 2rem;
+      width: 24em;
 
       @include dashboard-small-only {
         margin-bottom: 0;
@@ -36,16 +48,16 @@ body.topics.topics-show {
       }
     }
 
+    img {
+      @include size(220px);
+    }
+
     .topic-image {
-      @include size(180px);
-      position: absolute;
-      right: 0;
-      top: 1em;
+      float: right;
 
       @include dashboard-small-only {
-        top: 0;
-        position: relative;
-        display: inline-block;
+        float: none;
+        margin: auto;
       }
     }
   }

--- a/app/assets/stylesheets/_topics.scss
+++ b/app/assets/stylesheets/_topics.scss
@@ -6,6 +6,10 @@
       h1 {
         color: $topic-color;
       }
+
+      h2 {
+        color: $topic-color; 
+      }
     }
   }
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -2,11 +2,13 @@
 
 <% content_for :subject_block do %>
   <div class="topic-header">
-    <h1><%= @topic.name %></h1>
+    <div class="topic-header-text">
+      <h1><%= @topic.name %></h1>
 
-    <% if @topic.summary.present? %>
-      <h2 class="tagline"><%= @topic.summary %></h2>
-    <% end %>
+      <% if @topic.summary.present? %>
+        <h2 class="tagline"><%= @topic.summary %></h2>
+      <% end %>
+    </div>
 
     <div class="topic-image">
       <%= image_tag "topics/#{@topic.slug}.svg" %>


### PR DESCRIPTION
DEV WORK: We should make taglines for each topic mandatory. Right now topics such as Foundations (that don't have a tagline) just look broken.

![image](https://cloud.githubusercontent.com/assets/2095625/10692679/8e03769a-7993-11e5-88e0-8f184bf15b3f.png)

![image](https://cloud.githubusercontent.com/assets/2095625/10692695/9ee283fc-7993-11e5-973f-7362689ccae4.png)
