### PR TITLE
Only show weekly iteration vids in topic vid list

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -31,4 +31,8 @@ class Topic < ActiveRecord::Base
   def to_param
     slug
   end
+
+  def weekly_iteration_videos
+    videos.where(watchable: Show.the_weekly_iteration)
+  end
 end

--- a/app/views/topics/_resources.html.erb
+++ b/app/views/topics/_resources.html.erb
@@ -13,5 +13,5 @@
 
   <%= render "cards",
     title: "The Weekly Iteration",
-    resources: topic.videos %>
+    resources: topic.weekly_iteration_videos %>
 </section>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -81,6 +81,9 @@ FactoryGirl.define do
     sku 'TEST'
 
     factory :show, class: 'Show' do
+      trait :the_weekly_iteration do
+        name Show::THE_WEEKLY_ITERATION
+      end
     end
 
     factory :repository, class: 'Repository' do

--- a/spec/features/subscriber_views_topic_spec.rb
+++ b/spec/features/subscriber_views_topic_spec.rb
@@ -4,7 +4,7 @@ feature "Subscriber views a topic" do
   scenario "and sees associated resources" do
     topic = create(:topic, :explorable)
     subscriber = create(:subscriber)
-    video = create(:video)
+    video = create(:video, watchable: create(:show, :the_weekly_iteration))
     trail = create(:trail, :published, :video)
     topic.videos << video
     topic.trails << trail

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -42,4 +42,22 @@ describe Topic do
       expect(result).to eq 'Ruby, Rails'
     end
   end
+
+  describe "#weekly_iteration_videos" do
+    it "returns only videos from the weekly iteration, not from trails" do
+      topic = create(:topic, name: "Rails")
+      show = create(:show, :the_weekly_iteration)
+      video = create(:video, name: "Railsy", watchable: show, topics: [topic])
+      create_trail_video(topic)
+
+      expect(topic.weekly_iteration_videos.pluck(:name)).to eq([video.name])
+    end
+  end
+
+  def create_trail_video(topic)
+    create(:trail, :published, name: "Video Trail").tap do |trail|
+      video = create(:video, watchable: trail, topics: [topic])
+      create(:step, trail: trail, completeable: video)
+    end
+  end
 end

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -37,6 +37,8 @@ describe "topics/_resources" do
       videos: [build_stubbed(:video, slug: "a-video")]
     ).tap do |topic|
       allow(topic).to receive(:published_trails).and_return(published_trails)
+      allow(topic).to receive(:weekly_iteration_videos).
+        and_return([build_stubbed(:video)])
     end
   end
 


### PR DESCRIPTION
On the topic pages, we list Trails associated with the given topic first, then
provide a list of individual videos tagged with the topic. This is intended to
be only Weekly Iteration videos, but the existing code was grabbing all videos,
including those from trails.

This double lists the videos, but more problematically, it provides links to
videos that signed out users can't actually see.

This change updates the video display to only show videos from the Weekly
Iteration.
