### PR TITLE
Display "base" errors on checkout

### DIFF
--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -1,5 +1,7 @@
 <%= semantic_form_for checkout, url: checkouts_path(checkout.plan), html: { method: 'post' } do |form| %>
 
+  <%= form.semantic_errors %>
+
   <%= form.inputs do %>
     <% if signed_out? %>
       <ul class="checkout-sigin-signup-toggle">

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -9,6 +9,7 @@ feature "User creates a subscription" do
   scenario "doesn't create a Stripe subscription with an invalid credit card" do
     subscribe_with_invalid_credit_card
 
+    expect(page).to have_credit_card_error
     expect(current_user).not_to have_active_subscription
   end
 
@@ -162,5 +163,9 @@ feature "User creates a subscription" do
   def have_github_input
     have_content("GitHub username") &&
       have_css("input#checkout_github_username")
+  end
+
+  def have_credit_card_error
+    have_content(I18n.t("checkout.problem_with_card", message: ""))
   end
 end


### PR DESCRIPTION
Because:
- We don't control Stripe's credit card fields
- We don't have a field for coupons
- Errors can occur on these fields
- Those errors are recorded as "base" errors
- We can't display inline errors for these fields
- We want to display credit card processing errors

This commit:
- Displays "base" errors from the checkout object

https://trello.com/c/FB56vFqT
