### PR TITLE
Use error styles for "base" errors

### DIFF
--- a/app/assets/stylesheets/_base-forms.scss
+++ b/app/assets/stylesheets/_base-forms.scss
@@ -7,7 +7,7 @@ form {
   }
 
   .errors, .errors li {
-    color: $upcase-blue;
+    color: $red;
     font-size: 18px;
     font-style: bold;
     margin-top: 20px;


### PR DESCRIPTION
Most of our errors are colored red, but these errors are blue.

It looks like we accidentally changed errors from red to blue when we
changed the primary color theme:

https://github.com/thoughtbot/upcase/commit/2672b89d

This changes these errors to use the same colors as the inline errors.

Before:

![](https://dl.dropboxusercontent.com/1/view/fsd3jkojnrsjc50/Screenshots/2015-10-27-143712.png)

After:

![](https://dl.dropboxusercontent.com/1/view/42fpa0i92wynhwe/Screenshots/2015-10-27-143743.png)

https://trello.com/c/FB56vFqT
