### PR TITLE
Add hotjar for user session visualization

### DIFF
--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -10,5 +10,6 @@
 <%= render 'layouts/typekit' %>
 <%= csrf_meta_tag %>
 <%= render 'layouts/ie_shiv' %>
+<%= render "shared/hotjar" %>
 <%= render 'shared/visual_website_optimizer' %>
 <%= yield :head %>

--- a/app/views/shared/_hotjar.html.erb
+++ b/app/views/shared/_hotjar.html.erb
@@ -1,0 +1,10 @@
+<script>
+  (function(h,o,t,j,a,r){
+    h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+    h._hjSettings={hjid:94378,hjsv:5};
+    a=o.getElementsByTagName('head')[0];
+    r=o.createElement('script');r.async=1;
+    r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+    a.appendChild(r);
+  })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+</script>


### PR DESCRIPTION
Hotjar allows us to see how users, both visitors and subscribers, interact with
the site. By reviewing this session data we can find bottlenecks and unclear
points in the app and public facing pages.
