### PR TITLE
Coupons considered invalid by Stripe are invalid

### DIFF
--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -20,7 +20,7 @@ class Coupon
   end
 
   def valid?
-    stripe_coupon.present?
+    stripe_coupon.present? && stripe_coupon.valid
   end
 
   private

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -29,12 +29,28 @@ describe Coupon do
     expect(coupon.duration_in_months).to eq "3"
   end
 
-  it "is not valid if the coupon code does not exist" do
-    exception = Stripe::InvalidRequestError.new("No such coupon", "NONE")
-    allow(Stripe::Coupon).to receive(:retrieve).and_raise(exception)
-    coupon = Coupon.new("NONE")
+  describe "#valid?" do
+    it "is valid if the coupon exists and is usable" do
+      coupon = create(:coupon)
 
-    expect(coupon).not_to be_valid
+      expect(coupon).to be_valid
+    end
+
+    it "is not valid if the coupon code does not exist" do
+      exception = Stripe::InvalidRequestError.new("No such coupon", "NONE")
+      allow(Stripe::Coupon).to receive(:retrieve).and_raise(exception)
+      coupon = Coupon.new("NONE")
+
+      expect(coupon).not_to be_valid
+    end
+
+    it "is not valid if it can't be used" do
+      coupon = create(:coupon)
+      stripe_coupon = double(Stripe::Coupon, valid: false)
+      allow(Stripe::Coupon).to receive(:retrieve).and_return(stripe_coupon)
+
+      expect(coupon).not_to be_valid
+    end
   end
 
   describe "#apply" do


### PR DESCRIPTION
Because:
- We only remove coupons when they're invalid
- We can't complete a checkout with an invalid coupon

This commit:
- Ensures any invalid Stripe coupon is considered invalid locally

https://trello.com/c/FB56vFqT
