### PR TITLE
Users can GitHub auth to see free videos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "uglifier"
 gem "unicorn"
 gem "validates_email_format_of"
 gem "vanity", "2.0.0.beta8"
+gem "wrapped"
 
 group :development do
   gem "quiet_assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ GEM
     webmock (1.20.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    wrapped (0.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -441,6 +442,7 @@ DEPENDENCIES
   validates_email_format_of
   vanity (= 2.0.0.beta8)
   webmock
+  wrapped
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/assets/stylesheets/_exercises-and-teachers.scss
+++ b/app/assets/stylesheets/_exercises-and-teachers.scss
@@ -42,4 +42,11 @@
       margin-bottom: 2rem;
     }
   }
+
+  .available-link {
+    border: 1px solid $upcase-green;
+    border-radius: $base-border-radius;
+    color: $upcase-green;
+    padding: 5px 10px;
+  }
 }

--- a/app/assets/stylesheets/_trails-show.scss
+++ b/app/assets/stylesheets/_trails-show.scss
@@ -76,4 +76,8 @@
   .dot {
     margin: 0;
   }
+
+  .topic-description {
+    margin-bottom: 2em;
+  }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,8 +17,14 @@ module ApplicationHelper
     keywords.presence || Topic.all.pluck(:name).join(", ")
   end
 
-  def github_auth_path
-    '/auth/github'
+  def github_auth_path(params = {})
+    base_path = "/auth/github"
+
+    if params.any?
+      "#{base_path}?#{params.to_query}"
+    else
+      base_path
+    end
   end
 
   def format_markdown(markdown)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -9,4 +9,8 @@ class Exercise < ActiveRecord::Base
   def self.ordered
     order(:created_at)
   end
+
+  def accessible_without_subscription?
+    false
+  end
 end

--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -84,4 +84,8 @@ class Trail < ActiveRecord::Base
   def first_completeable
     steps.order(:position).first.completeable
   end
+
+  def trial_video
+    videos.where(accessible_without_subscription: true).first.wrapped
+  end
 end

--- a/app/views/exercises/_exercise_for_trail_preview.html.erb
+++ b/app/views/exercises/_exercise_for_trail_preview.html.erb
@@ -12,7 +12,7 @@
     <div class="exercise-item">
       <h3><%= exercise.name %></h3>
       <p><%= exercise.summary %></p>
-      <%= render "products/locked" %>
+      <%= render "products/locked", feature: exercise %>
     </div>
   <% end %>
 </figure>

--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -1,9 +1,17 @@
-<div class="product-card-locked">
-  <span class="icon">
-    <%= image_tag("icons/lock.svg", size: "11x15") %>
-  </span>
+<% if feature.accessible_without_subscription? %>
+  <%= link_to(
+    "Free Course",
+    github_auth_path(origin: url_for(feature)),
+    class: "available-link"
+  ) %>
+<% else %>
+  <div class="product-card-locked">
+    <span class="icon">
+      <%= image_tag("icons/lock.svg", size: "11x15") %>
+    </span>
 
-  <%= link_to 'Get access by joining Upcase',
-    join_path,
-    class: 'upgrade-link' %>
-</div>
+    <%= link_to 'Get access by joining Upcase',
+      join_path,
+      class: 'upgrade-link' %>
+  </div>
+<% end %>

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -17,6 +17,19 @@
 
   <div class="topic-title">
     <h1><%= trail.name %></h1>
-    <p><%= format_markdown trail.description %></p>
+    <div class="topic-description">
+      <%= format_markdown trail.description %>
+    </div>
+    <% unless signed_in? %>
+      <% trail.trial_video.present do |video| %>
+        <%= link_to(
+          github_auth_path(origin: video_path(video)),
+          class: "cta-button",
+        ) do %>
+          <%= image_tag("github-white.svg", class: "logo") %>
+          <%= t("trails.start_for_free") %>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </header>

--- a/app/views/videos/_video_for_trail_preview.html.erb
+++ b/app/views/videos/_video_for_trail_preview.html.erb
@@ -3,7 +3,7 @@
     <div class="dot"></div>
   </div>
 
-  <% if current_user_has_active_subscription? %>
+  <% if current_user_has_access_to?(video) %>
     <%= link_to video_path(video), class:"exercise-item", title: video.name do %>
       <h3><%= video.name %></h3>
       <p><%= video.summary %></p>
@@ -12,7 +12,7 @@
     <div class="exercise-item">
       <h3><%= video.name %></h3>
       <p><%= video.summary %></p>
-      <%= render "products/locked" %>
+      <%= render "products/locked", feature: video %>
     </div>
   <% end %>
 </figure>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
       heading:
         online: Online video tutorial
   trails:
+    start_for_free: Start Course For Free
     other_resources: Use these resources for reference and additional practice
     thoughtbot_resources: Use these thoughtbot resources first
     validations: '%{name} developers should be able to'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -413,6 +413,14 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_progress do
+      state { Status::UNSTARTED }
+
+      initialize_with do
+        CompleteableWithProgress.new(new(attributes.except(:state)), state)
+      end
+    end
+
     after(:stub) { |video| video.slug = video.id.to_s }
   end
 

--- a/spec/features/user_without_subscription_views_sample_video_spec.rb
+++ b/spec/features/user_without_subscription_views_sample_video_spec.rb
@@ -7,8 +7,8 @@ feature "User without a subscription views sample video" do
     video = trail.first_completeable
     video.update accessible_without_subscription: true
 
-    visit trail_path(trail, as: user)
-    click_on video.name
+    visit trail_path(trail)
+    click_on "Start Course For Free"
 
     expect(user.has_active_subscription?).to eq(false)
     expect(current_path).to eq(video_path(video))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,4 +26,19 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#github_auth_path" do
+    context "without query parameters" do
+      it "generates a bare path" do
+        expect(helper.github_auth_path).to eq("/auth/github")
+      end
+    end
+
+    context "with query parameters" do
+      it "adds the query parameters to the generated path" do
+        expect(helper.github_auth_path(one: "1", two: "2")).
+          to eq("/auth/github?one=1&two=2")
+      end
+    end
+  end
 end

--- a/spec/models/trail_spec.rb
+++ b/spec/models/trail_spec.rb
@@ -297,6 +297,63 @@ describe Trail do
     end
   end
 
+  describe "#trial_video" do
+    context "with videos accessible without a subscription" do
+      it "returns the first match" do
+        trail = create(:trail)
+        create(
+          :step,
+          trail: trail,
+          position: 3,
+          completeable: create(
+            :video,
+            name: "SecondAccessible",
+            accessible_without_subscription: true,
+          ),
+        )
+        create(
+          :step,
+          trail: trail,
+          position: 2,
+          completeable: create(
+            :video,
+            name: "FirstAccessible",
+            accessible_without_subscription: true,
+          ),
+        )
+        create(
+          :step,
+          trail: trail,
+          position: 1,
+          completeable: create(
+            :video,
+            name: "Inaccessible",
+            accessible_without_subscription: false,
+          ),
+        )
+
+        result = trail.trial_video
+
+        expect(result.map(&:name)).to eq("FirstAccessible".wrapped)
+      end
+    end
+
+    context "without any videos accessible without a subscription" do
+      it "returns nil" do
+        trail = create(:trail)
+        create(
+          :step,
+          trail: trail,
+          completeable: create(:video, accessible_without_subscription: false),
+        )
+
+        result = trail.trial_video
+
+        expect(result).to be_blank
+      end
+    end
+  end
+
   def trail_with_exercise_states(user, *states)
     exercises =
       states.map { |state| create_exercise_with_state(state, user: user) }

--- a/spec/views/videos/_video_for_trail_preview.html.erb_spec.rb
+++ b/spec/views/videos/_video_for_trail_preview.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "videos/_video_for_trail_preview.html" do
+  include Rails.application.routes.url_helpers
+
+  context "with access to the video" do
+    it "links to the video page" do
+      stub_access true
+      video = build_stubbed(:video, :with_progress)
+
+      render "videos/video_for_trail_preview", video: video
+
+      expect(rendered).to have_link_to(video_path(video))
+    end
+  end
+
+  context "without access to a subscription-only video" do
+    it "links to the join page" do
+      stub_access false
+      video = build_stubbed(
+        :video,
+        :with_progress,
+        accessible_without_subscription: false,
+      )
+
+      render "videos/video_for_trail_preview", video: video
+
+      expect(rendered).to have_link_to(join_path)
+    end
+  end
+
+  context "without access to a video accessible without a subscription" do
+    it "links to the GitHub signin path" do
+      stub_access false
+      video = create(
+        :video,
+        :with_progress,
+        accessible_without_subscription: true,
+      )
+
+      render "videos/video_for_trail_preview", video: video
+
+      github_signin_path = github_auth_path(origin: video_path(video))
+      expect(rendered).to have_link_to(github_signin_path)
+    end
+  end
+
+  def stub_access(result)
+    view_stubs(:current_user_has_access_to?).and_return(result)
+  end
+end


### PR DESCRIPTION
Because:
- We want users to be able to try before they buy
- We don't want to create a special trial plan

This commit:
- Allows access for users without subscriptions to some content
- Adds a call to action to try out the course for free when possible
- Uses GitHub OAuth to allow users to quickly get started

Notes:
- This uses the existing "accessible_without_subscription" flag
- That flag requires the user to be signed in, with or without GitHub
- Users could already access these videos, but they weren't linked

https://trello.com/c/zePF3JEV
