### PR TITLE
Display flash message for beta replies

### DIFF
--- a/app/controllers/beta/replies_controller.rb
+++ b/app/controllers/beta/replies_controller.rb
@@ -4,7 +4,7 @@ module Beta
 
     def create
       Reply.create!(offer: offer, user: current_user)
-      redirect_to practice_path
+      redirect_to practice_path, notice: t("beta.replies.flashes.success")
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,10 @@ en:
   authenticating:
     github_signin: Sign in with GitHub
     login_required: You must be signed in to view that page
+  beta:
+    replies:
+      flashes:
+        success: Request received! We'll let you know when the trail is ready.
   checkout:
     flashes:
       already_subscribed: You are already subscribed. You can change your plan.

--- a/spec/features/subscriber_requests_access_to_beta_trail_spec.rb
+++ b/spec/features/subscriber_requests_access_to_beta_trail_spec.rb
@@ -13,6 +13,7 @@ feature "subscriber requests access to beta trail" do
 
     click_on "Request Access"
 
+    expect(page).to have_content(I18n.t("beta.replies.flashes.success"))
     expect(page).not_to have_content("Exciting Beta Trail")
   end
 end


### PR DESCRIPTION
It's beta to let the user know we received their request for access.

https://trello.com/c/XeHQyMPh
