### PR TITLE
Track when users reply to beta offers

### DIFF
--- a/app/controllers/beta/replies_controller.rb
+++ b/app/controllers/beta/replies_controller.rb
@@ -4,6 +4,7 @@ module Beta
 
     def create
       create_reply
+      track_reply
       redirect_with_notice
     end
 
@@ -11,6 +12,13 @@ module Beta
 
     def create_reply
       offer.reply(user: current_user, accepted: accepted?)
+    end
+
+    def track_reply
+      analytics.track_replied_to_beta_offer(
+        name: offer.name,
+        accepted: accepted?,
+      )
     end
 
     def redirect_with_notice

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -51,6 +51,14 @@ class Analytics
     track_touched_video(name: name, watchable_name: watchable_name)
   end
 
+  def track_replied_to_beta_offer(name:, accepted:)
+    track(
+      "Replied to beta offer",
+      name: name,
+      accepted: accepted,
+    )
+  end
+
   private
 
   attr_reader :user

--- a/spec/controllers/beta/replies_controller_spec.rb
+++ b/spec/controllers/beta/replies_controller_spec.rb
@@ -6,10 +6,12 @@ describe Beta::RepliesController do
       it "accepts and redirects to practice" do
         offer = stub_offer
         user = sign_in
+        analytics = stub_analytics_for(user)
         post_create offer: offer, accepted: true
 
         expect(response).to redirect_to(practice_url)
         expect(offer).to have_received_reply(user: user, accepted: true)
+        expect(analytics).to have_tracked_reply(offer, true)
       end
     end
 
@@ -17,10 +19,12 @@ describe Beta::RepliesController do
       it "declines and redirects to practice" do
         offer = stub_offer
         user = sign_in
+        analytics = stub_analytics_for(user)
         post_create offer: offer, accepted: false
 
         expect(response).to redirect_to(practice_url)
         expect(offer).to have_received_reply(user: user, accepted: false)
+        expect(analytics).to have_tracked_reply(offer, false)
       end
     end
 
@@ -43,12 +47,24 @@ describe Beta::RepliesController do
       end
     end
 
+    def stub_analytics_for(user)
+      double(Analytics).tap do |analytics|
+        allow(Analytics).to receive(:new).with(user).and_return(analytics)
+        allow(analytics).to receive(:track_replied_to_beta_offer)
+      end
+    end
+
     def post_create(offer: stub_offer, accepted: false)
       post :create, offer_id: offer.to_param, accepted: accepted.to_s
     end
 
     def have_received_reply(user:, accepted:)
       have_received(:reply).with(user: user, accepted: accepted)
+    end
+
+    def have_tracked_reply(offer, accepted)
+      have_received(:track_replied_to_beta_offer).
+        with(name: offer.name, accepted: accepted)
     end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -151,4 +151,22 @@ describe Analytics do
         )
     end
   end
+
+  describe "#track_replied_to_beta_offer" do
+    it "records the offer name and reply" do
+      offer = build_stubbed(:beta_offer)
+
+      analytics_instance.track_replied_to_beta_offer(
+        name: offer.name,
+        accepted: true,
+      )
+
+      expect(analytics).to have_tracked("Replied to beta offer").
+        for_user(user).
+        with_properties(
+          name: offer.name,
+          accepted: true,
+        )
+    end
+  end
 end


### PR DESCRIPTION
Because:
- We want to find users in Intercom who are interested in beta trails

This commit:
- Records an analytics event when users reply to beta offers

https://trello.com/c/XeHQyMPh
