### PR TITLE
Fix See What You'll Learn button

### DIFF
--- a/app/views/layouts/signed_in.html.erb
+++ b/app/views/layouts/signed_in.html.erb
@@ -24,5 +24,6 @@
 
     <%= render "shared/footer" %>
     <%= render "shared/javascript" %>
+    <%= render "shared/table_of_contents" %>
   </body>
 </html>


### PR DESCRIPTION
I came across this issue the other day and decided to submit a quick fix.

The See What You'll Learn button on the subscriptions/new page is broken for users who are signed in and without an active subscription. This combination uses the signed_in layout which does not include the table of contents content used to display the popup.

This PR fixes the button by rendering the table of contents partial as part of the signed_in layout.

I wrote a view test to drive the change but removed it as I didn't think it added much confidence/value.  I can include it as part of the PR if preferred.
