### PR TITLE
Fire 'Authed to Access' event with video details

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,6 +79,17 @@ class ApplicationController < ActionController::Base
   end
   helper_method :onboarding_policy
 
+  def github_auth_path(params = {})
+    base_path = "/auth/github"
+
+    if params.any?
+      "#{base_path}?#{params.to_query}"
+    else
+      base_path
+    end
+  end
+  helper_method :github_auth_path
+
   def capture_campaign_params
     session[:campaign_params] ||= {
       utm_campaign: params[:utm_campaign],

--- a/app/controllers/auth_callbacks_controller.rb
+++ b/app/controllers/auth_callbacks_controller.rb
@@ -1,12 +1,26 @@
 class AuthCallbacksController < ApplicationController
   def create
-    @user = AuthHashService.new(auth_hash).find_or_create_user_from_auth_hash
-    sign_in @user
+    sign_in_user_from_auth_hash
+    track_authed_to_access
     redirect_to url_after_auth
     clear_return_to
   end
 
   private
+
+  def sign_in_user_from_auth_hash
+    user = AuthHashService.new(auth_hash).find_or_create_user_from_auth_hash
+    sign_in user
+  end
+
+  def track_authed_to_access
+    auth_to_access_video.present do |video|
+      analytics.track_authed_to_access(
+        video_name: video.name,
+        watchable_name: video.watchable_name,
+      )
+    end
+  end
 
   def url_after_auth
     if originated_from_sign_in_or_sign_up?
@@ -22,6 +36,11 @@ class AuthCallbacksController < ApplicationController
 
   def custom_return_path_or_default(default_path)
     ReturnPathFinder.new(auth_origin).return_path || default_path
+  end
+
+  def auth_to_access_video
+    slug = session.delete(:auth_to_access_video_slug)
+    Video.find_by(slug: slug).wrapped
   end
 
   def auth_hash

--- a/app/controllers/auth_to_accesses_controller.rb
+++ b/app/controllers/auth_to_accesses_controller.rb
@@ -1,0 +1,20 @@
+class AuthToAccessesController < ApplicationController
+  def show
+    save_video_slug
+    redirect_to github_auth_with_video_origin_path
+  end
+
+  private
+
+  def save_video_slug
+    session[:auth_to_access_video_slug] = video.slug
+  end
+
+  def github_auth_with_video_origin_path
+    github_auth_path(origin: video_path(video))
+  end
+
+  def video
+    @video = Video.find(params[:video_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,16 +17,6 @@ module ApplicationHelper
     keywords.presence || Topic.all.pluck(:name).join(", ")
   end
 
-  def github_auth_path(params = {})
-    base_path = "/auth/github"
-
-    if params.any?
-      "#{base_path}?#{params.to_query}"
-    else
-      base_path
-    end
-  end
-
   def format_markdown(markdown)
     if markdown.present?
       renderer = Redcarpet::Markdown.new(

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -59,6 +59,14 @@ class Analytics
     )
   end
 
+  def track_authed_to_access(video_name:, watchable_name:)
+    track(
+      "Authed to Access",
+      video_name: video_name,
+      watchable_name: watchable_name,
+    )
+  end
+
   private
 
   attr_reader :user

--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -1,7 +1,7 @@
 <% if feature.accessible_without_subscription? %>
   <%= link_to(
     "Free Course",
-    github_auth_path(origin: url_for(feature)),
+    video_auth_to_access_path(feature),
     class: "available-link"
   ) %>
 <% else %>

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -23,7 +23,7 @@
     <% unless signed_in? %>
       <% trail.trial_video.present do |video| %>
         <%= link_to(
-          github_auth_path(origin: video_path(video)),
+          video_auth_to_access_path(video),
           class: "cta-button",
         ) do %>
           <%= image_tag("github-white.svg", class: "logo") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Upcase::Application.routes.draw do
   get "/vanity/image"
 
   resources :videos, only: [:show] do
+    resource :auth_to_access, only: [:show]
     resource :twitter_player_card, only: [:show]
     resources :completions, only: [:create], controller: "video_completions"
   end

--- a/spec/features/user_without_subscription_views_sample_video_spec.rb
+++ b/spec/features/user_without_subscription_views_sample_video_spec.rb
@@ -14,5 +14,13 @@ feature "User without a subscription views sample video" do
     expect(current_path).to eq(video_path(video))
     expect(page).to have_css("h1", text: video.name)
     expect(page).not_to have_css(".locked-message")
+    expect_authed_to_access_event_fired_for(video)
+  end
+
+  def expect_authed_to_access_event_fired_for(video)
+    expect(analytics).to have_tracked("Authed to Access").with_properties(
+      video_name: video.name,
+      watchable_name: video.watchable_name,
+    )
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,19 +26,4 @@ describe ApplicationHelper do
       end
     end
   end
-
-  describe "#github_auth_path" do
-    context "without query parameters" do
-      it "generates a bare path" do
-        expect(helper.github_auth_path).to eq("/auth/github")
-      end
-    end
-
-    context "with query parameters" do
-      it "adds the query parameters to the generated path" do
-        expect(helper.github_auth_path(one: "1", two: "2")).
-          to eq("/auth/github?one=1&two=2")
-      end
-    end
-  end
 end

--- a/spec/support/session_helpers.rb
+++ b/spec/support/session_helpers.rb
@@ -1,4 +1,8 @@
 module SessionHelpers
+  def stub_signed_in(result = true)
+    view_stubs(:signed_in?).and_return(result)
+  end
+
   def sign_in
     sign_in_as create(:user)
   end

--- a/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
+++ b/spec/views/exercises/_exercise_for_trail_preview.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "exercises/_exercise_for_trail_preview.html" do
+  include SessionHelpers
+
   context "without an active subscription" do
     it "renders an upgrade link" do
       stub_has_active_subscription(false)
@@ -40,10 +42,6 @@ describe "exercises/_exercise_for_trail_preview.html" do
   def stub_has_active_subscription(access)
     stub_signed_in
     view_stubs(:current_user_has_active_subscription?).and_return(access)
-  end
-
-  def stub_signed_in
-    view_stubs(:signed_in?).and_return(true)
   end
 
   def render_exercise

--- a/spec/views/trails/_header.html.erb_spec.rb
+++ b/spec/views/trails/_header.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe "trails/_header" do
+  include SessionHelpers
+
+  context "when signed out" do
+    context "when there are trial videos in the trail" do
+      it "includes a 'Start for Free' button" do
+        stub_signed_in false
+        video = build_stubbed(:video)
+        trail = build_trail(trial_video: video)
+
+        render_trail(trail)
+
+        expect(rendered).to have_start_for_free_link_to(
+          video_auth_to_access_path(video),
+        )
+      end
+    end
+
+    context "when there are no trial videos in the trail" do
+      it "does not include a 'Start for Free' button" do
+        stub_signed_in false
+        trail = build_trail(trial_video: nil)
+
+        render_trail(trail)
+
+        expect(rendered).not_to have_start_for_free_link
+      end
+    end
+  end
+
+  def render_trail(trail)
+    render "trails/header", trail: trail, topic: build_stubbed(:topic)
+  end
+
+  def have_start_for_free_link_to(target)
+    have_css "a[href='#{target}']", text: I18n.t("trails.start_for_free")
+  end
+
+  def have_start_for_free_link
+    have_css "a", text: I18n.t("trails.start_for_free")
+  end
+
+  def build_trail(trial_video:)
+    build_stubbed(:trail).tap do |trail|
+      allow(trail).to receive(:trial_video).and_return(trial_video.wrapped)
+    end
+  end
+end

--- a/spec/views/videos/_video_for_trail_preview.html.erb_spec.rb
+++ b/spec/views/videos/_video_for_trail_preview.html.erb_spec.rb
@@ -30,7 +30,7 @@ describe "videos/_video_for_trail_preview.html" do
   end
 
   context "without access to a video accessible without a subscription" do
-    it "links to the GitHub signin path" do
+    it "links to the auth to access path" do
       stub_access false
       video = create(
         :video,
@@ -40,8 +40,7 @@ describe "videos/_video_for_trail_preview.html" do
 
       render "videos/video_for_trail_preview", video: video
 
-      github_signin_path = github_auth_path(origin: video_path(video))
-      expect(rendered).to have_link_to(github_signin_path)
+      expect(rendered).to have_link_to(video_auth_to_access_path(video))
     end
   end
 


### PR DESCRIPTION
In order to put authenticating users into relevant drip segments, we need to
send out an event when they first authenticate. This change adds this event,
"Authed to Access", with the video and watchable (trail or WI) name as
properties.

Initially we tried to track an "Attempted Auth to Access" event when users first
click the button, which would be followed by an actual "Authed to Access" event
after they complete the GitHub auth flow. This would allow us to build a funnel
to analyze how many users bounce in the auth step. Unfortunately we can't do
this truly anonymously and thus we rolled this back / are deferring that work to
a future PR.
