### PR TITLE
Hide inactive beta offers

### DIFF
--- a/app/models/beta/offer.rb
+++ b/app/models/beta/offer.rb
@@ -9,6 +9,10 @@ module Beta
       order(created_at: :desc)
     end
 
+    def self.active
+      where(active: true)
+    end
+
     def reply(user:, accepted:)
       replies.create!(user: user, accepted: accepted)
     end

--- a/app/models/beta/visible_offer_query.rb
+++ b/app/models/beta/visible_offer_query.rb
@@ -18,19 +18,15 @@ module Beta
     end
 
     def find_offers
-      if completed_trails?
-        offers_without_replies
+      if @user.has_completed_trails?
+        active_offers_without_replies
       else
         Offer.none
       end
     end
 
-    def completed_trails?
-      @user.statuses.by_type(Trail).completed.any?
-    end
-
-    def offers_without_replies
-      @relation.where(<<-SQL, @user.id)
+    def active_offers_without_replies
+      @relation.active.where(<<-SQL, @user.id)
         NOT EXISTS (
           SELECT NULL
           FROM beta_replies

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,10 @@ class User < ActiveRecord::Base
     stripe_customer_id.present?
   end
 
+  def has_completed_trails?
+    statuses.by_type(Trail).completed.any?
+  end
+
   private
 
   def personal_subscription

--- a/db/migrate/20151112165425_add_active_to_beta_offers.rb
+++ b/db/migrate/20151112165425_add_active_to_beta_offers.rb
@@ -1,0 +1,5 @@
+class AddActiveToBetaOffers < ActiveRecord::Migration
+  def change
+    add_column :beta_offers, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151105180146) do
+ActiveRecord::Schema.define(version: 20151112165425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,10 +29,11 @@ ActiveRecord::Schema.define(version: 20151105180146) do
   add_index "attempts", ["user_id"], name: "index_attempts_on_user_id", using: :btree
 
   create_table "beta_offers", force: :cascade do |t|
-    t.string   "name",        null: false
-    t.text     "description", null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.string   "name",                       null: false
+    t.text     "description",                null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "active",      default: true, null: false
   end
 
   create_table "beta_replies", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -42,6 +42,7 @@ FactoryGirl.define do
 
   factory :beta_offer, class: "Beta::Offer" do
     name
+    active true
     description "A great trail"
   end
 

--- a/spec/models/beta/offer_spec.rb
+++ b/spec/models/beta/offer_spec.rb
@@ -6,6 +6,17 @@ describe Beta::Offer do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:description) }
 
+  describe ".active" do
+    it "returns only active offers" do
+      create(:beta_offer, active: true, name: "active")
+      create(:beta_offer, active: false, name: "inactive")
+
+      result = Beta::Offer.active.map(&:name)
+
+      expect(result).to eq(%w(active))
+    end
+  end
+
   describe "#most_recent_first" do
     it "returns most recent offers first" do
       create :beta_offer, name: "one", created_at: 1.day.ago

--- a/spec/models/beta/visible_offer_query_spec.rb
+++ b/spec/models/beta/visible_offer_query_spec.rb
@@ -25,6 +25,16 @@ describe Beta::VisibleOfferQuery do
 
         expect(result.map(&:name)).to eq(%w(visible))
       end
+
+      it "does not yield inactive beta offers" do
+        user = create_user_with_trail_status(Status::COMPLETE)
+        create(:beta_offer, active: true, name: "active")
+        create(:beta_offer, active: false, name: "inactive")
+
+        result = visible_offers_for(user: user)
+
+        expect(result.map(&:name)).to eq(%w(active))
+      end
     end
 
     context "for a user who hasn't completed any trails yet" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,4 +425,23 @@ describe User do
       expect(user.annual_plan_sku).to eq("professional-yearly")
     end
   end
+
+  describe "has_completed_trails?" do
+    context "when the user has completed one or more trails" do
+      it "returns true" do
+        user = create(:user)
+        create(:status, :completed, completeable: create(:trail), user: user)
+
+        expect(user).to have_completed_trails
+      end
+    end
+
+    context "when the user has not completed any trails" do
+      it "returns false" do
+        user = create(:user)
+
+        expect(user).not_to have_completed_trails
+      end
+    end
+  end
 end


### PR DESCRIPTION
We've allowed the current set of beta offers to run for a week now and have
received sufficient feedback to move forward. In order to keep the concept of
the beta offers fresh and prevent blindness to them on the practice page, we
want to hide them when not actively seeking feedback.

This changeset allows us to hide beta offers by setting an `active` property to
false.
