### PR TITLE
Use landing layout for sales pages (join, teams)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   before_filter :capture_campaign_params
-  layout :layout_by_signed_in_state
+  layout :determine_layout
 
   protected
 
@@ -98,11 +98,16 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def layout_by_signed_in_state
-    if signed_in?
-      "signed_in"
+  def sales_page?
+    current_path = request.env["PATH_INFO"]
+    [join_path, teams_path].include? current_path
+  end
+
+  def determine_layout
+    if signed_out? || sales_page?
+      "landing"
     else
-      "visitor"
+      "signed_in"
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,3 @@
 class PagesController < HighVoltage::PagesController
-  layout :layout_by_signed_in_state
+  layout :determine_layout
 end

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -20,9 +20,11 @@
                 class: "table-of-contents-toggle",
                 data: { role: "table-of-contents-toggle" } %>
             </li>
-            <li>
-              <%= link_to "Sign In", sign_in_path %>
-            </li>
+            <% if signed_out? %>
+              <li>
+                <%= link_to "Sign In", sign_in_path %>
+              </li>
+            <% end %>
             <li class="header-cta">
               <%= link_to join_path(anchor: "price"), class: "header-cta-link" do %>
                 <%= image_tag("ralph-white.svg", class: "header-thoughtbot-logo") %>

--- a/spec/controllers/shows_controller_spec.rb
+++ b/spec/controllers/shows_controller_spec.rb
@@ -20,7 +20,7 @@ describe ShowsController do
       get :show, id: show
 
       expect(response).to render_template(
-        "layouts/visitor",
+        "layouts/landing",
         "show"
       )
     end


### PR DESCRIPTION
Currently, the layout is determined exclusively by the user's signed in / out
state. With recent changes to allow users without a subscription to view videos
and more generally interact with the site, we want a bit more subtlety to the
layout logic. Specifically, we always want sales focused pages (/join, /teams)
to be rendered with the simplified layout.

To support the above, this changeset does the following:
- Rename the "visitor" layout to "landing" to better describe its purpose
- Update the layout logic to always show the "landing" layout on /join and
  /teams
- Hide the "Sign In" link for signed in users viewing pages with the "landing"
  layout
