### PR TITLE
Clarify that visitor must authenticate with GitHub for access

### DIFF
--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -1,6 +1,6 @@
 <% if feature.accessible_without_subscription? %>
   <%= link_to(
-    "Free Course",
+    t(".available_for_free_after_authing"),
     video_auth_to_access_path(feature),
     class: "available-link"
   ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,8 @@ en:
     decks:
       decks-list-title: decks
   products:
+    locked:
+      available_for_free_after_authing: Sign In with GitHub for Free Access
     locked_features:
       subscribe_link: Subscribe to Upcase
       upgrade_link: upgrade your subscription
@@ -202,7 +204,7 @@ en:
       heading:
         online: Online video tutorial
   trails:
-    start_for_free: Start Course For Free
+    start_for_free: Start Course for Free by Signing In with GitHub
     other_resources: Use these resources for reference and additional practice
     thoughtbot_resources: Use these thoughtbot resources first
     validations: '%{name} developers should be able to'


### PR DESCRIPTION
I found it jarring to click "Free Course" and then be taken to GitHub's
OAuth permissions page.

This commit adds langage that clarifies what the user must do to get
access to content that is available without a subscription.
## Before

![screen shot 2015-11-16 at 2 10 54 pm](https://cloud.githubusercontent.com/assets/46677/11191885/e62263e6-8c6b-11e5-8b14-4997e541bc99.png)
## After

![screen shot 2015-11-16 at 2 08 42 pm](https://cloud.githubusercontent.com/assets/46677/11191884/e61eec02-8c6b-11e5-8479-aabb8fbbe19b.png)
