### PR TITLE
Display flash message after successful auth to access

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
   authenticating:
     github_signin: Sign in with GitHub
     login_required: You must be signed in to view that page
+    auth_to_access_success: "Success! Enjoy your free videos."
   beta:
     offers:
       actions:

--- a/spec/features/user_without_subscription_views_sample_video_spec.rb
+++ b/spec/features/user_without_subscription_views_sample_video_spec.rb
@@ -12,9 +12,14 @@ feature "User without a subscription views sample video" do
 
     expect(user.has_active_subscription?).to eq(false)
     expect(current_path).to eq(video_path(video))
+    expect(page).to have_free_access_flash_message
     expect(page).to have_css("h1", text: video.name)
     expect(page).not_to have_css(".locked-message")
     expect_authed_to_access_event_fired_for(video)
+  end
+
+  def have_free_access_flash_message
+    have_content I18n.t("authenticating.auth_to_access_success")
   end
 
   def expect_authed_to_access_event_fired_for(video)


### PR DESCRIPTION
The current text is a placeholder, I expect we'll want slightly different wording (actively seeking input on this!)

Below is a screenshot of what the flash looks like in practice. Not sure I love it as is, but I'm in favor of some messaging here. Thoughts?

![auth-to-access-flash](https://cloud.githubusercontent.com/assets/420113/11248251/2d4bbe24-8dee-11e5-9f72-10a3b13d26ac.png)
