### PR TITLE
Allow topics to specify their own page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,4 +51,8 @@ module ApplicationHelper
     current_user_is_subscription_owner? &&
       current_user_is_eligible_for_annual_upgrade?
   end
+
+  def page_title_with_app_name(page_specific_title, app_name)
+    [page_specific_title, app_name].compact.uniq.join(" from ")
+  end
 end

--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -1,5 +1,5 @@
 <meta charset="utf-8" />
-<title><%= raw [content_for(:page_title), t("layouts.app_name")].compact.uniq.join(" | ") %></title>
+<title><%= page_title_with_app_name(content_for(:page_title), t("layouts.app_name")) %></title>
 <%= render 'layouts/stylesheets' %>
 <link rel="icon" href="/favicon.ico" type="image/x-icon">
 <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence || t('layouts.meta_description') %>" />

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Practice" %>
+<% content_for :page_title, "Learn Ruby and Rails Development" %>
 
 <% unless current_user_has_active_subscription? %>
   <%= render "products/locked_features" %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,8 +1,9 @@
 <% content_for :additional_body_classes, @topic.slug.parameterize %>
+<% content_for :page_title, @topic.page_title %>
 
 <% content_for :subject_block do %>
   <div class="topic-header">
-    <h1><%= @topic.name %></h1>
+    <h1>Learn <%= @topic.name %></h1>
 
     <% if @topic.summary.present? %>
       <h2 class="tagline"><%= @topic.summary %></h2>

--- a/db/migrate/20151118203141_add_page_title_to_topics.rb
+++ b/db/migrate/20151118203141_add_page_title_to_topics.rb
@@ -1,0 +1,33 @@
+class AddPageTitleToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :page_title, :string
+
+    backfill_page_titles
+
+    change_column :topics, :page_title, :string, null: false
+  end
+
+  private
+
+  def backfill_page_titles
+    {
+      "vim" =>  "Learn Vim | Vim Training and Tutorials",
+      "rails" => "Learn Ruby on Rails | Ruby on Rails Tutorials",
+      "ios" => "Learn iOS Development | iOS Development Tutorials",
+      "haskell" => "Learn Haskell | Haskell Online Courses",
+      "testing" => "Learn TDD | Test Driven Development Tutorials",
+      "javascript" => "Learn Javascript | JS Tutorials and Courses",
+      "design" => "Learn Web Design | Web Design Tutorials",
+      "clean-code" => "Learn Clean Code | Clean Code Tutorials",
+      "foundations" => "Learn Ruby Fundamentals",
+      "workflow" => "Learn Ruby Workflows | Git, Tmux, and Dotfiles Tutorials",
+      "clojure" => "Learn Clojure",
+    }.each do |slug, page_title|
+      connection.update(<<-SQL)
+        UPDATE topics
+          SET page_title = '#{page_title}'
+          WHERE slug = '#{slug}'
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151112165425) do
+ActiveRecord::Schema.define(version: 20151118203141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -327,6 +327,7 @@ ActiveRecord::Schema.define(version: 20151112165425) do
     t.string   "slug",       limit: 255,                 null: false
     t.text     "summary"
     t.boolean  "explorable",             default: false, null: false
+    t.string   "page_title",                             null: false
   end
 
   add_index "topics", ["explorable"], name: "index_topics_on_explorable", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -216,6 +216,7 @@ FactoryGirl.define do
   factory :topic do
     keywords 'clean, clear, precise'
     name
+    page_title "Learn stuff from Upcase"
     summary 'short yet descriptive'
 
     trait :explorable do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,4 +26,22 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#page_title_with_app_name" do
+    context "with an empty page_title content_for" do
+      it "returns the application name" do
+        result = helper.page_title_with_app_name(nil, "Upcase")
+
+        expect(result).to eq "Upcase"
+      end
+    end
+
+    context "with a specified page_title content_for" do
+      it "concatenates the page_title content and the app name" do
+        result = helper.page_title_with_app_name("TDD", "Upcase")
+
+        expect(result).to eq "TDD from Upcase"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will let us set helpful title tages like "Learn Vim | Upcase" as opposed
to just "Upcase".
