### PR TITLE
Always send the user's email as a property

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -34,7 +34,7 @@ class Analytics
   end
 
   def track_cancelled(reason:)
-    track("Cancelled", reason: reason, email: user.email)
+    track("Cancelled", reason: reason)
   end
 
   def track_flashcard_attempted(deck:, title:)
@@ -79,7 +79,7 @@ class Analytics
     backend.track(
       event: event,
       user_id: user.id,
-      properties: properties,
+      properties: properties.merge(email: user.email),
     )
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -4,6 +4,17 @@ describe Analytics do
   let(:user) { build_stubbed(:user) }
   let(:analytics_instance) { Analytics.new(user) }
 
+  describe "any individual tracking call" do
+    it "includes the user's email as a properties" do
+      analytics_instance.track_accessed_forum
+
+      expect(analytics).to(
+        have_tracked("Logged into Forum").
+        with_properties(email: user.email)
+      )
+    end
+  end
+
   describe "#track_updated" do
     it "sends updated identify event to backend" do
       analytics_instance.track_updated


### PR DESCRIPTION
Services like Drip require a user's email to process events like "Authed
to Access" and others.

Before this commit we were sending a `user_id`, but that's not
sufficient for Drip.
