### PR TITLE
Add AccessLint javascript to raise accessibility errors to Airbrake

### DIFF
--- a/app/views/shared/_javascript.html.erb
+++ b/app/views/shared/_javascript.html.erb
@@ -16,3 +16,7 @@
 <%= javascript_tag do %>
   WistiaHelper.host = '<%= ENV['WISTIA_HOST'] %>'
 <% end %>
+
+<% if !Rails.env.production? %>
+  <%= javascript_include_tag "//cdn.accesslint.com/accesslint-0.1.js" %>
+<% end %>


### PR DESCRIPTION
- Includes clientside js accessibility testing library that posts back to the
  beta.accesslint.com and also throws js errors.
- js library is at: http://github.com/thoughtbot/accesslint.js
## Example Scenario
1. User visits homepage.
2. AccessLint runs an accessibility audit via javascript included. (runs rules from a third party accessibility library called [axe-core](https://github.com/dequelabs/axe-core))
3. The javascript library POSTs to beta.accesslint.com with any failures of the accessibility audit.
4. Assuming Airbrake integration is set up, developer gets accessibility errors in Airbrake.

![screen shot 2015-12-08 at 6 21 17 pm](https://cloud.githubusercontent.com/assets/108163/11671770/8c2fe088-9dd8-11e5-9178-3993fd2dd302.png)

<img width="1004" alt="screen shot 2015-11-29 at 4 00 13 pm" src="https://cloud.githubusercontent.com/assets/108163/11460024/69ce9a0c-96b2-11e5-97ab-7d74fc40d0e3.png">
<img width="1278" alt="screen shot 2015-11-29 at 4 08 19 pm" src="https://cloud.githubusercontent.com/assets/108163/11460079/8a92a8c2-96b3-11e5-8ee5-7175eceee691.png">
