### PR TITLE
Fix header margin on pages with subject block

### DIFF
--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -151,7 +151,6 @@ hr {
   margin-bottom: 3em;
   padding: 0;
   text-align: left;
-  width: 85%;
 
   @include dashboard-small-only {
     width: 100%;


### PR DESCRIPTION
The `.subject` block had an `85%` width applied to it, causing it to only use
that much of the available space. This caused odd layouts for trails and the
/practice page. Additionally, this was being overridden in topic pages.

before:

![screen shot 2015-12-01 at 1 48 22 pm](https://cloud.githubusercontent.com/assets/420113/11510600/7e75998e-9832-11e5-8a3e-84a64bb727d8.png)

after:

![screen shot 2015-12-01 at 1 50 48 pm](https://cloud.githubusercontent.com/assets/420113/11510610/8f3f9648-9832-11e5-810e-df9a03bd4fc4.png)
