### PR TITLE
Backfill page title for Analytics

### DIFF
--- a/db/migrate/20151118203141_add_page_title_to_topics.rb
+++ b/db/migrate/20151118203141_add_page_title_to_topics.rb
@@ -22,6 +22,7 @@ class AddPageTitleToTopics < ActiveRecord::Migration
       "foundations" => "Learn Ruby Fundamentals",
       "workflow" => "Learn Ruby Workflows | Git, Tmux, and Dotfiles Tutorials",
       "clojure" => "Learn Clojure",
+      "analytics" => "Learn Analytics",
     }.each do |slug, page_title|
       connection.update(<<-SQL)
         UPDATE topics


### PR DESCRIPTION
A topic for Analytics was created in an earlier migration, but was
missing from this backfill, violating the page_title not null
constraint.
