### PR TITLE
Fix Ampersand

### DIFF
--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -29,7 +29,7 @@
 <section class="topics-grid">
   <div class="landing-container">
     <h3 class="selling-point-title">
-      Join 1,000s of skilled programmers. Our videos & exercises have been viewed over 60,000 times.
+      Join 1,000s of skilled programmers. Our videos &amp; exercises have been viewed over 60,000 times.
     </h3>
     <ol>
       <% @topics.each do |topic| %>


### PR DESCRIPTION
**Change home page ampersand to HTML special entity code.**

**Because:**

Ampersands in HTML require a special entity code.

**Pull:**

Replace the ampersand with `&amp;`.
