### PR TITLE
Add extended description to topics and trails

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,8 @@
 //= require headhesive.min.js
 //= require header-setup
 //= require fastclick
+//= require readmore
+//= require extended_description
 
 $(function() {
   hljs.initHighlightingOnLoad();

--- a/app/assets/javascripts/extended_description.js
+++ b/app/assets/javascripts/extended_description.js
@@ -1,0 +1,5 @@
+$(function() {
+  $('.extended-description').readmore({
+    collapsedHeight: 0,
+  });
+});

--- a/app/assets/stylesheets/_base-typography.scss
+++ b/app/assets/stylesheets/_base-typography.scss
@@ -170,7 +170,6 @@ hr {
     font-size: 1em;
     font-weight: 700;
     line-height: 1.75em;
-    width: 85%;
   }
 
   .tagline, .tagline a {

--- a/app/assets/stylesheets/_resources-index.scss
+++ b/app/assets/stylesheets/_resources-index.scss
@@ -20,6 +20,14 @@ body.topics.topics-show {
       }
     }
 
+    .topic-content {
+      width: 80%;
+
+      @include dashboard-small-only {
+        width: 100%;
+      }
+    }
+
     h1 {
       margin-bottom: 0.6rem;
     }
@@ -79,4 +87,8 @@ body.topics.topics-show {
       padding: 0;
     }
   }
+}
+
+.extended-description {
+  display: none;
 }

--- a/app/assets/stylesheets/_topics.scss
+++ b/app/assets/stylesheets/_topics.scss
@@ -7,6 +7,12 @@
         color: $topic-color;
       }
     }
+
+    .topic-description {
+      h2 {
+        margin-bottom: 1rem;
+      }
+    }
   }
 
   .tiles ul .tile.#{$topic-name} {

--- a/app/assets/stylesheets/_trails-show.scss
+++ b/app/assets/stylesheets/_trails-show.scss
@@ -25,6 +25,17 @@
       margin: 1.5em auto 3em;
     }
 
+    h2 {
+      font-size: 1.125em;
+      font-weight: normal;
+      line-height: 1.6em;
+      margin-bottom: 1rem;
+
+      @include dashboard-small-only {
+        width: 100%;
+      }
+    }
+
     .title-card {
       @include span-columns(5);
       flex: none;
@@ -62,6 +73,10 @@
     .trail-topic-name {
       @include clearfix;
     }
+  }
+
+  .trail-description {
+    padding-bottom: 1em;
   }
 
   .trails-progress {

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -3,14 +3,26 @@
 
 <% content_for :subject_block do %>
   <div class="topic-header">
-    <h1>Learn <%= @topic.name %></h1>
-
-    <% if @topic.summary.present? %>
-      <h2 class="tagline"><%= @topic.summary %></h2>
-    <% end %>
-
     <div class="topic-image">
       <%= image_tag "topics/#{@topic.slug}.svg" %>
+    </div>
+
+    <div class="topic-content">
+      <h1>Learn <%= @topic.name %></h1>
+
+      <% if @topic.summary.present? %>
+        <div class="topic-description">
+          <h2 class="tagline">
+            <%= format_markdown @topic.summary %>
+          </h2>
+
+          <% if @topic.extended_description.present? %>
+            <div class="extended-description">
+              <%= format_markdown @topic.extended_description %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -17,9 +17,19 @@
 
   <div class="topic-title">
     <h1><%= trail.name %></h1>
-    <div class="topic-description">
-      <%= format_markdown trail.description %>
+
+    <div class="trail-description">
+      <h2 class="tagline">
+        <%= format_markdown trail.description %>
+      </h2>
+
+      <% if trail.extended_description.present? %>
+        <div class="extended-description">
+          <%= format_markdown trail.extended_description %>
+        </div>
+      <% end %>
     </div>
+
     <% unless signed_in? %>
       <% trail.trial_video.present do |video| %>
         <%= link_to(

--- a/db/migrate/20160104184621_add_extended_description_to_trails.rb
+++ b/db/migrate/20160104184621_add_extended_description_to_trails.rb
@@ -1,0 +1,5 @@
+class AddExtendedDescriptionToTrails < ActiveRecord::Migration
+  def change
+    add_column :trails, :extended_description, :text
+  end
+end

--- a/db/migrate/20160104200900_add_extended_description_to_topics.rb
+++ b/db/migrate/20160104200900_add_extended_description_to_topics.rb
@@ -1,0 +1,5 @@
+class AddExtendedDescriptionToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :extended_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151118203141) do
+ActiveRecord::Schema.define(version: 20160104200900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -320,29 +320,31 @@ ActiveRecord::Schema.define(version: 20151118203141) do
   end
 
   create_table "topics", force: :cascade do |t|
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "keywords",   limit: 255
-    t.string   "name",       limit: 255,                 null: false
-    t.string   "slug",       limit: 255,                 null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.string   "keywords",             limit: 255
+    t.string   "name",                 limit: 255,                 null: false
+    t.string   "slug",                 limit: 255,                 null: false
     t.text     "summary"
-    t.boolean  "explorable",             default: false, null: false
-    t.string   "page_title",                             null: false
+    t.boolean  "explorable",                       default: false, null: false
+    t.string   "page_title",                                       null: false
+    t.text     "extended_description"
   end
 
   add_index "topics", ["explorable"], name: "index_topics_on_explorable", using: :btree
   add_index "topics", ["slug"], name: "index_topics_on_slug", unique: true, using: :btree
 
   create_table "trails", force: :cascade do |t|
-    t.string   "name",             limit: 255,                 null: false
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
-    t.string   "complete_text",    limit: 255,                 null: false
-    t.boolean  "published",                    default: false, null: false
-    t.string   "slug",             limit: 255,                 null: false
-    t.text     "description",                  default: "",    null: false
-    t.integer  "topic_id",                                     null: false
-    t.string   "title_card_image",             default: ""
+    t.string   "name",                 limit: 255,                 null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.string   "complete_text",        limit: 255,                 null: false
+    t.boolean  "published",                        default: false, null: false
+    t.string   "slug",                 limit: 255,                 null: false
+    t.text     "description",                      default: "",    null: false
+    t.integer  "topic_id",                                         null: false
+    t.string   "title_card_image",                 default: ""
+    t.text     "extended_description"
   end
 
   add_index "trails", ["published"], name: "index_trails_on_published", using: :btree

--- a/vendor/assets/javascripts/readmore.js
+++ b/vendor/assets/javascripts/readmore.js
@@ -1,0 +1,330 @@
+/*!
+ * @preserve
+ *
+ * Readmore.js jQuery plugin
+ * Author: @jed_foster
+ * Project home: http://jedfoster.github.io/Readmore.js
+ * Licensed under the MIT license
+ *
+ * Debounce function from http://davidwalsh.name/javascript-debounce-function
+ */
+
+/* global jQuery */
+
+(function(factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // CommonJS
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function($) {
+  'use strict';
+
+  var readmore = 'readmore',
+      defaults = {
+        speed: 100,
+        collapsedHeight: 200,
+        heightMargin: 16,
+        moreLink: '<a href="#">Read More</a>',
+        lessLink: '<a href="#">Close</a>',
+        embedCSS: true,
+        blockCSS: 'display: block; width: 100%;',
+        startOpen: false,
+
+        // callbacks
+        beforeToggle: function(){},
+        afterToggle: function(){}
+      },
+      cssEmbedded = {},
+      uniqueIdCounter = 0;
+
+  function debounce(func, wait, immediate) {
+    var timeout;
+
+    return function() {
+      var context = this, args = arguments;
+      var later = function() {
+        timeout = null;
+        if (! immediate) {
+          func.apply(context, args);
+        }
+      };
+      var callNow = immediate && !timeout;
+
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+
+      if (callNow) {
+        func.apply(context, args);
+      }
+    };
+  }
+
+  function uniqueId(prefix) {
+    var id = ++uniqueIdCounter;
+
+    return String(prefix == null ? 'rmjs-' : prefix) + id;
+  }
+
+  function setBoxHeights(element) {
+    var el = element.clone().css({
+          height: 'auto',
+          width: element.width(),
+          maxHeight: 'none',
+          overflow: 'hidden'
+        }).insertAfter(element),
+        expandedHeight = el.outerHeight(),
+        cssMaxHeight = parseInt(el.css({maxHeight: ''}).css('max-height').replace(/[^-\d\.]/g, ''), 10),
+        defaultHeight = element.data('defaultHeight');
+
+    el.remove();
+
+    var collapsedHeight = cssMaxHeight || element.data('collapsedHeight') || defaultHeight;
+
+    // Store our measurements.
+    element.data({
+      expandedHeight: expandedHeight,
+      maxHeight: cssMaxHeight,
+      collapsedHeight: collapsedHeight
+    })
+    // and disable any `max-height` property set in CSS
+    .css({
+      maxHeight: 'none'
+    });
+  }
+
+  var resizeBoxes = debounce(function() {
+    $('[data-readmore]').each(function() {
+      var current = $(this),
+          isExpanded = (current.attr('aria-expanded') === 'true');
+
+      setBoxHeights(current);
+
+      current.css({
+        height: current.data( (isExpanded ? 'expandedHeight' : 'collapsedHeight') )
+      });
+    });
+  }, 100);
+
+  function embedCSS(options) {
+    if (! cssEmbedded[options.selector]) {
+      var styles = ' ';
+
+      if (options.embedCSS && options.blockCSS !== '') {
+        styles += options.selector + ' + [data-readmore-toggle], ' +
+          options.selector + '[data-readmore]{' +
+            options.blockCSS +
+          '}';
+      }
+
+      // Include the transition CSS even if embedCSS is false
+      styles += options.selector + '[data-readmore]{' +
+        'transition: height ' + options.speed + 'ms;' +
+        'overflow: hidden;' +
+      '}';
+
+      (function(d, u) {
+        var css = d.createElement('style');
+        css.type = 'text/css';
+
+        if (css.styleSheet) {
+          css.styleSheet.cssText = u;
+        }
+        else {
+          css.appendChild(d.createTextNode(u));
+        }
+
+        d.getElementsByTagName('head')[0].appendChild(css);
+      }(document, styles));
+
+      cssEmbedded[options.selector] = true;
+    }
+  }
+
+  function Readmore(element, options) {
+    this.element = element;
+
+    this.options = $.extend({}, defaults, options);
+
+    embedCSS(this.options);
+
+    this._defaults = defaults;
+    this._name = readmore;
+
+    this.init();
+
+    // IE8 chokes on `window.addEventListener`, so need to test for support.
+    if (window.addEventListener) {
+      // Need to resize boxes when the page has fully loaded.
+      window.addEventListener('load', resizeBoxes);
+      window.addEventListener('resize', resizeBoxes);
+    }
+    else {
+      window.attachEvent('load', resizeBoxes);
+      window.attachEvent('resize', resizeBoxes);
+    }
+  }
+
+
+  Readmore.prototype = {
+    init: function() {
+      var current = $(this.element);
+
+      current.data({
+        defaultHeight: this.options.collapsedHeight,
+        heightMargin: this.options.heightMargin
+      });
+
+      setBoxHeights(current);
+
+      var collapsedHeight = current.data('collapsedHeight'),
+          heightMargin = current.data('heightMargin');
+
+      if (current.outerHeight(true) <= collapsedHeight + heightMargin) {
+        // The block is shorter than the limit, so there's no need to truncate it.
+        return true;
+      }
+      else {
+        var id = current.attr('id') || uniqueId(),
+            useLink = this.options.startOpen ? this.options.lessLink : this.options.moreLink;
+
+        current.attr({
+          'data-readmore': '',
+          'aria-expanded': this.options.startOpen,
+          'id': id
+        });
+
+        current.after($(useLink)
+          .on('click', (function(_this) {
+            return function(event) {
+              _this.toggle(this, current[0], event);
+            };
+          })(this))
+          .attr({
+            'data-readmore-toggle': '',
+            'aria-controls': id
+          }));
+
+        if (! this.options.startOpen) {
+          current.css({
+            height: collapsedHeight
+          });
+        }
+      }
+    },
+
+    toggle: function(trigger, element, event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      if (! trigger) {
+        trigger = $('[aria-controls="' + _this.element.id + '"]')[0];
+      }
+
+      if (! element) {
+        element = _this.element;
+      }
+
+      var $element = $(element),
+          newHeight = '',
+          newLink = '',
+          expanded = false,
+          collapsedHeight = $element.data('collapsedHeight');
+
+      if ($element.height() <= collapsedHeight) {
+        newHeight = $element.data('expandedHeight') + 'px';
+        newLink = 'lessLink';
+        expanded = true;
+      }
+      else {
+        newHeight = collapsedHeight;
+        newLink = 'moreLink';
+      }
+
+      // Fire beforeToggle callback
+      // Since we determined the new "expanded" state above we're now out of sync
+      // with our true current state, so we need to flip the value of `expanded`
+      this.options.beforeToggle(trigger, $element, ! expanded);
+
+      $element.css({'height': newHeight});
+
+      // Fire afterToggle callback
+      $element.on('transitionend', (function(_this) {
+        return function() {
+          _this.options.afterToggle(trigger, $element, expanded);
+
+          $(this).attr({
+            'aria-expanded': expanded
+          }).off('transitionend');
+        }
+      })(this));
+
+      $(trigger).replaceWith($(this.options[newLink])
+        .on('click', (function(_this) {
+            return function(event) {
+              _this.toggle(this, element, event);
+            };
+          })(this))
+        .attr({
+          'data-readmore-toggle': '',
+          'aria-controls': $element.attr('id')
+        }));
+    },
+
+    destroy: function() {
+      $(this.element).each(function() {
+        var current = $(this);
+
+        current.attr({
+          'data-readmore': null,
+          'aria-expanded': null
+        })
+          .css({
+            maxHeight: '',
+            height: ''
+          })
+          .next('[data-readmore-toggle]')
+          .remove();
+
+        current.removeData();
+      });
+    }
+  };
+
+
+  $.fn.readmore = function(options) {
+    var args = arguments,
+        selector = this.selector;
+
+    options = options || {};
+
+    if (typeof options === 'object') {
+      return this.each(function() {
+        if ($.data(this, 'plugin_' + readmore)) {
+          var instance = $.data(this, 'plugin_' + readmore);
+          instance.destroy.apply(instance);
+        }
+
+        options.selector = selector;
+
+        $.data(this, 'plugin_' + readmore, new Readmore(this, options));
+      });
+    }
+    else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
+      return this.each(function () {
+        var instance = $.data(this, 'plugin_' + readmore);
+        if (instance instanceof Readmore && typeof instance[options] === 'function') {
+          instance[options].apply(instance, Array.prototype.slice.call(args, 1));
+        }
+      });
+    }
+  };
+
+}));
+


### PR DESCRIPTION
Topics and trails could both be a little better at describing themselves, both to give users more context and for SEO purposes.

This adds `extended_description` columns to both tables, and adds a "Read More" JavaScript widget to access them.

![extended_descriptions](https://cloud.githubusercontent.com/assets/811217/12147686/37cdaa24-b468-11e5-9af5-71f34e912830.gif)
