### PR TITLE
Track sampler vs subscriber on analtyics events

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,6 +1,9 @@
 class Analytics
   include AnalyticsHelper
 
+  SAMPLER = "sampler"
+  SUBSCRIBER = "subscriber"
+
   class_attribute :backend
   self.backend = AnalyticsRuby
 
@@ -71,6 +74,14 @@ class Analytics
 
   attr_reader :user
 
+  def user_type(user)
+    if user.has_active_subscription?
+      SUBSCRIBER
+    else
+      SAMPLER
+    end
+  end
+
   def track_touched_video(name:, watchable_name:)
     track("Touched Video", name: name, watchable_name: watchable_name)
   end
@@ -79,7 +90,10 @@ class Analytics
     backend.track(
       event: event,
       user_id: user.id,
-      properties: properties.merge(email: user.email),
+      properties: properties.merge(
+        email: user.email,
+        user_type: user_type(user),
+      ),
     )
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -13,6 +13,34 @@ describe Analytics do
         with_properties(email: user.email)
       )
     end
+
+    context "if the user has an active subscription" do
+      it "identifies the user as a 'subscriber' when tracking" do
+        subscriber = create(:subscriber)
+        subscriber_analytics_instance = Analytics.new(subscriber)
+
+        subscriber_analytics_instance.track_accessed_forum
+
+        expect(analytics).to(
+          have_tracked("Logged into Forum").
+          with_properties(user_type: "subscriber"),
+        )
+      end
+    end
+
+    context "if the user does not have an active subscription" do
+      it "identifies the user as a 'sampler' when tracking" do
+        sampler = build_stubbed(:user)
+        sampler_analytics_instance = Analytics.new(sampler)
+
+        sampler_analytics_instance.track_accessed_forum
+
+        expect(analytics).to(
+          have_tracked("Logged into Forum").
+          with_properties(user_type: "sampler"),
+        )
+      end
+    end
   end
 
   describe "#track_updated" do


### PR DESCRIPTION
Now that we have exposed some videos as `accessible_without_subscription`, our analytics are a bit skewed by samplers watching those videos. This update identifies the user type, either of `subscriber` or `sampler` when tracking events. Currently we do not track any events for signed out users.
