### PR TITLE
Use mime/types/columnar for memory savings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 ruby "2.2.3"
 
+gem "mime-types", '~> 2.6', require: 'mime/types/columnar'
+
 gem "active_model_serializers", "0.8.3"
 gem "acts_as_list", "~> 0.6.0"
 gem "airbrake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,6 +416,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   launchy
+  mime-types (~> 2.6)
   neat
   nokogiri (~> 1.6.4)
   octokit (~> 3.5.2)


### PR DESCRIPTION
Requiring `mime/types/columnar` rather than letting other gems require
`mime-types` directly results in a memory savings of about ~5MB at
require time in this app, according to `derailed bundle:mem` from
derailed_benchmarks.

This columnar behavior is default in mime-types >= 3.0, but we
actionmailer depends on 2.x. Once our dependencies will allow for
mime-types 3.0, we can remove this.
