### PR TITLE
Add last attempted to decks

### DIFF
--- a/app/assets/stylesheets/_flashcards.scss
+++ b/app/assets/stylesheets/_flashcards.scss
@@ -26,6 +26,19 @@
   }
 }
 
+.deck-details {
+  p {
+    font-size: $font-size-smallest;
+    margin-bottom: 0;
+    text-align: right;
+  }
+
+  .last-attempted {
+    color: $gray-3;
+    font-style: italic;
+  }
+}
+
 .reveal-answer,
 .next-flashcard[type="submit"] {
   @extend %button;

--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -2,8 +2,7 @@ class DecksController < ApplicationController
   before_action :require_login
 
   def index
-    @decks = Deck.published.most_recent_first
-    @flashcards_to_review = FlashcardsNeedingReviewQuery.new(current_user).run
+    @deck_list = DeckList.new(current_user)
   end
 
   def show

--- a/app/helpers/deck_helper.rb
+++ b/app/helpers/deck_helper.rb
@@ -5,4 +5,12 @@ module DeckHelper
       deck_flashcard_path(flashcard.deck, flashcard, mode: "reviewing")
     )
   end
+
+  def last_attempted_in_words(time)
+    if time.present?
+      t(".last_attempted", distance: time_ago_in_words(time))
+    else
+      t(".never_attempted")
+    end
+  end
 end

--- a/app/models/latest_deck_attempt.rb
+++ b/app/models/latest_deck_attempt.rb
@@ -1,0 +1,8 @@
+class LatestDeckAttempt < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :deck
+
+  def self.by(user)
+    where(user_id: user.id)
+  end
+end

--- a/app/models/null_attempt.rb
+++ b/app/models/null_attempt.rb
@@ -6,4 +6,8 @@ class NullAttempt
   def low_confidence?
     false
   end
+
+  def updated_at
+    nil
+  end
 end

--- a/app/services/deck_list.rb
+++ b/app/services/deck_list.rb
@@ -1,0 +1,31 @@
+class DeckList
+  def initialize(user)
+    @user = user
+  end
+
+  def decks
+    @_decks ||= Deck.published.most_recent_first
+  end
+
+  def flashcards_to_review
+    @_flashcards_to_review ||= FlashcardsNeedingReviewQuery.
+      new(user).
+      run
+  end
+
+  def last_attempted_at(deck)
+    latest_deck_attempt = latest_deck_attempts.detect do |attempt|
+      attempt.deck_id == deck.id
+    end || NullAttempt.new
+
+    latest_deck_attempt.updated_at
+  end
+
+  private
+
+  attr_reader :user
+
+  def latest_deck_attempts
+    @_latest_deck_attempts ||= LatestDeckAttempt.by(user)
+  end
+end

--- a/app/views/decks/_deck.html.erb
+++ b/app/views/decks/_deck.html.erb
@@ -1,8 +1,13 @@
-<div class="deck">
+<div id="<%= dom_id deck %>" class="deck">
   <h4 class="deck-title">
     <%= link_to deck.title, deck %>
   </h4>
-  <p class="flashcards-count">
-    <%= t(".number_of_flashcards", length: deck.length) %>
-  </p>
+  <div class="deck-details">
+    <p>
+      <%= t(".number_of_flashcards", length: deck.length) %>
+    </p>
+    <p class="last-attempted">
+      <%= last_attempted_in_words(@deck_list.last_attempted_at(deck)) %>
+    </p>
+  </div>
 </div>

--- a/app/views/decks/index.html.erb
+++ b/app/views/decks/index.html.erb
@@ -6,13 +6,13 @@
   <p><%= t('.feature_description') %></p>
 
   <section class="decks-area">
-    <%= render @decks %>
+    <%= render @deck_list.decks %>
   </section>
 
   <section class="saved-deck">
     <%= render(
       "flashcards/needing_review",
-      flashcards_to_review: @flashcards_to_review
+      flashcards_to_review: @deck_list.flashcards_to_review
     ) %>
   </section>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,8 @@ en:
   decks:
     deck:
       number_of_flashcards: '%{length} flashcards'
+      last_attempted: 'Last attempted %{distance} ago'
+      never_attempted: 'Never attempted'
     index:
       feature_description: Flashcards are short quizzes with questions and answers
         provided. They're mobile-friendly, and a perfect fit for commutes, waiting

--- a/db/migrate/20160113192505_create_latest_deck_attempts.rb
+++ b/db/migrate/20160113192505_create_latest_deck_attempts.rb
@@ -1,0 +1,5 @@
+class CreateLatestDeckAttempts < ActiveRecord::Migration
+  def change
+    create_view :latest_deck_attempts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160104200900) do
+ActiveRecord::Schema.define(version: 20160113192505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -469,6 +469,19 @@ ActiveRecord::Schema.define(version: 20160104200900) do
   attempts.updated_at
  FROM attempts
 ORDER BY attempts.user_id, attempts.flashcard_id, attempts.updated_at DESC;
+      SQL
+
+      create_view :latest_deck_attempts, sql_definition:<<-SQL
+        SELECT DISTINCT ON (attempts.user_id, flashcards.deck_id) attempts.id,
+  attempts.confidence,
+  attempts.flashcard_id,
+  attempts.user_id,
+  attempts.created_at,
+  attempts.updated_at,
+  flashcards.deck_id
+ FROM (attempts
+   JOIN flashcards ON ((flashcards.id = attempts.flashcard_id)))
+ORDER BY attempts.user_id, flashcards.deck_id, attempts.updated_at DESC;
       SQL
 
         create_view :slugs, sql_definition:<<-SQL

--- a/db/views/latest_deck_attempts_v01.sql
+++ b/db/views/latest_deck_attempts_v01.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT ON (attempts.user_id, flashcards.deck_id) attempts.*, flashcards.deck_id
+FROM attempts INNER JOIN flashcards ON flashcards.id = attempts.flashcard_id
+ORDER BY attempts.user_id, flashcards.deck_id, attempts.updated_at DESC

--- a/spec/models/null_attempt_spec.rb
+++ b/spec/models/null_attempt_spec.rb
@@ -12,4 +12,10 @@ describe NullAttempt do
       expect(NullAttempt.new.low_confidence?).to be_falsey
     end
   end
+
+  describe "#updated_at" do
+    it "returns nil" do
+      expect(NullAttempt.new.updated_at).to be_nil
+    end
+  end
 end

--- a/spec/services/deck_list_spec.rb
+++ b/spec/services/deck_list_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe DeckList do
+  describe "#last_attempted_at" do
+    let(:user)       { create(:user) }
+    let(:deck)       { create(:deck) }
+    let(:flashcards) { create_list(:flashcard, 2, deck: deck) }
+
+    context "the user has attempted a flashcard in the deck" do
+      it "returns the time of the most recent attempt" do
+        first_attempt = create(:attempt,
+                               flashcard: flashcards.first,
+                               user: user,
+                               updated_at: 15.minutes.ago)
+        second_attempt = create(:attempt,
+                                flashcard: flashcards.first,
+                                user: user,
+                                updated_at: 45.minutes.ago)
+        third_attempt = create(:attempt,
+                               flashcard: flashcards.second,
+                               user: user,
+                               updated_at: 2.minutes.ago)
+        fourth_attempt = create(:attempt,
+                                flashcard: flashcards.second,
+                                user: user,
+                                updated_at: 10.minutes.ago)
+
+        deck_list = DeckList.new(user)
+
+        expect(deck_list.last_attempted_at(deck)).
+          to be_within(1.second).of third_attempt.updated_at
+      end
+    end
+
+    context "the user has yet to attempt a flashcard in the deck" do
+      it "returns nil" do
+        deck_list = DeckList.new(user)
+
+        expect(deck_list.last_attempted_at(user)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We currently display the number of flashcards in a deck on the decks index page, but it's not easy for a user to know which deck to attempt next.

This change introduces copy on each deck that indicates when it was last attempted.
