### PR TITLE
Remove unnecessary parts of `rails_12factor'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ end
 
 group :production, :staging do
   gem "font_assets"
-  gem "rails_12factor"
+  gem "rails_stdout_logging"
   gem "skylight"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,9 +250,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_admin (0.6.7)
       builder (~> 3.1)
       coffee-rails (~> 4.0)
@@ -267,7 +264,6 @@ GEM
       remotipart (~> 1.0)
       safe_yaml (~> 1.0)
       sass-rails (>= 4.0, < 6)
-    rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.3)
     railties (4.2.5.2)
       actionpack (= 4.2.5.2)
@@ -427,8 +423,8 @@ DEPENDENCIES
   rack-mini-profiler
   rack-rewrite (~> 1.5.1)
   rails (~> 4.2.5)
-  rails_12factor
   rails_admin (~> 0.6.7)
+  rails_stdout_logging
   recipient_interceptor
   redcarpet
   request_store


### PR DESCRIPTION
rails_12factor is a meta gem which uses `rails_serve_static_assets` and
`rails_stdout_logging` to enable various 12 factor favorable things on
Heroku. We already have the `serve_static_files` setting on in our
application, so we don't need a gem to do it for us. In fact, using an
outdated version of that gem was causing a warning about a deprecated
rails setting.

We still do need the settings enabled by `rails_stdout_logging`, so I
left that gem in place.

This setup is consistent with what suspenders has been doing for some
time.
