### PR TITLE
Make header subscribe button go right to checkout

### DIFF
--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -19,6 +19,10 @@ module PlansHelper
     "plans/#{plan.sku.underscore}"
   end
 
+  def professional_checkout_path
+    new_checkout_path(plan: Plan::PROFESSIONAL_SKU)
+  end
+
   def formatted_name(plan)
     first_line, _, last_line = plan.name.rpartition(" ")
     [first_line, last_line].join("<br/>").html_safe

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -27,7 +27,7 @@
               </li>
             <% end %>
             <li class="header-cta">
-              <%= link_to join_path(anchor: "price"), class: "header-cta-link" do %>
+              <%= link_to professional_checkout_path, class: "header-cta-link" do %>
                 <%= t("subscriptions.join_cta") %>
               <% end %>
             </li>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -19,7 +19,7 @@
       <h2 class="hero-title">Let&rsquo;s get that &ldquo;junior&rdquo; out of your title</h2>
       <p class="hero-body">Upcase turns junior Rails developers into ass-kicking
       name-takers. We're not a bootcamp, we're a finishing school.</p>
-      <%= link_to "#price", class: "cta-button subscribe-cta" do %>
+      <%= link_to professional_checkout_path, class: "cta-button subscribe-cta" do %>
         <span><%= t("subscriptions.join_cta") %></span>
       <% end %>
     </div>
@@ -170,7 +170,7 @@
       <p>For aspiring senior developers looking for battle-tested best
       practices, a killer community, and mentorship from the right people.</p>
       <div class="price-cta">
-        <%= link_to new_checkout_path(plan: Plan.professional), class: "cta-button subscribe-cta light-bg" do %>
+        <%= link_to professional_checkout_path, class: "cta-button subscribe-cta light-bg" do %>
           <span><%= t(".sign_up_cta") %></span>
         <% end %>
       </div>


### PR DESCRIPTION
Do not stop at `subscriptions#new`. Historically, links to the
professional plan checkout have been done with `new_checkout_path(plan:
Plan.professional)`. Doing so in the header meant that every single
feature spec involving a signed out user would have to be sure to have a
professional plan available in the database.

Doing a database hit just to get the plan so you can get the string
"professional" from it rather than from a constant seems wasteful. I
elected to side-step the test problem and slightly improve production
performance by just using the constant directly.
