### PR TITLE
Improve readability of the video notes

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -64,7 +64,11 @@ $inline-code-background: hsla(0, 0, 0, 0.07);
 $light-gray-border: #ccc;
 $row-highlight: #f9f9f9;
 
+$base-spacing: 1em;
+$large-spacing: 2em;
+
 $max-width: 1100px;
+$max-width-narrow: 900px;
 $navigation-height: 60px;
 $navigation-cta-offset: 10px;
 $header-height: $navigation-height - ($navigation-cta-offset * 2);

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -73,6 +73,28 @@
 }
 
 .video-notes {
+  border: 1px solid $gray-4;
+  border-radius: $base-border-radius;
+}
+
+
+.video-notes-header {
+  background-color: $gray-5;
+  border-bottom: 1px solid $gray-4;
+  padding: $base-spacing;
+
+  h3 {
+    margin: 0;
+  }
+}
+
+.video-notes-content {
+  padding: $base-spacing;
+
+  @include dashboard-medium {
+    padding: $large-spacing;
+  }
+
   h3 {
     margin-top: 0;
   }
@@ -81,6 +103,10 @@
     list-style: initial;
     margin-left: 1.2em;
   }
+}
+
+.videos-show .content {
+  max-width: $max-width-narrow;
 }
 
 #videos .video {

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -48,8 +48,13 @@
 <% if @video.has_notes? %>
   <div class="text-box">
     <section class="video-notes">
-      <h3>Notes</h3>
-      <%= format_markdown(@video.notes) %>
+      <header class="video-notes-header">
+        <h3>Notes</h3>
+      </header>
+
+      <div class="video-notes-content">
+        <%= format_markdown(@video.notes) %>
+      </div>
     </section>
   </div>
 <% end %>


### PR DESCRIPTION
Prior to this change, the notes would span full-width of the main `contents` section. This made it difficult to read the notes due to the width.

This change decreases the overall width, and then wraps the notes content in a box and uses padding to additionally trim down the width while keeping the video at a reasonable size.

Previous:

![previous full width](https://cloud.githubusercontent.com/assets/420113/12688236/f7ad5078-c6a2-11e5-8637-b090438c0fdc.png)

New:

![new reduced width](https://cloud.githubusercontent.com/assets/420113/12688218/dbb637ea-c6a2-11e5-8630-11d2461faf11.png)
