### PR TITLE
Add video access callouts for non-subscribers

### DIFF
--- a/app/assets/stylesheets/_base-variables.scss
+++ b/app/assets/stylesheets/_base-variables.scss
@@ -2,6 +2,8 @@ $sans-serif: "proxima-nova-1", "proxima-nova-2", "museo-sans-1", "museo-sans-2",
 
 $serif: "adelle-1", "adelle-2", $helvetica;
 
+$sans-serif-semibold: 600;
+
 $upcase-blue: #2387E0;
 $upcase-blue-1: #487BF6;
 $upcase-blue-2: #0093CB;
@@ -65,7 +67,8 @@ $light-gray-border: #ccc;
 $row-highlight: #f9f9f9;
 
 $base-spacing: 1em;
-$large-spacing: 2em;
+$medium-spacing: $base-spacing * 2;
+$large-spacing: $base-spacing * 3.75;
 
 $max-width: 1100px;
 $max-width-narrow: 900px;
@@ -86,6 +89,7 @@ $base-background-2: #fafafa;
 
 $base-border-color-1: #DCDCDC;
 $base-border-color-blue: #E9F2FD;
+$base-border-color-yellow: lighten($cta-color-dark, 30%);
 
 $base-box-shadow: 1px 1px 2px rgba($black, 0.08);
 $heavy-box-shadow: 0 1px 3px rgba($black, 0.2);
@@ -93,6 +97,11 @@ $heavy-box-shadow: 0 1px 3px rgba($black, 0.2);
 $font-size-smallest: rem(12);
 $font-size-small: 0.96rem;
 $base-font-color: $darkwarmgray;
+
+$base-line-height: 1em;
+$medium-line-height: $base-line-height * 1.5;
+
+$base-letter-spacing: 2px;
 
 $base-border-radius: 3px;
 

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -175,6 +175,38 @@
   }
 }
 
+.access-callout {
+  @include margin($medium-spacing null);
+  align-items: center;
+  background: lighten($cta-color-light, 40%);
+  border: 1px solid $base-border-color-yellow;
+  display: flex;
+  padding: $base-spacing;
+
+  @include dashboard-small-only {
+    flex-direction: column;
+  }
+
+  p {
+    font-weight: $sans-serif-semibold;
+    margin-bottom: 0;
+    margin-right: $base-spacing;
+
+    @include dashboard-small-only {
+      margin-bottom: $base-spacing;
+      margin-right: 0;
+    }
+  }
+
+  .cta-button {
+    flex: none;
+
+    @include dashboard-small-only {
+      width: 100%;
+    }
+  }
+}
+
 .video-text.unstarted:before {
   content: image-url("play.svg");
 }

--- a/app/views/videos/_access_callout.html.erb
+++ b/app/views/videos/_access_callout.html.erb
@@ -1,0 +1,9 @@
+<% if video.accessible_without_subscription? %>
+  <% if signed_out? %>
+    <%= render "videos/auth_to_access", video: video %>
+  <% else %>
+    <%= render "videos/subscribe_callout_for_free_sample" %>
+  <% end %>
+<% else %>
+  <%= render "videos/subscribe_callout_for_preview" %>
+<% end %>

--- a/app/views/videos/_auth_to_access.html.erb
+++ b/app/views/videos/_auth_to_access.html.erb
@@ -1,0 +1,8 @@
+<div class="access-callout auth-to-access">
+  <p><%= t("videos.show.auth_to_access_callout_text") %></p>
+
+  <%= link_to video_auth_to_access_path(video), class: "cta-button subscribe-cta light-bg" do %>
+    <%= image_tag("github-black.svg", class: "logo") %>
+    <span><%= t("videos.show.auth_to_access_button_text") %></span>
+  <% end %>
+</div>

--- a/app/views/videos/_subscribe_callout_for_free_sample.html.erb
+++ b/app/views/videos/_subscribe_callout_for_free_sample.html.erb
@@ -1,0 +1,7 @@
+<div class="access-callout subscription-required">
+  <p><%= t("videos.show.access_callout_for_sample_text") %></p>
+
+  <%= link_to professional_checkout_path, class: "cta-button subscribe-cta light-bg" do %>
+    <span><%= t("videos.show.access_callout_for_sample_button") %></span>
+  <% end %>
+</div>

--- a/app/views/videos/_subscribe_callout_for_preview.html.erb
+++ b/app/views/videos/_subscribe_callout_for_preview.html.erb
@@ -1,0 +1,7 @@
+<div class="access-callout subscription-required">
+  <p><%= t("videos.show.access_callout_for_preview_text") %></p>
+
+  <%= link_to professional_checkout_path, class: "cta-button subscribe-cta light-bg" do %>
+    <span><%= t("videos.show.access_callout_for_preview_button") %></span>
+  <% end %>
+</div>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -13,8 +13,8 @@
   </h2>
 <% end %>
 
-<% unless current_user_has_access_to?(@video) %>
-  <%= render "watchables/preview" %>
+<% unless current_user_has_active_subscription? %>
+  <%= render "videos/access_callout", video: @video %>
 <% end %>
 
 <span class="divider">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,12 @@ en:
   videos:
     show:
       mark-as-complete: Mark as Complete
+      auth_to_access_callout_text: This video is a preview. Want to see the full-length video right now for free?
+      auth_to_access_button_text: Sign In with GitHub for Free Access
+      access_callout_for_preview_text: This video is only a short sample, but you can access the full version and all our other great content by subscribing.
+      access_callout_for_preview_button: Subscribe Now
+      access_callout_for_sample_text: We hope you're enjoying this full-length sample video. Ready to dive into all the other great content?
+      access_callout_for_sample_button: Subscribe Now
     seek_buttons:
       jump-to-topic-in-video: Jump to Topic In Video
   watchables:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -434,6 +434,10 @@ FactoryGirl.define do
       end
     end
 
+    trait :free_sample do
+      accessible_without_subscription true
+    end
+
     trait :with_preview do
       sequence(:preview_wistia_id) { |n| "preview-#{n}" }
     end

--- a/spec/features/visitor_views_weekly_iteration_spec.rb
+++ b/spec/features/visitor_views_weekly_iteration_spec.rb
@@ -8,7 +8,7 @@ feature "Visitor" do
     visit show_url(show)
 
     expect(page).to have_content(show.name)
-    expect_page_to_have_preview_cta
+    expect_page_to_have_show_preview_cta
     expect_to_see_call_to_subscribe_to_upcase
   end
 
@@ -20,8 +20,8 @@ feature "Visitor" do
     click_link video.name
 
     expect(page).to have_content(video.notes)
-    expect_page_to_have_preview_cta
-    expect_to_see_call_to_subscribe_to_upcase
+    expect(page).to have_video_preview_callout
+    expect(page).to have_subscribe_cta
   end
 
   def create_video(show)
@@ -34,7 +34,7 @@ feature "Visitor" do
     )
   end
 
-  def expect_page_to_have_preview_cta
+  def expect_page_to_have_show_preview_cta
     expect(page.body).to include(
       I18n.t("watchables.preview.cta", subscribe_url: join_path).html_safe,
     )
@@ -44,5 +44,20 @@ feature "Visitor" do
     expect(page).to have_content(
       "Subscribe to #{I18n.t('shared.subscription.name')}",
     )
+  end
+
+  def have_video_preview_callout
+    have_content I18n.t("videos.show.access_callout_for_preview_text")
+  end
+
+  def have_subscribe_cta
+    have_link(
+      I18n.t("videos.show.access_callout_for_preview_button"),
+      href: professional_checkout_path,
+    )
+  end
+
+  def professional_checkout_path
+    new_checkout_path(plan: Plan::PROFESSIONAL_SKU)
   end
 end

--- a/spec/views/videos/_access_callout.html.erb_spec.rb
+++ b/spec/views/videos/_access_callout.html.erb_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe "videos/_access_callout" do
+  context "when the user is a guest" do
+    context "and the video is a free sample" do
+      it "displays an auth to access message and button for the video" do
+        video = build_stubbed(:video, :free_sample)
+
+        render_callout video, signed_out: true
+
+        expect(rendered).to have_css ".access-callout.auth-to-access"
+        expect(rendered).to have_auth_to_access_link_for(video)
+      end
+    end
+
+    context "when the video is not a free sample" do
+      it "displays the 'preview' message and CTA" do
+        video = build_stubbed(:video)
+
+        render_callout video, signed_out: true
+
+        expect(rendered).to have_css ".access-callout.subscription-required"
+        expect(rendered).to have_subscribe_cta
+      end
+    end
+  end
+
+  context "when the user is a sampler" do
+    context "and the video is a free sample" do
+      it "displays a subscribe CTA about viewing all the videos" do
+        video = build_stubbed(:video, :free_sample)
+
+        render_callout video, signed_out: false
+
+        expect(rendered).to have_css ".access-callout.subscription-required"
+        expect(rendered).to have_content(
+          I18n.t("videos.show.access_callout_for_sample_text"),
+        )
+        expect(rendered).to have_subscribe_cta
+      end
+    end
+
+    context "and the video is not a free sample" do
+      it "displays the 'preview' message and CTA" do
+        video = build_stubbed(:video)
+
+        render_callout video, signed_out: false
+
+        expect(rendered).to have_css ".access-callout.subscription-required"
+        expect(rendered).to have_content(
+          I18n.t("videos.show.access_callout_for_preview_text"),
+        )
+        expect(rendered).to have_subscribe_cta
+      end
+    end
+  end
+
+  def have_auth_to_access_link_for(video)
+    have_link(
+      I18n.t("videos.show.auth_to_access_button_text"),
+      href: video_auth_to_access_path(video),
+    )
+  end
+
+  def render_callout(video, signed_out: false)
+    allow(view).to receive(:signed_out?).and_return(signed_out)
+    render template: "videos/_access_callout", locals: { video: video }
+  end
+
+  def have_subscribe_cta
+    have_link(
+      "Subscribe Now",
+      href: new_checkout_path(:professional),
+    )
+  end
+end

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -41,23 +41,23 @@ describe "videos/show" do
   end
 
   describe "preview notice and subscribe CTA" do
-    context "the user does not have access to the full video" do
-      it "displays the notice and subscribe CTA" do
-        video = build_stubbed(:video, watchable: build_stubbed(:show))
+    context "the user is not a subscriber" do
+      it "displays the auth to access CTA for the video" do
+        video = build_stubbed(:video, :free_sample)
 
-        render_video video, has_access: false
+        render_video video, subscriber: false
 
-        expect(rendered).to have_locked_message_with_subscribe_cta
+        expect(rendered).to have_access_callout
       end
     end
 
-    context "the user has access to the full video" do
+    context "the user is a subscriber" do
       it "does not display the notice or subscribe CTA" do
         video = build_stubbed(:video, watchable: build_stubbed(:show))
 
-        render_video video, has_access: true
+        render_video video, subscriber: true
 
-        expect(rendered).not_to have_locked_message_with_subscribe_cta
+        expect(rendered).not_to have_access_callout
       end
     end
   end
@@ -209,8 +209,8 @@ describe "videos/show" do
     have_css(".trails-progress")
   end
 
-  def have_locked_message_with_subscribe_cta
-    have_css(".locked-message", text: /Subscribe/)
+  def have_access_callout
+    have_css ".access-callout"
   end
 
   def be_displaying_video_with_id(video_id)
@@ -239,10 +239,13 @@ describe "videos/show" do
     video.reload
   end
 
-  def render_video(video, has_access: true)
+  def render_video(video, has_access: true, subscriber: false)
     assign :video, video
     allow(view).to receive(:current_user_has_access_to?).and_return(has_access)
     allow(view).to receive(:current_user).and_return(build_stubbed(:user))
+    allow(view).to receive(:signed_out?).and_return(false)
+    allow(view).to receive(:current_user_has_active_subscription?).
+      and_return(subscriber)
     render template: "videos/show"
   end
 end


### PR DESCRIPTION
We've recently begun marking a number of videos as free samples, allowing any signed-in user to view these videos. This change adds a context specific (user & video state) callout and CTA button to all videos when viewed by non-subscribers:

<img width="926" alt="preview" src="https://cloud.githubusercontent.com/assets/420113/12762407/02763e58-c9bd-11e5-8e6a-e8a4960db2e2.png">

![sample](https://cloud.githubusercontent.com/assets/420113/12762412/0519583e-c9bd-11e5-90e3-ca460ade297a.png)
