### PR TITLE
Remove hard coded "Membership" in favor of i18n

### DIFF
--- a/app/views/layouts/_signed_in_header.html.erb
+++ b/app/views/layouts/_signed_in_header.html.erb
@@ -34,7 +34,7 @@
             <li class="subscription">
               <%= link_to new_subscription_path do %>
                 <span><%= t("shared.subscriptions.icon") %></span>
-                <%= t("shared.subscription.name") %> Membership
+                <%= t("shared.subscriptions.single_user") %>
               <% end %>
             </li>
           <% end %>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -56,8 +56,8 @@
     subscription.</li>
 
     <li>&#8220;Single-User Subscriber&#8221; refers to a Subscriber who
-    purchases a subscription to Upcase <%= t('shared.subscription.name')
-    %>&#174; for one (1) User.</li>
+    purchases a subscription to <%= t('shared.subscription.name') %>&#174; for
+    one (1) User.</li>
 
     <li>&#8220;Multi-User Subscriber&#8221;
     refers to a Subscriber who purchases a subscription to <%=

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
     subscription:
       name: Upcase
     subscriptions:
+      single_user: Upcase Membership
       icon: ✶
     team_plan_name: Upcase for Teams
     upcase: Upcase

--- a/spec/support/subscriptions.rb
+++ b/spec/support/subscriptions.rb
@@ -25,7 +25,7 @@ module Subscriptions
   end
 
   def click_upcase_call_to_action_in_header
-    click_link "Upcase Membership"
+    click_link I18n.t("shared.subscriptions.single_user")
   end
 
   def settings_page


### PR DESCRIPTION
Why:
- We'd like to consistently use i18n for all copy.
- The "Terms" page currently has the following copy:

```
“Single-User Subscriber” refers to a Subscriber who purchases a
subscription to Upcase Upcase® for one (1) User.
```

This PR:
- Adds a new translation for signing up as a single user.
- Updates the terms to remove the duplicate "Upcase" when defining
  "Single-user Subscription".
