### PR TITLE
Add teams link into header

### DIFF
--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -21,6 +21,11 @@
                 class: "table-of-contents-toggle",
                 data: { role: "table-of-contents-toggle" } %>
             </li>
+            <li>
+              <%= link_to teams_path do %>
+                <%= t("shared.header.teams") %>
+              <% end %>
+            </li>
             <% if signed_out? %>
               <li>
                 <%= link_to "Sign In", sign_in_path %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -189,6 +189,7 @@
         <li>Flashcard decks</li>
         <li>New videos every week</li>
       </ul>
+      <%= link_to "Have a team?", teams_path, class: :team %>
     </div>
   </section>
 </section>

--- a/app/views/teams/_plan.html.erb
+++ b/app/views/teams/_plan.html.erb
@@ -13,7 +13,7 @@
       skills, stay on top of best practices, and keep up to date with new
       technologies.</p>
       <div class="price-cta">
-        <%= link_to "Get your team started today", new_checkout_path(plan), :class => "cta-button signup" %>
+        <%= link_to t("teams.join_cta"), new_checkout_path(plan), class: "cta-button signup" %>
       </div>
     </div>
     <div class="price-includes">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,14 +141,16 @@ en:
       forum: Forum
       help-link: Help
       tagline: Learn with thoughtbot
+      teams: Teams
       search: Search
       trails: Trails
       weekly_iteration: Weekly Iteration
     subscription:
       name: Upcase
     subscriptions:
-      single_user: Subscribe Now
       icon: ✶
+      multi_user: Team Membership
+      single_user: Subscribe Now
     team_plan_name: Upcase for Teams
     upcase: Upcase
   show:
@@ -186,6 +188,8 @@ en:
     reason: Why have you decided to leave?
     reason_explanation: This information will help us make Upcase better for future
       members.
+  teams:
+    join_cta: Get your team started today
   teachers:
     teacher:
       header: Taught by

--- a/spec/features/visitor_purchases_team_subscription_spec.rb
+++ b/spec/features/visitor_purchases_team_subscription_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 feature 'Visitor can purchase a subscription for their team' do
   scenario 'successful purchase' do
-    visit_team_plan_checkout_page
+    create_team_plan
+    navigate_to_team_sign_up
+
     fill_out_account_creation_form email: 'user@fabtabulous.com'
     fill_out_credit_card_form_with_valid_credit_card
 
@@ -13,8 +15,14 @@ feature 'Visitor can purchase a subscription for their team' do
     expect_to_see_team_name 'Fabtabulous'
   end
 
-  def team_plan
-    Plan.team.first
+  def create_team_plan
+    create(:plan, :team, :featured)
+  end
+
+  def navigate_to_team_sign_up
+    visit root_path
+    click_link I18n.t("shared.header.teams")
+    click_link I18n.t("teams.join_cta")
   end
 
   def expect_to_see_team_name(team_name)


### PR DESCRIPTION
Why:
- We'd like for users to know there is a team plan if they have a team
  they'd like to sign up.
- There should be a clear flow for signing up for a team subscription.

This PR:
- Adds a teams link to the landing layout.
- Add teams to signed in but not subscribed header.
