### PR TITLE
Remove gap between header and hero on teams

### DIFF
--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -1,3 +1,11 @@
+.teams {
+  #header-wrapper {
+    @include dashboard-medium {
+      margin: 0 auto;
+    }
+  }
+}
+
 #header-wrapper {
   @include linear-gradient($upcase-blue-1, $upcase-blue-2);
   @include dashboard-medium {


### PR DESCRIPTION
Why:
- There is an obnoxious gap between the header and the hero item on the
  `/teams` page

This PR:
- Removes the margin on header when on the `/teams` page.
