### PR TITLE
Take users directly to checkout

### DIFF
--- a/app/views/layouts/_signed_in_header.html.erb
+++ b/app/views/layouts/_signed_in_header.html.erb
@@ -32,7 +32,7 @@
           </li>
           <% unless current_user_has_active_subscription? %>
             <li class="subscription">
-              <%= link_to new_subscription_path do %>
+              <%= link_to professional_checkout_path do %>
                 <span><%= t("shared.subscriptions.icon") %></span>
                 <%= t("shared.subscriptions.single_user") %>
               <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,7 @@ en:
     subscription:
       name: Upcase
     subscriptions:
-      single_user: Upcase Membership
+      single_user: Subscribe Now
       icon: ✶
     team_plan_name: Upcase for Teams
     upcase: Upcase

--- a/spec/views/shared/_header.html.erb_spec.rb
+++ b/spec/views/shared/_header.html.erb_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "layouts/_signed_in_header.html.erb" do
   include AnalyticsHelper
   include Gravatarify::Helper
+  include PlansHelper
 
   let(:call_to_action_label) { "Get two months free" }
 
@@ -66,7 +67,7 @@ describe "layouts/_signed_in_header.html.erb" do
         current_user_has_active_subscription: false
       )
 
-      expect(rendered).to have_css("a[href='#{new_subscription_path}']")
+      expect(rendered).to have_subscribe_checkout_link
     end
   end
 
@@ -77,7 +78,7 @@ describe "layouts/_signed_in_header.html.erb" do
         current_user_has_active_subscription: true
       )
 
-      expect(rendered).not_to have_css("a[href='#{new_subscription_path}']")
+      expect(rendered).not_to have_subscribe_checkout_link
     end
   end
 
@@ -96,6 +97,13 @@ describe "layouts/_signed_in_header.html.erb" do
 
   def have_search_link
     have_link(I18n.t("shared.header.search"), practice_path)
+  end
+
+  def have_subscribe_checkout_link
+    have_link(
+      I18n.t("shared.subscriptions.single_user"),
+      href: professional_checkout_path,
+    )
   end
 
   def render(


### PR DESCRIPTION
Why:

Currently we take users to the landing page if they are authenticated
but don't have a subscription and click the "Upcase Membership" link.
This isn't ideal; if they are authenticated then they have been sampling
Upcase content and are presumably sold on subscribing. The landing page
is not for them!

This PR:
- Rewords "Upcase Membership" to "Subscribe".
- This link in the header now takes users directly to the checkout page
  rather then the landing page.
