### PR TITLE
Add empty alt text for decorative logos

### DIFF
--- a/app/views/layouts/_signed_in_header.html.erb
+++ b/app/views/layouts/_signed_in_header.html.erb
@@ -3,8 +3,8 @@
   data-role="header">
   <div class="header-container">
     <%= link_to root_path, class: "branding" do %>
-      <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg") %></h1>
-      <%= image_tag("ralph.svg", class: "ralph-header-logo") %>
+      <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg", alt: "Upcase") %></h1>
+      <%= image_tag("ralph.svg", class: "ralph-header-logo", alt: "thoughtbot") %>
     <% end %>
     <a class="nav-toggle">Menu</a>
     <nav class="closed">

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -9,8 +9,8 @@
       data-role="header">
       <div class="header-container">
         <%= link_to root_path, class: "branding" do %>
-          <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg") %></h1>
-          <%= image_tag("ralph.svg", class: "ralph-header-logo") %>
+          <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg", alt: "Upcase") %></h1>
+          <%= image_tag("ralph.svg", class: "ralph-header-logo", alt: "thoughtbot") %>
           <span class="header-tagline"><%= t("shared.header.tagline") %></span>
         <% end %>
         </h1>

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -20,7 +20,7 @@
     happy with our lessons, community, and commitment to your future.</p>
 
     <%= link_to "#", class: "cta-button bottom-image" do %>
-      <%= image_tag("ralph-white.svg", class: "cta-button-logo") %>
+      <%= image_tag("ralph-white.svg", class: "cta-button-logo", alt: "") %>
       <span class="cta-button-text"><%= t(".pay-button-cta") %></span>
     <% end %>
   </div>

--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -1,6 +1,6 @@
 <% if feature.accessible_without_subscription? %>
   <%= link_to video_auth_to_access_path(feature), class: "available-link" do %>
-    <%= image_tag("github.svg", class: "logo") %>
+    <%= image_tag("github.svg", class: "logo", alt: "") %>
     <%= t(".available_for_free_after_authing") %>
   <% end %>
 <% else %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <section id="auth-form-container">
   <%= link_to github_auth_path, class: 'cta-button secondary-button' do %>
-    <%= image_tag("github.svg", class: "github-logo") %>
+    <%= image_tag("github.svg", class: "github-logo", alt: "") %>
     <%= t("authenticating.github_signin") %>
   <% end %>
   <span class="divider">

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -36,7 +36,7 @@
           video_auth_to_access_path(video),
           class: "cta-button subscribe-cta light-bg",
         ) do %>
-          <%= image_tag("github-black.svg", class: "logo") %>
+          <%= image_tag("github-black.svg", class: "logo", alt: "") %>
           <%= t("trails.start_for_free") %>
         <% end %>
       <% end %>

--- a/app/views/videos/_auth_to_access.html.erb
+++ b/app/views/videos/_auth_to_access.html.erb
@@ -2,7 +2,7 @@
   <p><%= t("videos.show.auth_to_access_callout_text") %></p>
 
   <%= link_to video_auth_to_access_path(video), class: "cta-button subscribe-cta light-bg" do %>
-    <%= image_tag("github-black.svg", class: "logo") %>
+    <%= image_tag("github-black.svg", class: "logo", alt: "") %>
     <span><%= t("videos.show.auth_to_access_button_text") %></span>
   <% end %>
 </div>


### PR DESCRIPTION
- Rails sets the alt to the file name with the full digest fingerprint, which
  gets announced to screen reader users:

``````
<img src="//d3v2mfwlau8x6c.cloudfront.net/assets/upcase/upcase-header-logo-small-74d881f2938298c588db0b7c93de56caf020a767f5981ad9919f1ab5728e278f.svg" alt="Upcase header logo small 74d881f2938298c588db0b7c93de56caf020a767f5981ad9919f1ab5728e278f">```
``````
