### PR TITLE
Subscribe CTA on teams redirect to team checkout

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,6 +2,8 @@ class TeamsController < ApplicationController
   before_filter :must_be_team_owner, only: :edit
 
   def new
+    @landing_page = true
+    @team_page = true
     @catalog = Catalog.new
   end
 

--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -23,6 +23,10 @@ module PlansHelper
     new_checkout_path(plan: Plan::PROFESSIONAL_SKU)
   end
 
+  def team_checkout_path
+    new_checkout_path(plan: Plan::TEAM_SKU)
+  end
+
   def formatted_name(plan)
     first_line, _, last_line = plan.name.rpartition(" ")
     [first_line, last_line].join("<br/>").html_safe

--- a/app/helpers/team_plans_helper.rb
+++ b/app/helpers/team_plans_helper.rb
@@ -6,6 +6,10 @@ module TeamPlansHelper
     end
   end
 
+  def team_page?
+    @team_page.present?
+  end
+
   private
 
   def team_plan_quantity_select_attributes(plan)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,8 +1,9 @@
 class Plan < ActiveRecord::Base
-  DISCOUNTED_ANNUAL_PLAN_SKU = "175-annually"
-  PRIME_249_SKU = "prime-249"
-  PROFESSIONAL_SKU = "professional"
-  THE_WEEKLY_ITERATION_SKU = "the-weekly-iteration"
+  DISCOUNTED_ANNUAL_PLAN_SKU = "175-annually".freeze
+  PRIME_249_SKU = "prime-249".freeze
+  PROFESSIONAL_SKU = "professional".freeze
+  TEAM_SKU = "professional-29-team".freeze
+  THE_WEEKLY_ITERATION_SKU = "the-weekly-iteration".freeze
 
   has_many :checkouts
   has_many :subscriptions, as: :plan

--- a/app/views/layouts/_signed_out_header.html.erb
+++ b/app/views/layouts/_signed_out_header.html.erb
@@ -16,19 +16,28 @@
             class: "table-of-contents-toggle",
             data: { role: "table-of-contents-toggle" } %>
         </li>
-        <li>
-          <%= link_to teams_path do %>
-            <%= t("shared.header.teams") %>
-          <% end %>
-        </li>
-        <% if signed_out? %>
+
+        <% unless team_page? %>
           <li>
-            <%= link_to "Sign In", sign_in_path %>
+            <%= link_to teams_path do %>
+              <%= t("shared.header.teams") %>
+            <% end %>
           </li>
         <% end %>
+
+        <% if signed_out? %>
+          <li>
+            <%= link_to t("shared.header.sign_in"), sign_in_path %>
+          </li>
+        <% end %>
+
         <li class="header-cta">
-          <%= link_to professional_checkout_path, class: "header-cta-link" do %>
-            <%= t("subscriptions.join_cta") %>
+          <% if content_for?(:header_cta_link) %>
+            <%= content_for(:header_cta_link) %>
+          <% else %>
+            <%= link_to professional_checkout_path, class: "header-cta-link" do %>
+              <%= t("subscriptions.join_cta") %>
+            <% end %>
           <% end %>
         </li>
       </ul>

--- a/app/views/teams/_hero.html.erb
+++ b/app/views/teams/_hero.html.erb
@@ -2,5 +2,5 @@
   <%= render "subscriptions/upcase.svg" %>
   <h1>Someone’s getting boss of the year.</h1>
   <h5>Sign your team up for Upcase and save 10% per user.</h5>
-  <%= link_to t("subscriptions.join_cta"), "#price", class: "cta-button signup" %>
+  <%= link_to t("subscriptions.join_cta"), team_checkout_path, class: "cta-button signup" %>
 </section>

--- a/app/views/teams/_plan.html.erb
+++ b/app/views/teams/_plan.html.erb
@@ -3,7 +3,7 @@
     <div class="price-header-title">
       <h3>Enroll your team</h3>
     </div>
-    <div class="price-header-cost">    
+    <div class="price-header-cost">
       <h4><sup>$</sup><%= plan.price_in_dollars %> <sub>per <%= plan_interval plan %> per user</sub></h4>
     </div>
   </header>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,5 +1,10 @@
 <% content_for :page_title, "Team Pricing" %>
 <% content_for :additional_body_classes, "landing" %>
+<% content_for :header_cta_link do %>
+  <%= link_to team_checkout_path, class: "header-cta-link" do %>
+    <%= t("subscriptions.team_join_cta") %>
+  <% end %>
+<% end %>
 
 <%= render 'teams/hero' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       tagline: Learn with thoughtbot
       teams: Teams
       search: Search
+      sign_in: Sign In
       trails: Trails
       weekly_iteration: Weekly Iteration
     subscription:
@@ -188,6 +189,7 @@ en:
     reason: Why have you decided to leave?
     reason_explanation: This information will help us make Upcase better for future
       members.
+    team_join_cta: Start Your Team
   teams:
     join_cta: Get your team started today
   teachers:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -152,7 +152,7 @@ FactoryGirl.define do
     trait :team do
       price_in_dollars 89
       name "Upcase for Teams"
-      sku "team_plan"
+      sku Plan::TEAM_SKU
       includes_team true
       minimum_quantity 3
     end

--- a/spec/features/visitor_purchases_team_subscription_spec.rb
+++ b/spec/features/visitor_purchases_team_subscription_spec.rb
@@ -22,7 +22,7 @@ feature 'Visitor can purchase a subscription for their team' do
   def navigate_to_team_sign_up
     visit root_path
     click_link I18n.t("shared.header.teams")
-    click_link I18n.t("teams.join_cta")
+    click_link I18n.t("subscriptions.join_cta")
   end
 
   def expect_to_see_team_name(team_name)

--- a/spec/views/layouts/_signed_out_header.htlm.erb_spec.rb
+++ b/spec/views/layouts/_signed_out_header.htlm.erb_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+describe "layouts/_signed_out_header.html.erb" do
+  include PlansHelper
+
+  context "when not on the teams page" do
+    it "renders a link to the teams page" do
+      render_header(team_page: false)
+
+      expect(rendered).to have_link(
+        t("shared.header.teams"),
+        team_checkout_path,
+      )
+    end
+  end
+
+  context "when on the teams page" do
+    it "doesn't renders a link to the teams page" do
+      render_header(team_page: true)
+
+      expect(rendered).not_to have_link(
+        t("shared.header.teams"),
+        team_checkout_path,
+      )
+    end
+  end
+
+  context "where there is content_for `header_cta_link`" do
+    it "shows the content in the CTA button" do
+      render_header(header_cta_link: "result")
+
+      expect(rendered).to have_css(
+        ".header-cta",
+        text: "result",
+      )
+    end
+  end
+
+  context "where there isn't content_for `header_cta_link`" do
+    it "renders a CTA link to the professional_checkout" do
+      render_header(header_cta_link: nil)
+
+      expect(rendered).to have_link(
+        t("subscriptions.join_cta"),
+        professional_checkout_path,
+      )
+    end
+  end
+
+  context "when signed_out" do
+    it "renders the sign_in link" do
+      render_header(signed_out: true)
+
+      expect(rendered).to have_link(
+        t("shared.header.sign_in"),
+        sign_in_path,
+      )
+    end
+  end
+
+  context "when signed_in" do
+    it "doesn't render the sign_in link" do
+      render_header(signed_out: false)
+
+      expect(rendered).not_to have_link(
+        t("shared.header.sign_in"),
+        sign_in_path,
+      )
+    end
+  end
+
+  def render_header(signed_out: false, team_page: false, header_cta_link: nil)
+    allow(view).to receive(:signed_out?).and_return(signed_out)
+    allow(view).to receive(:team_page?).and_return(team_page)
+
+    if header_cta_link
+      allow(view).to receive(:content_for?).
+        with(:header_cta_link).
+        and_return(true)
+      allow(view).to receive(:content_for).
+        with(:header_cta_link).
+        and_return(header_cta_link)
+    end
+
+    render
+  end
+end

--- a/spec/views/teams/_hero.html.erb_spec.rb
+++ b/spec/views/teams/_hero.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe "teams/_hero.html.erb" do
+  include PlansHelper
+
+  it "renders a link to the teams checkout" do
+    render "teams/hero"
+
+    expect(rendered).to have_link(
+      t("subscriptions.join_cta"),
+      team_checkout_path,
+    )
+  end
+end


### PR DESCRIPTION
Why:

Currently the teams page has links throughout the page that send to use
to the team checkout. However, the CTA in the header takes the user to
the professional plan checkout. This mismatch in behavior is confusing
and could lead to the user signing up for the wrong plan.

This PR:
- Changes the "Subscribe" CTA in the header to link to the teams
  checkout when on the teams page.
- Changes the teams page to show the landing header no matter what state
  the user is in.
- Adds helpers for linking to the teams checkout and determining if on
  the teams page.
