### PR TITLE
Restore alt text to header logo

### DIFF
--- a/app/views/layouts/_signed_out_header.html.erb
+++ b/app/views/layouts/_signed_out_header.html.erb
@@ -2,7 +2,10 @@
   data-role="header">
   <div class="header-container">
     <%= link_to root_path, class: "branding" do %>
-      <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg") %></h1>
+      <h1 class="small-logo">
+        <%= image_tag("upcase/upcase-header-logo-small.svg", alt: "Upcase") %>
+      </h1>
+
       <%= image_tag("ralph.svg", class: "ralph-header-logo") %>
       <span class="header-tagline"><%= t("shared.header.tagline") %></span>
     <% end %>


### PR DESCRIPTION
Why:

This was introduced in 8d3d69a38679c468cb7f74dd57924c8dcd526db0 and
mistakenly removed in f80897894ce6882af1d0850211ab5e469edea3cc.

This PR:

Restores the alt text to the logo in `_signed_out_header.html.erb`.
