### PR TITLE
Remove helper current_user_has_active_subscription?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,18 +37,13 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_is_subscription_owner?
-    current_user_has_active_subscription? &&
+    current_user.has_active_subscription? &&
       current_user.subscription.owner?(current_user)
   end
   helper_method :current_user_is_subscription_owner?
 
-  def current_user_has_active_subscription?
-    current_user && current_user.has_active_subscription?
-  end
-  helper_method :current_user_has_active_subscription?
-
   def current_user_is_eligible_for_annual_upgrade?
-    current_user_has_active_subscription? &&
+    current_user.has_active_subscription? &&
       current_user.eligible_for_annual_upgrade?
   end
   helper_method :current_user_is_eligible_for_annual_upgrade?

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -36,7 +36,7 @@ class CheckoutsController < ApplicationController
   end
 
   def redirect_when_already_subscribed
-    if current_user_has_active_subscription?
+    if current_user.has_active_subscription?
       redirect_to(
         root_path,
         notice: t("checkout.flashes.already_subscribed"),

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -33,7 +33,7 @@ module CheckoutsHelper
   end
 
   def choose_plan_link(plan)
-    if current_user_has_active_subscription?
+    if current_user.has_active_subscription?
       change_plan_link(plan)
     else
       new_plan_link(plan)

--- a/app/views/layouts/_signed_in_header.html.erb
+++ b/app/views/layouts/_signed_in_header.html.erb
@@ -1,9 +1,10 @@
 <section id="header-wrapper"
-  class="without-hero <%= "subscriber" if current_user_has_active_subscription? %>"
+  class="without-hero <%= "subscriber" if current_user.has_active_subscription? %>"
   data-role="header">
   <div class="header-container">
     <%= link_to root_path, class: "branding" do %>
       <h1 class="small-logo"><%= image_tag("upcase/upcase-header-logo-small.svg", alt: "Upcase") %></h1>
+
       <%= image_tag("ralph.svg", class: "ralph-header-logo", alt: "thoughtbot") %>
     <% end %>
     <a class="nav-toggle">Menu</a>
@@ -30,7 +31,7 @@
           <li>
             <%= link_to t("shared.header.search"), search_path %>
           </li>
-          <% unless current_user_has_active_subscription? %>
+          <% unless current_user.has_active_subscription? %>
             <li class="subscription">
               <%= link_to professional_checkout_path do %>
                 <span><%= t("shared.subscriptions.icon") %></span>

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Learn Ruby and Rails Development" %>
 
-<% unless current_user_has_active_subscription? %>
+<% unless current_user.has_active_subscription? %>
   <%= render "products/locked_features" %>
 <% end %>
 

--- a/app/views/products/_subscription.html.erb
+++ b/app/views/products/_subscription.html.erb
@@ -1,4 +1,4 @@
-<% unless current_user_has_active_subscription? %>
+<% unless current_user.has_active_subscription? %>
   <div class="subscription-cta">
     <h2><%= t("#{offering.offering_type}.preview_cta") %></h2>
     <div class="license">

--- a/app/views/shared/_sidebar_forum.html.erb
+++ b/app/views/shared/_sidebar_forum.html.erb
@@ -1,4 +1,4 @@
-<% if current_user_has_active_subscription? %>
+<% if current_user.has_active_subscription? %>
   <div class="forum">
     <%= link_to "Discuss in the Forum", Forum.url, class: "button" %>
   </div>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -13,7 +13,7 @@
   </h2>
 <% end %>
 
-<% unless current_user_has_active_subscription? %>
+<% unless current_user.has_active_subscription? %>
   <%= render "videos/access_callout", video: @video %>
 <% end %>
 

--- a/app/views/watchables/_link.html.erb
+++ b/app/views/watchables/_link.html.erb
@@ -1,4 +1,4 @@
-<% if current_user_has_active_subscription? %>
+<% if current_user.has_active_subscription? %>
   <div class="license">
     <%= link_to \
       t("#{watchable.offering_type}.checkout_cta"),

--- a/spec/views/plans/_plan.html.erb_spec.rb
+++ b/spec/views/plans/_plan.html.erb_spec.rb
@@ -46,9 +46,7 @@ describe "plans/_plan.html" do
 
     it "links to change existing plan when user has a subscription" do
       plan = build_plan
-      user = double("user", plan: build_stubbed(:plan))
-      view_stubs(:current_user).and_return(user)
-      stub_view(active_subscription: true)
+      stub_view(active_subscription: true, plan: build_stubbed(:plan))
 
       render_plan(plan)
 
@@ -57,9 +55,13 @@ describe "plans/_plan.html" do
     end
   end
 
-  def stub_view(active_subscription: false)
-    view_stubs(:current_user_has_active_subscription?).
-      and_return(active_subscription)
+  def stub_view(active_subscription: false, plan: nil)
+    user = double(
+      :current_user,
+      has_active_subscription?: active_subscription,
+      plan: plan,
+    )
+    view_stubs(:current_user).and_return(user)
   end
 
   def build_plan

--- a/spec/views/plans/_pricing.html.erb_spec.rb
+++ b/spec/views/plans/_pricing.html.erb_spec.rb
@@ -23,7 +23,8 @@ describe "plans/_pricing.html" do
   end
 
   def render_pricing_with_plans(plans)
-    view_stubs(:current_user_has_active_subscription?).and_return(false)
+    user = double(:current_user, has_active_subscription?: false)
+    view_stubs(:current_user).and_return(user)
     render "plans/pricing", plans: plans
   end
 end

--- a/spec/views/practice/show.html.erb_spec.rb
+++ b/spec/views/practice/show.html.erb_spec.rb
@@ -83,9 +83,10 @@ describe "practice/show.html" do
   end
 
   def stub_user_access(has_active_subscription: false)
-    view_stubs(:current_user).and_return(build_stubbed(:user))
-    view_stubs(:current_user_has_active_subscription?).
+    user = build_stubbed(:user)
+    allow(user).to receive(:has_active_subscription?).
       and_return(has_active_subscription)
+    view_stubs(:current_user).and_return(user)
     view_stubs(:current_user_has_access_to?).and_return(false)
   end
 

--- a/spec/views/shared/_header.html.erb_spec.rb
+++ b/spec/views/shared/_header.html.erb_spec.rb
@@ -122,10 +122,6 @@ describe "layouts/_signed_in_header.html.erb" do
     )
 
     view_stub_with_return(
-      current_user_has_active_subscription?:
-        current_user_has_active_subscription
-    )
-    view_stub_with_return(
       current_user_is_eligible_for_annual_upgrade?:
         current_user_is_eligible_for_annual_upgrade
     )
@@ -140,7 +136,8 @@ describe "layouts/_signed_in_header.html.erb" do
         "user",
         email: current_user_email,
         admin?: current_user_is_admin,
-        has_access_to?: false
+        has_access_to?: false,
+        has_active_subscription?: current_user_has_active_subscription,
       )
     )
     super()

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -241,11 +241,11 @@ describe "videos/show" do
 
   def render_video(video, has_access: true, subscriber: false)
     assign :video, video
+    user = build_stubbed(:user)
+    allow(user).to receive(:has_active_subscription?).and_return(subscriber)
     allow(view).to receive(:current_user_has_access_to?).and_return(has_access)
-    allow(view).to receive(:current_user).and_return(build_stubbed(:user))
+    allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:signed_out?).and_return(false)
-    allow(view).to receive(:current_user_has_active_subscription?).
-      and_return(subscriber)
     render template: "videos/show"
   end
 end


### PR DESCRIPTION
Why:

Now that we have a NullUser/Guest this helper method that checks for the
existence of a user isn't necessary.

This PR:
- Removes the current_user_has_active_subscription? helper method.
- Replaces instances of current_user_has_active_subscription? with
  current_user.has_active_subscription?
