### PR TITLE
Add tracking events to analytics

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -6,6 +6,10 @@ class Exercise < ActiveRecord::Base
   validates :name, presence: true
   validates :url, presence: true
 
+  def trail_name
+    trail.try(:name)
+  end
+
   def self.ordered
     order(:created_at)
   end

--- a/app/services/exercise_tracker.rb
+++ b/app/services/exercise_tracker.rb
@@ -1,0 +1,40 @@
+class ExerciseTracker
+  def initialize(exercise)
+    @exercise = exercise
+  end
+
+  def started_events
+    [
+      [
+        "Started exercise",
+        {
+          name: exercise.name,
+          watchable_name: exercise.trail_name,
+        },
+      ], [
+        "Touched Step",
+        {
+          name: exercise.name,
+          watchable_name: exercise.trail_name,
+          type: "Exercise",
+        },
+      ]
+    ]
+  end
+
+  def finished_events
+    [
+      [
+        "Finished exercise",
+        {
+          name: exercise.name,
+          watchable_name: exercise.trail_name,
+        },
+      ],
+    ]
+  end
+
+  private
+
+  attr_reader :exercise
+end

--- a/app/services/trail_tracker.rb
+++ b/app/services/trail_tracker.rb
@@ -1,0 +1,31 @@
+class TrailTracker
+  def initialize(trail)
+    @trail = trail
+  end
+
+  def started_events
+    [
+      [
+        "Started trail",
+        {
+          name: trail.name,
+        },
+      ],
+    ]
+  end
+
+  def finished_events
+    [
+      [
+        "Finished trail",
+        {
+          name: trail.name,
+        },
+      ],
+    ]
+  end
+
+  private
+
+  attr_reader :trail
+end

--- a/app/services/video_tracker.rb
+++ b/app/services/video_tracker.rb
@@ -1,0 +1,46 @@
+class VideoTracker
+  def initialize(video)
+    @video = video
+  end
+
+  def started_events
+    [
+      [
+        "Started video",
+        {
+          name: video.name,
+          watchable_name: video.watchable_name,
+        },
+      ], [
+        "Touched Video",
+        {
+          name: video.name,
+          watchable_name: video.watchable_name,
+        },
+      ], [
+        "Touched Step",
+        {
+          name: video.name,
+          watchable_name: video.watchable_name,
+          type: "Video",
+        },
+      ]
+    ]
+  end
+
+  def finished_events
+    [
+      [
+        "Finished video",
+        {
+          name: video.name,
+          watchable_name: video.watchable_name,
+        },
+      ],
+    ]
+  end
+
+  private
+
+  attr_reader :video
+end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -56,7 +56,7 @@ describe Status do
       end
     end
 
-    context "when the user has not started the completable" do
+    context "when the user has not started the completeable" do
       it "returns an Unstarted null object" do
         user = build_stubbed(:user)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.include AnalyticsHelper
+  config.include Clearance::Testing::Matchers, type: :request
+  config.include Clearance::Testing::Helpers, type: :request
   config.include Paperclip::Shoulda::Matchers
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
@@ -67,6 +69,7 @@ RSpec.configure do |config|
   config.include CheckoutHelpers
   config.include SessionHelpers, type: :feature
   config.include PathHelpers, type: :feature
+  config.include SignInRequestHelpers, type: :request
 
   config.infer_spec_type_from_file_location!
 end

--- a/spec/requests/statuses_endpoint_spec.rb
+++ b/spec/requests/statuses_endpoint_spec.rb
@@ -15,9 +15,11 @@ describe "POST /api/v1/exercises/:exercise_uuid/status" do
   end
 
   def perform_request(uuid, state)
-    post "/api/v1/exercises/#{uuid}/status",
-         access_token: access_token,
-         state: state
+    post(
+      "/api/v1/exercises/#{uuid}/status",
+      access_token: access_token,
+      state: state,
+    )
   end
 
   def access_token

--- a/spec/requests/video_status_spec.rb
+++ b/spec/requests/video_status_spec.rb
@@ -54,12 +54,6 @@ describe "Video status" do
 
   def sign_in
     @current_user = create(:user)
-    post(
-      "/session",
-      session: {
-        email: @current_user.email,
-        password: "password"
-      }
-    )
+    sign_in_as(@current_user)
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -52,55 +52,132 @@ describe Analytics do
     end
   end
 
-  describe "#track_video_started" do
-    it "tracks started video event" do
-      video = build_stubbed(:video)
+  describe "#track_completeable_started" do
+    context "with a video" do
+      it "tracks started video event" do
+        video = build_stubbed(:video)
 
-      analytics_instance.track_video_started(
-        name: video.name,
-        watchable_name: video.watchable_name,
-      )
+        analytics_instance.track_completeable_started(video)
 
-      expect(analytics).to have_tracked("Started video").
-        for_user(user).
-        with_properties(
-          name: video.name,
-          watchable_name: video.watchable_name,
-        )
+        expect(analytics).to have_tracked("Started video").
+          for_user(user).
+          with_properties(
+            name: video.name,
+            watchable_name: video.watchable_name,
+          )
+      end
+
+      it "also tracks video touched event" do
+        video = build_stubbed(:video)
+
+        analytics_instance.track_completeable_started(video)
+
+        expect(analytics).to have_tracked("Touched Video").
+          for_user(user).
+          with_properties(
+            name: video.name,
+            watchable_name: video.watchable_name,
+          )
+      end
+
+      it "also tracks step touched event" do
+        video = build_stubbed(:video)
+
+        analytics_instance.track_completeable_started(video)
+
+        expect(analytics).to have_tracked("Touched Step").
+          for_user(user).
+          with_properties(
+            name: video.name,
+            watchable_name: video.watchable_name,
+            type: "Video",
+          )
+      end
     end
 
-    it "also tracks video touched event" do
-      video = build_stubbed(:video)
+    context "with an exercise" do
+      it "tracks started exercise event" do
+        exercise = build_stubbed(:exercise)
 
-      analytics_instance.track_video_started(
-        name: video.name,
-        watchable_name: video.watchable_name,
-      )
+        analytics_instance.track_completeable_started(exercise)
 
-      expect(analytics).to have_tracked("Touched Video").
-        for_user(user).
-        with_properties(
-          name: video.name,
-          watchable_name: video.watchable_name,
-        )
+        expect(analytics).to have_tracked("Started exercise").
+          for_user(user).
+          with_properties(
+            name: exercise.name,
+            watchable_name: exercise.trail_name,
+          )
+      end
+
+      it "also tracks step touched event" do
+        exercise = build_stubbed(:exercise)
+
+        analytics_instance.track_completeable_started(exercise)
+
+        expect(analytics).to have_tracked("Touched Step").
+          for_user(user).
+          with_properties(
+            name: exercise.name,
+            watchable_name: exercise.trail_name,
+            type: "Exercise",
+          )
+      end
+    end
+
+    context "with a trail" do
+      it "tracks started trail event" do
+        trail = build_stubbed(:trail)
+
+        analytics_instance.track_completeable_started(trail)
+
+        expect(analytics).to have_tracked("Started trail").
+          for_user(user).
+          with_properties(name: trail.name)
+      end
     end
   end
 
-  describe "#track_video_finished" do
-    it "tracks finished video event" do
-      video = build_stubbed(:video)
+  describe "#track_completeable_finished" do
+    context "with a video" do
+      it "tracks finished video event" do
+        video = build_stubbed(:video)
 
-      analytics_instance.track_video_finished(
-        name: video.name,
-        watchable_name: video.watchable_name,
-      )
+        analytics_instance.track_completeable_finished(video)
 
-      expect(analytics).to have_tracked("Finished video").
-        for_user(user).
-        with_properties(
-          name: video.name,
-          watchable_name: video.watchable_name,
-        )
+        expect(analytics).to have_tracked("Finished video").
+          for_user(user).
+          with_properties(
+            name: video.name,
+            watchable_name: video.watchable_name,
+          )
+      end
+    end
+
+    context "with an exercise" do
+      it "tracks finished exercise event" do
+        exercise = build_stubbed(:exercise)
+
+        analytics_instance.track_completeable_finished(exercise)
+
+        expect(analytics).to have_tracked("Finished exercise").
+          for_user(user).
+          with_properties(
+            name: exercise.name,
+            watchable_name: exercise.trail_name,
+          )
+      end
+    end
+
+    context "with a trail" do
+      it "tracks finished exercise event" do
+        trail = build_stubbed(:trail)
+
+        analytics_instance.track_completeable_finished(trail)
+
+        expect(analytics).to have_tracked("Finished trail").
+          for_user(user).
+          with_properties(name: trail.name)
+      end
     end
   end
 
@@ -177,16 +254,39 @@ describe Analytics do
     it "also tracks video touched event" do
       video = build_stubbed(:video)
 
-      analytics_instance.track_video_started(
+      download_properties = {
         name: video.name,
         watchable_name: video.watchable_name,
-      )
+        download_type: "Original",
+      }
+
+      analytics_instance.track_downloaded(download_properties)
 
       expect(analytics).to have_tracked("Touched Video").
         for_user(user).
         with_properties(
           name: video.name,
           watchable_name: video.watchable_name,
+        )
+    end
+
+    it "also tracks step touched event" do
+      video = build_stubbed(:video)
+
+      download_properties = {
+        name: video.name,
+        watchable_name: video.watchable_name,
+        download_type: "Original",
+      }
+
+      analytics_instance.track_downloaded(download_properties)
+
+      expect(analytics).to have_tracked("Touched Step").
+        for_user(user).
+        with_properties(
+          name: video.name,
+          watchable_name: video.watchable_name,
+          type: "Video",
         )
     end
   end

--- a/spec/support/sign_in_request_helper.rb
+++ b/spec/support/sign_in_request_helper.rb
@@ -1,0 +1,11 @@
+module SignInRequestHelpers
+  def sign_in_as(user)
+    post(
+      "/session",
+      session: {
+        email: user.email,
+        password: user.password,
+      },
+    )
+  end
+end


### PR DESCRIPTION
Why:

We're about to release trails with more content then ever before! We
currently track when users engage with our video content and find
analysing drop off for those videos across a trail valuable. However, we
currently don't have the same analytics tracking for exercise. This
means that we'll be blind when it comes to analysing how users are
interacting with the exercises contained within a trail.

This PR:
- Adds tracking events for exercise for starting and finishing an
  exercise.
- Adds tracking events for "steps" to track when a video or exercise is
  touched. This will be valuable for combining exercise and video data.
- Adds tracking for starting or finishing a trail.
