### PR TITLE
Make CTA button for starting trails dynamic

### DIFF
--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -34,9 +34,18 @@ $not-started-dot-color: #D8D8D8;
     text-align: center;
   }
 
+  .steps-and-start {
+    flex: 1;
+  }
+
   .trail {
+    display: flex;
     margin-bottom: 5em;
     width: 100%;
+
+    @include body-mobile {
+      flex-direction: column;
+    }
 
     header {
       @include clearfix;
@@ -201,6 +210,10 @@ $not-started-dot-color: #D8D8D8;
   }
 
   .started {
+    .trail {
+      flex-direction: column;
+    }
+
     p.description,
     a.start-trail,
     .person,
@@ -219,6 +232,10 @@ $not-started-dot-color: #D8D8D8;
       margin-bottom: 0;
       margin-right: 4em;
       width: 50%;
+
+      @include body-mobile {
+        width: 100%;
+      }
     }
 
     .numerical-progress, .help-icon, .help-tooltip {

--- a/app/helpers/trails_helper.rb
+++ b/app/helpers/trails_helper.rb
@@ -12,4 +12,45 @@ module TrailsHelper
       link_to completeable, title: completeable.name, &block
     end
   end
+
+  def trail_call_to_action(trail)
+    if current_user.subscriber?
+      start_trail_link(trail.first_completeable)
+    elsif current_user.sampler?
+      or_visit_trail(trail) { |video| start_trail_link(video) }
+    else
+      or_visit_trail(trail) { |video| auth_to_access_button(video) }
+    end
+  end
+
+  def or_visit_trail(trail)
+    trail.sample_video.map { |video|
+      yield video
+    }.unwrap_or(
+      visit_trail_link(trail)
+    )
+  end
+
+  def start_trail_link(url)
+    link_to(
+      t("trails.start_trail"),
+      url,
+      class: "start-trail cta-button small-button",
+    )
+  end
+
+  def visit_trail_link(trail)
+    link_to(
+      t("trails.visit_trail"),
+      trail,
+      class: "cta-button small-button",
+    )
+  end
+
+  def auth_to_access_button(video, cta_text: t("trails.start_for_free"))
+    cta_classes = "cta-button subscribe-cta light-bg"
+    link_to video_auth_to_access_path(video), class: cta_classes do
+      image_tag("github-black.svg", class: "logo", alt: "") + cta_text
+    end
+  end
 end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -3,6 +3,10 @@ class Guest
     false
   end
 
+  def sampler?
+    false
+  end
+
   def admin?
     false
   end

--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -81,7 +81,7 @@ class Trail < ActiveRecord::Base
     first_step.completeable
   end
 
-  def trial_video
+  def sample_video
     videos.where(accessible_without_subscription: true).first.wrapped
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ActiveRecord::Base
     subscription.present?
   end
 
+  def sampler?
+    !subscriber?
+  end
+
   def has_access_to?(feature)
     subscriber? || feature.accessible_without_subscription?
   end

--- a/app/views/trails/_header.html.erb
+++ b/app/views/trails/_header.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <% unless signed_in? %>
-      <% trail.trial_video.present do |video| %>
+      <% trail.sample_video.present do |video| %>
         <%= link_to(
           video_auth_to_access_path(video),
           class: "cta-button subscribe-cta light-bg",

--- a/app/views/trails/_incomplete_trail.html.erb
+++ b/app/views/trails/_incomplete_trail.html.erb
@@ -7,13 +7,12 @@
       <%= render "practice/trail_description_tooltip", trail: trail %>
     </header>
 
-    <%= render "trails/step_dots", trail: trail %>
+    <div class="steps-and-start">
+      <%= render "trails/step_dots", trail: trail %>
 
-    <% if trail.steps.present? %>
-      <%= link_to url_for(trail.first_completeable),
-        class: "start-trail cta-button small-button" do %>
-        Start trail
+      <% if trail.steps.present? %>
+        <%= trail_call_to_action(trail) %>
       <% end %>
-    <% end %>
+    </div>
   </section>
 </div>

--- a/app/views/videos/_auth_to_access.html.erb
+++ b/app/views/videos/_auth_to_access.html.erb
@@ -1,8 +1,5 @@
 <div class="access-callout auth-to-access">
   <p><%= t("videos.show.auth_to_access_callout_text") %></p>
 
-  <%= link_to video_auth_to_access_path(video), class: "cta-button subscribe-cta light-bg" do %>
-    <%= image_tag("github-black.svg", class: "logo", alt: "") %>
-    <span><%= t("videos.show.auth_to_access_button_text") %></span>
-  <% end %>
+  <%= auth_to_access_button(video, cta_text: t("videos.show.auth_to_access_button_text")) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,9 @@ en:
     other_resources: Use these resources for reference and additional practice
     thoughtbot_resources: Use these thoughtbot resources first
     validations: '%{name} developers should be able to'
+    start_trail: Start trail
+    visit_trail: Visit trail
+    subscribe: Subscribe
   users:
     flashes:
       update:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -517,6 +517,13 @@ FactoryGirl.define do
         create(:step, trail: trail, completeable: video)
       end
     end
+
+    trait :with_sample_video do
+      after :create do |trail|
+        video = create(:video, accessible_without_subscription: true, watchable: nil)
+        create(:step, trail: trail, completeable: video)
+      end
+    end
   end
 
   factory :step do

--- a/spec/helpers/trails_helper_spec.rb
+++ b/spec/helpers/trails_helper_spec.rb
@@ -37,4 +37,75 @@ describe TrailsHelper do
       end
     end
   end
+
+  describe "#trail_call_to_action" do
+    context "for a subscriber" do
+      context "for a trail with a trial video" do
+        it "renders a Start Trail link" do
+          trail = create(:trail, :with_sample_video)
+          user = build(:subscriber)
+          allow(helper).to receive(:current_user).and_return(user)
+
+          html = helper.trail_call_to_action(trail)
+
+          expect(html).to include(I18n.t("trails.start_trail"))
+          expect(html).to include(video_path(trail.videos.first))
+        end
+      end
+    end
+
+    context "for a sampler" do
+      context "for a trail with no trial video" do
+        it "renders a Visit Trail link" do
+          trail = create(:trail, :video)
+          user = create(:user)
+          allow(helper).to receive(:current_user).and_return(user)
+
+          html = helper.trail_call_to_action(trail)
+
+          expect(html).to include(I18n.t("trails.visit_trail"))
+          expect(html).to include(trail_path(trail))
+        end
+      end
+
+      context "for a trail with a trial video" do
+        it "renders a Start Trail link" do
+          trail = create(:trail, :with_sample_video)
+          user = create(:user)
+          allow(helper).to receive(:current_user).and_return(user)
+
+          html = helper.trail_call_to_action(trail)
+
+          expect(html).to include(I18n.t("trails.start_trail"))
+          expect(html).to include(video_path(trail.videos.first))
+        end
+      end
+    end
+
+    context "for a guest" do
+      context "for a trail with no trial video" do
+        it "renders a Visit Trail link" do
+          trail = create(:trail, :video)
+          allow(helper).to receive(:current_user).and_return(Guest.new)
+
+          html = helper.trail_call_to_action(trail)
+
+          expect(html).to include(I18n.t("trails.visit_trail"))
+          expect(html).to include(trail_path(trail))
+        end
+      end
+
+      context "for a trail with a trial video" do
+        it "renders an auth to access link" do
+          trail = create(:trail, :with_sample_video)
+          allow(helper).to receive(:current_user).and_return(Guest.new)
+
+          html = helper.trail_call_to_action(trail)
+
+          expect(html).to include(I18n.t("trails.start_for_free"))
+          expect(html).to include(video_auth_to_access_path(trail.videos.first))
+        end
+      end
+    end
+  end
 end

--- a/spec/models/guest_spec.rb
+++ b/spec/models/guest_spec.rb
@@ -9,6 +9,14 @@ describe Guest do
     end
   end
 
+  describe "#sampler?" do
+    it "returns false" do
+      guest = Guest.new
+
+      expect(guest.sampler?).to be_falsy
+    end
+  end
+
   describe "#admin?" do
     it "returns false" do
       guest = Guest.new

--- a/spec/models/trail_spec.rb
+++ b/spec/models/trail_spec.rb
@@ -264,7 +264,7 @@ describe Trail do
     end
   end
 
-  describe "#trial_video" do
+  describe "#sample_video" do
     context "with videos accessible without a subscription" do
       it "returns the first match" do
         trail = create(:trail)
@@ -299,7 +299,7 @@ describe Trail do
           ),
         )
 
-        result = trail.trial_video
+        result = trail.sample_video
 
         expect(result.map(&:name)).to eq("FirstAccessible".wrapped)
       end
@@ -314,7 +314,7 @@ describe Trail do
           completeable: create(:video, accessible_without_subscription: false),
         )
 
-        result = trail.trial_video
+        result = trail.sample_video
 
         expect(result).to be_blank
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,13 +117,14 @@ describe User do
     end
   end
 
-  context "#subscriber?" do
+  context "#subscriber?, #sampler?" do
     it "returns true if the user's associated subscription is active" do
       user = User.new
       subscription = build_stubbed(:active_subscription)
       allow(user).to receive(:subscriptions).and_return([subscription])
 
       expect(user.subscriber?).to eq(true)
+      expect(user.sampler?).to eq(false)
     end
 
     it "returns true with an active team subscription" do
@@ -140,6 +141,7 @@ describe User do
       user = User.new
       user.team = team
       expect(user.subscriber?).to eq(false)
+      expect(user.sampler?).to eq(true)
     end
 
     it "returns false if the user's associated subscription is not active" do
@@ -148,12 +150,14 @@ describe User do
       allow(user).to receive(:subscriptions).and_return([subscription])
 
       expect(user.subscriber?).to eq(false)
+      expect(user.sampler?).to eq(true)
     end
 
     it "returns false if the user doesn't even have a subscription" do
       user = User.new
 
       expect(user.subscriber?).to eq(false)
+      expect(user.sampler?).to eq(true)
     end
 
     context "with an inactive subscription and an active team subscription" do
@@ -161,10 +165,11 @@ describe User do
         user = create(
           :user,
           :with_inactive_subscription,
-          :with_team_subscription
+          :with_team_subscription,
         )
 
         expect(user.subscriber?).to eq(true)
+        expect(user.sampler?).to eq(false)
       end
     end
 
@@ -173,10 +178,11 @@ describe User do
         user = create(
           :user,
           :with_subscription,
-          :with_inactive_team_subscription
+          :with_inactive_team_subscription,
         )
 
         expect(user.subscriber?).to eq(true)
+        expect(user.sampler?).to eq(false)
       end
     end
 
@@ -185,10 +191,11 @@ describe User do
         user = create(
           :user,
           :with_inactive_subscription,
-          :with_inactive_team_subscription
+          :with_inactive_team_subscription,
         )
 
         expect(user.subscriber?).to eq(false)
+        expect(user.sampler?).to eq(true)
       end
     end
   end

--- a/spec/views/trails/_header.html.erb_spec.rb
+++ b/spec/views/trails/_header.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "trails/_header" do
       it "includes a 'Start for Free' button" do
         stub_signed_in false
         video = build_stubbed(:video)
-        trail = build_trail(trial_video: video)
+        trail = build_trail(sample_video: video)
 
         render_trail(trail)
 
@@ -21,7 +21,7 @@ describe "trails/_header" do
     context "when there are no trial videos in the trail" do
       it "does not include a 'Start for Free' button" do
         stub_signed_in false
-        trail = build_trail(trial_video: nil)
+        trail = build_trail(sample_video: nil)
 
         render_trail(trail)
 
@@ -42,9 +42,9 @@ describe "trails/_header" do
     have_css "a", text: I18n.t("trails.start_for_free")
   end
 
-  def build_trail(trial_video:)
+  def build_trail(sample_video:)
     build_stubbed(:trail).tap do |trail|
-      allow(trail).to receive(:trial_video).and_return(trial_video.wrapped)
+      allow(trail).to receive(:sample_video).and_return(sample_video.wrapped)
     end
   end
 end

--- a/spec/views/trails/_incomplete_trail.html.erb_spec.rb
+++ b/spec/views/trails/_incomplete_trail.html.erb_spec.rb
@@ -2,26 +2,21 @@ require "rails_helper"
 
 describe "trails/_incomplete_trail.html" do
   context "for a trail with only videos" do
-    it "renders a Start Trail link" do
-      render_trail completeables: [create(:video)]
+    it "renders a CTA link" do
+      view_stubs(:current_user).and_return(Guest.new)
+      video = create(:video)
 
-      expect(rendered).to have_start_trail_link
-    end
-  end
+      render_trail completeables: [video]
 
-  context "for a trail with only exercises" do
-    it "renders a Start Trail link" do
-      render_trail completeables: [create(:exercise)]
-
-      expect(rendered).to have_start_trail_link
+      expect(rendered).to have_cta_link
     end
   end
 
   context "for an empty trail" do
-    it "doesn't render a Start Trail link" do
+    it "doesn't render a CTA link" do
       render_trail completeables: []
 
-      expect(rendered).not_to have_start_trail_link
+      expect(rendered).not_to have_cta_link
     end
   end
 
@@ -46,7 +41,7 @@ describe "trails/_incomplete_trail.html" do
     )
   end
 
-  def have_start_trail_link
-    have_link("Start trail")
+  def have_cta_link
+    have_css(".cta-button")
   end
 end

--- a/spec/views/videos/_access_callout.html.erb_spec.rb
+++ b/spec/views/videos/_access_callout.html.erb_spec.rb
@@ -11,10 +11,8 @@ describe "videos/_access_callout" do
         expect(rendered).to have_content(
           I18n.t("videos.show.auth_to_access_callout_text")
         )
-        expect(rendered).to have_link(
-          I18n.t("videos.show.auth_to_access_button_text"),
-          href: video_auth_to_access_path(video),
-        )
+        expect(rendered).to have_css ".access-callout.auth-to-access"
+        expect(rendered).to have_auth_to_access_button_for(video)
       end
     end
 
@@ -58,6 +56,13 @@ describe "videos/_access_callout" do
         expect(rendered).to have_subscribe_cta
       end
     end
+  end
+
+  def have_auth_to_access_button_for(video)
+    have_link(
+      I18n.t("videos.show.auth_to_access_button_text"),
+      href: video_auth_to_access_path(video),
+    )
   end
 
   def render_callout(video, signed_out: false)


### PR DESCRIPTION
Makes the "Start Trial" button dynamic:
- If the user has a subscription, display "Start Trial" and link to the trail
- If the user does not have a subscription
  - and the trail has a trial video:
    - and the user is logged in: display "Start Trial" and link to the trail
    - and the user is logged out: display "Start Trial" and link to a login page before seeing the video
  - and the trial has _no_ trial video: display "Subscribe" and link to the new subscription page

https://trello.com/c/JUceElgQ/63-make-start-trail-button-a-subscribe-cta-for-samplers
