### PR TITLE
Add a script to auto-create markers for videos

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,12 +1,3 @@
 def find_user(email)
   User.find_by_email(email)
 end
-
-def create_video_markers(slug:, markers:)
-  Video.find_by(slug: slug).tap do |video|
-    markers.each do |anchor, time|
-      video.markers.find_or_create_by(anchor: anchor, time: time)
-    end
-  end
-end
-

--- a/bin/create-markers.rb
+++ b/bin/create-markers.rb
@@ -1,0 +1,42 @@
+#!./bin/rails runner
+
+# This script is designed to be run on Heroku, to create Markers for the Video
+# with a given slug.
+#
+# It assumes that it's receiving a Markdown document on STDIN with the marker
+# times in the headers, like:
+#
+#    ## Creating a database view 324
+#
+# Run it like this:
+#
+#   cat ../upcase-content/the-weekly-iteration/scenic.md | staging run ./bin/create-markers.rb cool-scenic-slug
+#
+# The slug is the `video.slug` in the database.
+
+renderer = Redcarpet::Markdown.new(
+  Redcarpet::Render::HTML.new(with_toc_data: true),
+  autolink: true,
+  tables: true,
+  fenced_code_blocks: true,
+  no_intra_emphasis: true,
+)
+
+video_slug = ARGV.first
+doc = Nokogiri::HTML(renderer.render(STDIN.read))
+
+# When we run `STDIN.read`, Heroku prints out everything it just read. In order
+# to separate that from error messages or output we actually care about, we
+# print blank lines.
+puts "\n" * 10
+
+video = Video.find_by!(slug: video_slug)
+doc.css("h1, h2, h3, h4, h5, h6").each do |header|
+  header[:id].scan(/^(.+)-(\d+)$/).each do |anchor, time|
+    video.markers.find_or_create_by!(anchor: anchor, time: time.to_i)
+  end
+end
+
+p video
+puts "\n==================================================\n"
+p video.markers


### PR DESCRIPTION
Instead of manually creating markers for videos, now we can pipe in a Markdown file, tell it which Video (by slug) we want to create markers for, and the script will parse it all out and create the markers for us.

The script expects the piped-in Markdown file to have the markers in a specific format (documented in the script).

Now that we have a script, we can remove `create_video_markers` from the `.irbrc`.
