### PR TITLE
User Reactivation if scheduled for deactivation

### DIFF
--- a/app/controllers/subscriber/reactivations_controller.rb
+++ b/app/controllers/subscriber/reactivations_controller.rb
@@ -1,0 +1,11 @@
+class Subscriber::ReactivationsController < ApplicationController
+  def create
+    reactivation = Reactivation.new(subscription: current_user.subscription)
+    reactivation.fulfill
+
+    redirect_to(
+      my_account_path,
+      notice: t("subscriptions.flashes.reactivate.success")
+    )
+  end
+end

--- a/app/models/reactivation.rb
+++ b/app/models/reactivation.rb
@@ -1,0 +1,9 @@
+class Reactivation
+  def initialize(subscription:)
+    @subscription = subscription
+  end
+
+  def fulfill
+    @subscription.reactivate
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -41,6 +41,10 @@ class Subscription < ActiveRecord::Base
     update_column(:deactivated_on, Time.zone.today)
   end
 
+  def reactivate
+    update_column(:scheduled_for_deactivation_on, nil)
+  end
+
   def change_plan(sku:)
     write_plan(sku: sku)
     change_stripe_plan(sku: sku)

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -3,6 +3,7 @@
     <p><strong><%= subscription.plan.name %></strong> <br /> Active since <%= subscription.created_at.to_s(:simple) %></p>
     <% if subscription.scheduled_for_deactivation? %>
       <p><%= t('subscriptions.deactivation_scheduled_on', date: subscription.scheduled_for_deactivation_on.to_s(:simple)) %></p>
+      <%= button_to t('subscriptions.reactivate'), subscriber_reactivation_path %>
     <% end %>
   <% else %>
     <p>Canceled on <%= subscription.deactivated_on.to_s(:simple) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,8 @@ en:
           balance has been applied to future invoices.
       discount:
         success: You've switched to a discounted subscription! Congrats.
+      reactivate:
+        success: Subscription successfully reactivated!
       subscription_required: You need a subscription to Upcase to access that feature.
       update:
         success: You have successfully updated your subscription credit card information.
@@ -189,6 +191,7 @@ en:
     reason: Why have you decided to leave?
     reason_explanation: This information will help us make Upcase better for future
       members.
+    reactivate: Reactivate!
     team_join_cta: Start Your Team
   teams:
     join_cta: Get your team started today

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Upcase::Application.routes.draw do
     resources :invoices, only: [:index, :show]
     resource :cancellation, only: [:new, :create]
     resource :discount, only: :create
+    resource :reactivation, only: :create
   end
 
   namespace :beta do

--- a/spec/features/user_reactivates_subscription_spec.rb
+++ b/spec/features/user_reactivates_subscription_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+feature "User reactivates subscription" do
+  scenario "after canceling, but before the grace period ends" do
+    sign_in_as_user_with_subscription
+    @current_user.subscription.update!(scheduled_for_deactivation_on: 1.month.from_now)
+    visit my_account_path
+
+    click_on I18n.t("subscriptions.reactivate")
+
+    expect(page).to have_content(I18n.t("subscriptions.flashes.reactivate.success"))
+  end
+end

--- a/spec/models/reactivation_spec.rb
+++ b/spec/models/reactivation_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Reactivation do
+  describe '#fulfill' do
+    it 'reactivates subscription' do
+      subscription = spy
+
+      reactivation = Reactivation.new(subscription: subscription)
+      reactivation.fulfill
+
+      expect(subscription).to have_received(:reactivate)
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -302,6 +302,16 @@ describe Subscription do
     end
   end
 
+  describe "#reactivate" do
+    it "unsets scheduled_for_deactivation_on" do
+      subscription = create(:subscription, scheduled_for_deactivation_on: 1.day.from_now)
+      subscription.reactivate
+      subscription.reload
+
+      expect(subscription.scheduled_for_deactivation_on).to be_nil
+    end
+  end
+
   def setup_cutomer
     stripe_customer = double(
       "StripeCustomer",


### PR DESCRIPTION
This is the result of a morning pairing exercise with web dev candidate Jevon Wild.

Previously, resubscribing required manual credit card entry.
This commit adds a "Reactivate" button on the my account page for users
who have canceled their subscription, but are still within the grace
period. Clicking this button un-schedules their subscription from
deactivation.

A future commit can extend this functionality to reactivate users whose
subscriptions have been fully deactivated.

This does introduce the slight chance of a race condition, wherein the
page was rendered prior to deactivation, and deactivation occurs before
clicking the button. In this case, the reactivation will not actually
succeed, although the user will be notified that it did.

https://trello.com/c/8pd5H3uc
