### PR TITLE
Fix warning about `config.serve_static_assets`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
       remotipart (~> 1.0)
       safe_yaml (~> 1.0)
       sass-rails (>= 4.0, < 6)
-    rails_serve_static_assets (0.0.2)
+    rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.3)
     railties (4.2.5.1)
       actionpack (= 4.2.5.1)


### PR DESCRIPTION
During `rake assets:precompile`, the `rails_serve_static_assets` gem was setting the (deprecated) `config.serve_static_assets` setting.

This upgrades it to a new version that correctly sets `config.serve_static_files` instead.

Here's the full text of the warning:

```
DEPRECATION WARNING: The configuration option `config.serve_static_assets`
has been renamed to `config.serve_static_files` to clarify its role (it
merely enables serving everything in the `public` folder and is unrelated
to the asset pipeline). The `serve_static_assets` alias will be removed in
Rails 5.0.
```
