### PR TITLE
Set the Video notes and markers at the same time

### DIFF
--- a/bin/create-notes-and-markers.rb
+++ b/bin/create-notes-and-markers.rb
@@ -1,7 +1,7 @@
 #!./bin/rails runner
 
-# This script is designed to be run on Heroku, to create Markers for the Video
-# with a given slug.
+# This script is designed to be run on Heroku, to set the notes and create
+# Markers for the Video with a given slug.
 #
 # It assumes that it's receiving a Markdown document on STDIN with the marker
 # times in the headers, like:
@@ -10,7 +10,7 @@
 #
 # Run it like this:
 #
-#   cat ../upcase-content/the-weekly-iteration/scenic.md | staging run ./bin/create-markers.rb cool-scenic-slug
+#   cat ../upcase-content/weekly-iteration-notes/scenic.md | staging run ./bin/create-notes-and-markers.rb cool-scenic-slug
 #
 # The slug is the `video.slug` in the database.
 
@@ -23,20 +23,24 @@ renderer = Redcarpet::Markdown.new(
 )
 
 video_slug = ARGV.first
-doc = Nokogiri::HTML(renderer.render(STDIN.read))
-
+raw_notes = STDIN.read
 # When we run `STDIN.read`, Heroku prints out everything it just read. In order
 # to separate that from error messages or output we actually care about, we
 # print blank lines.
 puts "\n" * 10
 
+doc = Nokogiri::HTML(renderer.render(raw_notes))
+# Remove the timestamps from the end of the headers
+notes = raw_notes.gsub(/^(##+ .+) \d+$/, '\1')
+
 video = Video.find_by!(slug: video_slug)
+video.update!(notes: notes)
+
 doc.css("h1, h2, h3, h4, h5, h6").each do |header|
   header[:id].scan(/^(.+)-(\d+)$/).each do |anchor, time|
     video.markers.find_or_create_by!(anchor: anchor, time: time.to_i)
   end
 end
 
-p video
 puts "\n==================================================\n"
-p video.markers
+puts "!!! Don't forget to set a summary: https://#{ENV.fetch("APP_DOMAIN")}/admin/video/#{video.id}/edit"


### PR DESCRIPTION
Given headers with a timestamp at the end like `## Foo bar 23`, we strip out the timestamp when setting the notes so users won't see the timestamp.
