### PR TITLE
Remove notifications:upcase_welcome task

### DIFF
--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,6 +1,0 @@
-namespace :notifications do
-  desc 'Send welcome emails to those who subscribed to upcase in the last 24 hours'
-  task upcase_welcome: :environment do
-    Subscription.deliver_welcome_emails
-  end
-end


### PR DESCRIPTION
- `Subscriptions.deliver_welcome_emails` was removed in 2be3514092b87fbe7056ba02142625362ae182e3
- We deliver welcome emails with Intercom now
