### PR TITLE
User property tracking improvements

### DIFF
--- a/spec/services/stripe_events_spec.rb
+++ b/spec/services/stripe_events_spec.rb
@@ -2,61 +2,84 @@ require "rails_helper"
 
 describe StripeEvents do
   describe "#customer_subscription_deleted" do
-    it "sends notifications if no subscription is found" do
-      allow(Honeybadger).to receive(:notify)
+    context "no local subscription record found" do
+      it "sends notifications if no subscription is found" do
+        allow(Honeybadger).to receive(:notify)
 
-      StripeEvents.new(event).customer_subscription_deleted
+        StripeEvents.new(event).customer_subscription_deleted
 
-      expect(Honeybadger).to have_received(:notify).once
+        expect(Honeybadger).to have_received(:notify).once
+      end
     end
 
-    it "cancels plan if subscription found" do
-      subscription = stub_subscription
-      cancellation = spy("Cancellation")
-      allow(Cancellation).to receive(:new).and_return(cancellation)
+    context "when a local subscription record is found" do
+      it "processes the cancellation" do
+        subscription = stub_subscription
+        cancellation = stub_cancellation
 
-      StripeEvents.new(event).customer_subscription_deleted
+        StripeEvents.new(event).customer_subscription_deleted
 
-      expect(Cancellation).to(
-        have_received(:new).
-        with(subscription: subscription)
-      )
-      expect(cancellation).to have_received(:process).once
+        expect(Cancellation).to have_received(:new).
+          with(subscription: subscription)
+        expect(cancellation).to have_received(:process).once
+      end
+
+      it "tracks the user's updated properties" do
+        stub_subscription
+        stub_cancellation
+        tracker = stub_analytics
+
+        StripeEvents.new(event).customer_subscription_deleted
+
+        expect(tracker).to have_received(:track_updated)
+      end
     end
   end
 
   describe "#customer_subscription_updated" do
-    it "sends notifications if no local subscription is found" do
-      allow(Honeybadger).to receive(:notify)
+    context "no local subscription record found" do
+      it "sends notifications if no local subscription is found" do
+        allow(Honeybadger).to receive(:notify)
 
-      StripeEvents.new(event).customer_subscription_updated
+        StripeEvents.new(event).customer_subscription_updated
 
-      expect(Honeybadger).to have_received(:notify).once
+        expect(Honeybadger).to have_received(:notify).once
+      end
     end
 
-    it "updates subscription plan if local subscription found" do
-      subscription = stub_subscription
-      updater = spy("Updater")
-      allow(SubscriptionUpcomingInvoiceUpdater).to receive(:new).
-        and_return(updater)
+    context "when a local subscription record is found" do
+      it "updates subscription plan if local subscription found" do
+        subscription = stub_subscription
+        updater = stub_invoice_updater
 
-      StripeEvents.new(event).customer_subscription_updated
+        StripeEvents.new(event).customer_subscription_updated
 
-      expect(subscription).to have_received(:write_plan).
-        with(sku: FakeStripe::PLAN_ID)
-      expect(SubscriptionUpcomingInvoiceUpdater).
-        to have_received(:new).with([subscription])
-      expect(updater).to have_received(:process).once
+        expect(subscription).to have_received(:write_plan).
+          with(sku: FakeStripe::PLAN_ID)
+        expect(SubscriptionUpcomingInvoiceUpdater).
+          to have_received(:new).with([subscription])
+        expect(updater).to have_received(:process).once
+      end
+
+      it "tracks the user's updated properties" do
+        stub_subscription
+        stub_invoice_updater
+        tracker = stub_analytics
+
+        StripeEvents.new(event).customer_subscription_updated
+
+        expect(tracker).to have_received(:track_updated)
+      end
     end
   end
 
   private
 
   def stub_subscription
-    subscription = build_stubbed(:subscription)
-    allow(Subscription).to receive(:find_by).and_return(subscription)
-    allow(subscription).to receive(:write_plan)
-    subscription
+    build_stubbed(:subscription).tap do |subscription|
+      allow(Subscription).to receive(:find_by).and_return(subscription)
+      allow(subscription).to receive(:write_plan)
+    end
   end
 
   def event
@@ -73,5 +96,23 @@ describe StripeEvents do
       id: FakeStripe::SUBSCRIPTION_ID,
       plan: double("Plan", id: FakeStripe::PLAN_ID)
     )
+  end
+
+  def stub_cancellation
+    stub_instance_as_spy Cancellation
+  end
+
+  def stub_analytics
+    stub_instance_as_spy Analytics
+  end
+
+  def stub_invoice_updater
+    stub_instance_as_spy SubscriptionUpcomingInvoiceUpdater
+  end
+
+  def stub_instance_as_spy(class_to_stub)
+    spy(class_to_stub.to_s).tap do |instance|
+      allow(class_to_stub).to receive(:new).and_return(instance)
+    end
   end
 end


### PR DESCRIPTION
We use the `track_updated` method to publish user properties out via Segment, getting them into systems like Intercom, Amplitude, and Drip. Unfortunately this method currently only fires when a user logs in. Typically users do not log in after canceling meaning that our edge systems have an incorrect view of a users `subscriber?` status.

This change fires `track_updated` when we receive any Stripe webhook related to subscription changes, which will help keep the edge systems in sync.
