### PR TITLE
Use official `flex` style to avoid warnings

### DIFF
--- a/app/assets/stylesheets/_exercises-and-teachers.scss
+++ b/app/assets/stylesheets/_exercises-and-teachers.scss
@@ -1,11 +1,11 @@
 .exercises-and-teachers {
-  @include display(flex);
-  @include flex-wrap(wrap);
-  @include justify-content(space-between);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
 
   .exercises-container {
-    @include flex-basis(33em);
-    @include flex-shrink(1);
+    flex-basis: 33em;
+    flex-shrink: 1;
     margin: 1em;
 
     .divider {
@@ -38,9 +38,9 @@
   }
 
   .text-box-wrapper {
-    @include flex-basis(9em);
-    @include flex-shrink(1);
-    @include flex-grow(1);
+    flex-basis: 9em;
+    flex-grow: 1;
+    flex-shrink: 1;
     margin: 1em;
 
     .text-box h5 {

--- a/app/assets/stylesheets/landing/_price.scss
+++ b/app/assets/stylesheets/landing/_price.scss
@@ -137,15 +137,15 @@ $pricing-margin: 0.5rem;
 }
 
 .price-cta {
-  @include display(flex);
-  @include flex-wrap(wrap);
-  @include justify-content(space-between);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   text-align: center;
 
   a {
-    @include flex-basis(12em);
-    @include flex-shrink(0);
-    @include flex-grow(1);
+    flex-basis: 12em;
+    flex-grow: 1;
+    flex-shrink: 0;
     margin: $pricing-margin;
   }
 }


### PR DESCRIPTION
Previously we've used Bourbon to handle vendor-prefixing, but our current
practice is to use autoprefixer-rails. Currently we have a combination in
Upcase, and autoprefixer emits a warning with the test suite output about the
use of an un-supported syntax for flexbox (see below)

This change removes the Bourbon mixin usage for all flexbox functionality,
relying on autoprefixer to do its magic, and cleaning up the test output. Yay!

```
Randomized with seed 56306
.........................autoprefixer: /upcase/app/assets/stylesheets/application.scss:6014:3: You should write display: flex by final spec instead of display: box
autoprefixer: /upcase/app/assets/stylesheets/application.scss:7641:3: You should write display: flex by final spec instead of display: box
.................................................................................................................................................................................
```
