### PR TITLE
Track account created via analytics

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -32,6 +32,10 @@ class Analytics
     backend.identify(user_id: user.id, traits: identify_hash(user))
   end
 
+  def track_account_created
+    track("Account created")
+  end
+
   def track_searched(query:, results_count:)
     track("Searched", query: query, results_count: results_count)
   end

--- a/app/services/auth_hash_service.rb
+++ b/app/services/auth_hash_service.rb
@@ -35,6 +35,7 @@ class AuthHashService
   def create_from_auth_hash
     create_user.tap do |user|
       promote_thoughtbot_employee_to_admin(user)
+      track_account_created(user)
     end
   end
 
@@ -66,6 +67,10 @@ class AuthHashService
       user.admin = true
       user.save!
     end
+  end
+
+  def track_account_created(user)
+    Analytics.new(user).track_account_created
   end
 
   def octokit_client

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -308,4 +308,12 @@ describe Analytics do
         )
     end
   end
+
+  describe "#track_account_created" do
+    it "tracks that a new account was created" do
+      analytics_instance.track_account_created
+
+      expect(analytics).to have_tracked("Account created").for_user(user)
+    end
+  end
 end

--- a/spec/services/auth_hash_service_spec.rb
+++ b/spec/services/auth_hash_service_spec.rb
@@ -34,6 +34,16 @@ describe AuthHashService, '#find_or_create_user_from_auth_hash' do
     expect(user).to be_admin
   end
 
+  context "when a new account is created" do
+    it "notififes analytics of account_created" do
+      tracker = stub_analytics_tracker
+
+      AuthHashService.new(auth_hash).find_or_create_user_from_auth_hash
+
+      expect(tracker).to have_received(:track_account_created)
+    end
+  end
+
   context 'with an existing user' do
     it "finds the user by email" do
       existing_user = create(:user, email: auth_hash["info"]["email"])
@@ -61,6 +71,15 @@ describe AuthHashService, '#find_or_create_user_from_auth_hash' do
       expect(existing_user).to eq AuthHashService.new(auth_hash).
         find_or_create_user_from_auth_hash
     end
+
+    it "does not track account_created" do
+      tracker = stub_analytics_tracker
+      create_user_with_github_auth
+
+      AuthHashService.new(auth_hash).find_or_create_user_from_auth_hash
+
+      expect(tracker).not_to have_received(:track_account_created)
+    end
   end
 
   def stub_team_member(return_value)
@@ -83,5 +102,16 @@ describe AuthHashService, '#find_or_create_user_from_auth_hash' do
         'nickname' => 'thoughtbot',
       }
     }.merge(options)
+  end
+
+  def stub_analytics_tracker
+    double("Analytics").tap do |tracker|
+      allow(tracker).to receive(:track_account_created)
+      allow(Analytics).to receive(:new).and_return(tracker)
+    end
+  end
+
+  def create_user_with_github_auth
+    create(:user, auth_provider: "github", auth_uid: auth_hash["uid"])
   end
 end


### PR DESCRIPTION
We want to be able to follow up with all new users (non-subscribers) to welcome
them to Upcase and describe the content we have. We only want to do this when
they first subscribe, so this new event will provide us a unique hook.
