### PR TITLE
Track authentications on the checkout page

### DIFF
--- a/app/controllers/authenticated_on_checkouts_controller.rb
+++ b/app/controllers/authenticated_on_checkouts_controller.rb
@@ -1,0 +1,20 @@
+class AuthenticatedOnCheckoutsController < ApplicationController
+  def show
+    set_authenticated_on_checkout_page_flag
+    redirect_to github_auth_with_checkout_origin_path
+  end
+
+  private
+
+  def set_authenticated_on_checkout_page_flag
+    session[:authenticated_on_checkout] = true
+  end
+
+  def github_auth_with_checkout_origin_path
+    github_auth_path(origin: new_checkout_path(plan: plan))
+  end
+
+  def plan
+    Plan.find_by!(sku: params[:plan])
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -48,6 +48,10 @@ class Analytics
     track("Logged into Forum")
   end
 
+  def track_authenticated_on_checkout
+    track("Authenticated on checkout")
+  end
+
   def track_cancelled(reason:)
     track("Cancelled", reason: reason)
   end

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -13,7 +13,7 @@
           <%= link_to "Already have an account? Sign in",
                       sign_in_path(return_to: request.fullpath), class: "cta-button secondary-button" %>
         </li>
-        <li><%= link_to "Sign up with GitHub", github_auth_path, class: "cta-button secondary-button" %></li>
+        <li><%= link_to "Sign up with GitHub", authenticated_on_checkout_path(plan: checkout.plan), class: "cta-button secondary-button" %></li>
       </ul>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Upcase::Application.routes.draw do
   get "/terms" => "pages#show", as: :terms, id: "terms"
 
   scope ":plan" do
+    resource :authenticated_on_checkout, only: [:show]
     resources :checkouts, only: [:new, :create]
   end
 

--- a/spec/controllers/authenticated_on_checkouts_controller_spec.rb
+++ b/spec/controllers/authenticated_on_checkouts_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe AuthenticatedOnCheckoutsController do
+  context "#show" do
+    it "records that the user authenticated on checkout" do
+      get :show, plan: create(:plan)
+
+      expect(session[:authenticated_on_checkout]).to eq(true)
+    end
+
+    it "redirects to github auth with a proper origin param" do
+      plan = create(:plan)
+      plan_checkout_origin = { "origin" => new_checkout_path(plan: plan) }
+
+      get :show, plan: plan.sku
+
+      expect(response).to redirect_to(%r{/auth/github})
+      expect(response_query_params).to include(plan_checkout_origin)
+    end
+  end
+
+  def response_query_params
+    parsed_uri = URI.parse(response.location)
+    unescaped_query_params = URI.unescape(parsed_uri.query || "")
+    Hash[unescaped_query_params.split("&").map { |q| q.split("=") }]
+  end
+end

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -127,6 +127,15 @@ feature 'Visitor signs up for a subscription' do
     expect_to_see_checkout_success_flash
   end
 
+  scenario "analytics is notififed when a user auths on the checkout page" do
+    attempt_to_subscribe
+    click_link "with GitHub"
+
+    expect_to_be_on_checkout_page
+
+    expect(analytics).to have_tracked("Authenticated on checkout")
+  end
+
   def expect_error_on_github_username_field
     expect(github_username_field[:class]).to include("error")
   end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -209,6 +209,16 @@ describe Analytics do
     end
   end
 
+  describe "#track_authenticated_on_checkout" do
+    it "tracks that the user authenticated on the checkout page" do
+      analytics_instance.track_authenticated_on_checkout
+
+      expect(analytics).to(
+        have_tracked("Authenticated on checkout").for_user(user),
+      )
+    end
+  end
+
   describe "#track_cancelled" do
     it "tracks that the user cancelled along with the reason and email" do
       analytics_instance.track_cancelled(reason: "No good")


### PR DESCRIPTION
This will allow us to follow up with users who begin the checkout process but
don't complete it.
