### PR TITLE
Add contact links

### DIFF
--- a/app/assets/stylesheets/_users-edit.scss
+++ b/app/assets/stylesheets/_users-edit.scss
@@ -9,6 +9,10 @@ body.users-edit {
     font-size: 1em;
   }
 
+  .contact {
+    margin-top: $medium-spacing;
+  }
+
   #account-sidebar {
     a {
       font-size: $font-size-small;;

--- a/app/assets/stylesheets/layout/_layout.scss
+++ b/app/assets/stylesheets/layout/_layout.scss
@@ -26,7 +26,8 @@ section {
   width: 100%;
 
   .text-box-wrapper {
-    @include span-columns(12);
+    @include span-columns(8.5);
+    margin-right: 3%;
     position: relative;
 
     &:before {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -14,14 +14,11 @@
           <li>
             <%= link_to "Upcase source code on GitHub", repositories_path %>
           </li>
-        <% else %>
-          <li>
-            <%= mail_to ENV["SUPPORT_EMAIL"], "Contact us" %>
-          </li>
         <% end %>
         <li><a href="http://thoughtbot.com">About thoughtbot</a></li>
         <li><%= link_to "Privacy Policy", privacy_path %></li>
         <li><%= link_to "Terms & Conditions", terms_path %></li>
+        <li><%= mail_to ENV["SUPPORT_EMAIL"], t("footer.contact_us") %></li>
       </ul>
     </section>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -53,4 +53,10 @@
     <h3>Your Team</h3>
     <%= render current_team %>
   <% end %>
+
+  <div class="contact">
+    <h3><%= t(".have_any_questions") %></h3>
+    <p><%= t(".here_to_help") %></p>
+    <%= mail_to ENV.fetch("SUPPORT_EMAIL"), t(".contact_us"), class: "cta-button" %>
+  </div>
 </aside>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,8 @@ en:
       next-flashcard: Next Flashcard
       numbered-title: Flashcard %{position} of %{total}
       return-to-results: Return to Flashcard Results
+  footer:
+    contact_us: Contact us
   formtastic:
     labels:
       acceptance:
@@ -228,6 +230,10 @@ en:
     flashes:
       update:
         success: Your profile has been updated.
+    edit:
+      have_any_questions: Have any questions?
+      here_to_help: We're here to help, so feel free to send any questions in and we'll get back to you right away.
+      contact_us: Contact us
   videos:
     show:
       mark-as-complete: Mark as Complete

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -38,15 +38,6 @@ describe "shared/_footer.html.erb" do
       expect(rendered).to have_content("Upcase source code")
     end
 
-    it "does not show the contact us link" do
-      view_stub_with_return(signed_in?: true)
-      view_stub_with_return(current_user: create(:user))
-
-      render
-
-      expect(rendered).not_to have_content("Contact us")
-    end
-
     it "does show a sign out link" do
       view_stub_with_return(signed_in?: true)
       view_stub_with_return(current_user: create(:user))


### PR DESCRIPTION
This change adds a contact button to the account page, and updates the footer "Contact Us" link to be shown to all users, signed in or signed out.

![image](https://cloud.githubusercontent.com/assets/420113/13987384/b1d3a47a-f0dd-11e5-9af1-cb40032c5e3f.png)
