### PR TITLE
Set return_to path to current_path on sign in links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,4 +62,8 @@ module ApplicationHelper
     titleable.page_title.presence ||
       t("dynamic_page_titles.#{type}", name: titleable.name)
   end
+
+  def sign_in_path_with_current_path_return_to
+    sign_in_path(return_to: request.fullpath)
+  end
 end

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -13,7 +13,7 @@
       <ul class="checkout-signin-signup-toggle">
         <li>
           <%= link_to "Already have an account? Sign in",
-                      sign_in_path(return_to: request.fullpath), class: "cta-button secondary-button" %>
+                      sign_in_path_with_current_path_return_to, class: "cta-button secondary-button" %>
         </li>
         <li><%= link_to "Sign up with GitHub", authenticated_on_checkout_path(plan: checkout.plan), class: "cta-button secondary-button" %></li>
       </ul>

--- a/app/views/layouts/_marketing_header_links.html.erb
+++ b/app/views/layouts/_marketing_header_links.html.erb
@@ -15,7 +15,7 @@
 
   <% if signed_out? %>
     <li>
-      <%= link_to t("shared.header.sign_in"), sign_in_path %>
+      <%= link_to t("shared.header.sign_in"), sign_in_path_with_current_path_return_to %>
     </li>
   <% end %>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,7 +5,7 @@
         <li><%= link_to("Sign out", sign_out_path, method: :delete) %></li>
         <li><%= render partial: "shared/admin_sign_out" %></li>
       <% else %>
-        <li><%= link_to "Sign in", sign_in_path %></li>
+        <li><%= link_to "Sign in", sign_in_path_with_current_path_return_to %></li>
       <% end %>
     </ul>
     <section class="thoughtbot">

--- a/spec/features/visitor_views_weekly_iteration_spec.rb
+++ b/spec/features/visitor_views_weekly_iteration_spec.rb
@@ -23,6 +23,18 @@ feature "Visitor" do
     expect(page).to have_subscribe_cta
   end
 
+  scenario "navigates directly to a video and signs in" do
+    show = create(:the_weekly_iteration)
+    video = create_video(show)
+    desired_video_path = video_path(video)
+
+    visit desired_video_path
+    click_link "Sign In"
+    click_link "Sign in with GitHub"
+
+    expect(current_path).to eq(desired_video_path)
+  end
+
   def create_video(show)
     name_with_unsafe_character = "Unfriendly Nil's Unfriendly"
     create(


### PR DESCRIPTION
When a user is on a page and signs on, they typically want to be returned to
that page. As an example, when we send out emails to users with links to Weekly
Iteration videos or new trails, many existing users will click through and be in
a signed out state. Currently, when they sign in, they are taken to the
/practice page.

This change appends the `return_to` param to all Sign In links to correspond to
the current_path such that the user will return to that page after signing in.
