### PR TITLE
Update the Megamenu

### DIFF
--- a/app/assets/stylesheets/landing/_table-of-contents.scss
+++ b/app/assets/stylesheets/landing/_table-of-contents.scss
@@ -18,11 +18,26 @@
   }
 }
 
-.table-of-contents-container {
+.table-of-contents-outer-container {
   @include outer-container;
-  padding: 2em 0;
   position: relative;
+  margin-top: $base-spacing;
 
+  h2 {
+    padding-bottom: $medium-spacing;
+
+    @include marketing-mobile {
+      padding-bottom: $base-spacing;
+    }
+  }
+
+  .see-all a {
+    font-style: italic;
+    font-weight: 500;
+  }
+}
+
+.table-of-contents-container {
   h3 a {
     color: $darkwarmgray;
   }
@@ -44,6 +59,14 @@
     }
   }
 
+  li {
+    margin-bottom: 0.4em;
+
+    @include marketing-mobile {
+      margin-bottom: 0.7em;
+    }
+  }
+
   img {
     @include position(absolute, -0.5em 0 0 0px);
     @include size(3em);
@@ -51,11 +74,9 @@
 }
 
 .table-of-contents-close {
-  @include position(absolute, 0px 0px 0 0);
   color: $gray-3;
+  float: right;
   font-size: 2em;
-  height: 2em;
-  width: 2em;
 
   &:hover,
   &:focus {

--- a/app/views/shared/_table_of_contents.html.erb
+++ b/app/views/shared/_table_of_contents.html.erb
@@ -1,148 +1,176 @@
 <section class="table-of-contents" data-role="table-of-contents">
-  <div class="table-of-contents-container">
-    <ul>
-      <li>
-        <%= image_tag "topics/clean-code.svg" %>
-        <h3><%= link_to "Clean Code", "/clean-code" %></h3>
-      </li>
-      <li>
-        <%= link_to "Refactoring", "/refactoring" %>
-      </li>
-      <li>
-        <%= link_to "Form Objects", "/videos/form_objects" %>
-      </li>
-      <li>
-        <%= link_to "Ruby Science: Move Method", "/videos/ruby-science-move-method" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/workflow.svg" %>
-        <h3><%= link_to "Workflow", "/workflow" %></h3>
-      </li>
-      <li>
-        <%= link_to "tmux", "/tmux" %>
-      </li>
-      <li>
-        <%= link_to "Git Workflow", "/videos/git-workflow" %>
-      </li>
-      <li>
-        <%= link_to "Part 4: Vim Integration", "/videos/tmux-vim-integration" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/vim.svg" %>
-        <h3><%= link_to "Vim", "/vim" %></h3>
-      </li>
-      <li>
-        <%= link_to "Navigating Ruby Files with Vim", "/navigating-ruby-files-with-vim" %>
-      </li>
-      <li>
-        <%= link_to "The Art of Vim", "/the-art-of-vim" %>
-      </li>
-      <li>
-        <%= link_to "Onramp to Vim", "/onramp-to-vim" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/rails.svg" %>
-        <h3><%= link_to "Ruby on Rails", "/rails" %></h3>
-      </li>
-      <li>
-        <%= link_to "Advanced ActiveRecord Querying", "/advanced-activerecord-querying" %>
-      </li>
-      <li>
-        <%= link_to "Test-Driven Rails", "/test-driven-rails" %>
-      </li>
-      <li>
-        <%= link_to "Form Objects", "/videos/form_objects" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/ios.svg" %>
-        <h3><%= link_to "iOS", "/ios" %></h3>
-      </li>
-      <li>
-        <%= link_to "You got your Objective-C in My Swift!", "/videos/you-got-your-objective-c-in-my-swift" %>
-      </li>
-      <li>
-        <%= link_to "Property-Based Testing in Swift", "/videos/property-based-testing-in-swift" %>
-      </li>
-      <li>
-        <%= link_to "Swift First Impressions", "/videos/swift-first-impressions" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/haskell.svg" %>
-        <h3><%= link_to "Haskell", "/haskell" %></h3>
-      </li>
-      <li>
-        <%= link_to "Haskell: Intro to Functions", "/videos/haskell-intro-to-functions" %>
-      </li>
-      <li>
-        <%= link_to "Haskell: Intro to Types", "/videos/haskell-intro-to-types" %>
-      </li>
-      <li>
-        <%= link_to "Haskell: Pattern Matching", "/videos/haskell-pattern-matching" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/testing.svg" %>
-        <h3><%= link_to "Testing", "/testing" %></h3>
-      </li>
-      <li>
-        <%= link_to "Testing Fundamentals", "/testing-fundamentals" %>
-      </li>
-      <li>
-        <%= link_to "Test Doubles", "/test-doubles" %>
-      </li>
-      <li>
-        <%= link_to "Route, Controller, Action", "/videos/route-controller-action" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/javascript.svg" %>
-        <h3><%= link_to "JavaScript", "/javascript" %></h3>
-      </li>
-      <li>
-        <%= link_to "Intro to React", "/videos/intro-to-react" %>
-      </li>
-      <li>
-        <%= link_to "Intro to Ember", "/videos/intro-to-ember" %>
-      </li>
-      <li>
-        <%= link_to "Unit Testing JavaScript", "/videos/unit-testing-javascript" %>
-      </li>
-    </ul>
-
-    <ul>
-      <li>
-        <%= image_tag "topics/design.svg" %>
-        <h3><%= link_to "Design", "/design" %></h3>
-      </li>
-      <li>
-        <%= link_to "Design for Developers", "/design-for-developers" %>
-      </li>
-      <li>
-        <%= link_to "The Playbook: Video Edition", "/the-playbook-video-edition" %>
-      </li>
-      <li>
-        <%= link_to "Serving Your Front-End", "/videos/serving-your-front-end" %>
-      </li>
-    </ul>
+  <div class="table-of-contents-outer-container">
     <a href="#" class="table-of-contents-close" data-role="table-of-contents-close">&times;</a>
+    <h2>15 Full Courses, 100+ Screencasts &amp; New Content Weekly</h2>
+    <div class="table-of-contents-container">
+      <ul>
+        <li>
+          <%= image_tag "topics/rails.svg" %>
+          <h3><%= link_to "Master Rails", "/rails" %></h3>
+        </li>
+        <li>
+          <%= link_to "Advanced ActiveRecord Querying", "/advanced-activerecord-querying" %>
+        </li>
+        <li>
+          <%= link_to "Test-Driven Rails", "/test-driven-rails" %>
+        </li>
+        <li>
+          <%= link_to "Form Objects", "/videos/form_objects" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all Rails content...", "/rails" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/vim.svg" %>
+          <h3><%= link_to "Learn Vim", "/vim" %></h3>
+        </li>
+        <li>
+          <%= link_to "Onramp to Vim", "/onramp-to-vim" %>
+        </li>
+        <li>
+          <%= link_to "The Art of Vim", "/the-art-of-vim" %>
+        </li>
+        <li>
+          <%= link_to "Navigating Ruby in Vim", "/navigating-ruby-files-with-vim" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all Vim content...", "/vim" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/workflow.svg" %>
+          <h3><%= link_to "Seamless Workflow", "/workflow" %></h3>
+        </li>
+        <li>
+          <%= link_to "Learn tmux", "/tmux" %>
+        </li>
+        <li>
+          <%= link_to "Introduction to Dotfiles", "/videos/intro-to-dotfiles" %>
+        </li>
+        <li>
+          <%= link_to "Vim Integration with tmux", "/videos/tmux-vim-integration" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all workflow content...", "/workflow" %>
+        </li>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/testing.svg" %>
+          <h3><%= link_to "Ruby Testing", "/testing" %></h3>
+        </li>
+        <li>
+          <%= link_to "Testing Fundamentals", "/testing-fundamentals" %>
+        </li>
+        <li>
+          <%= link_to "Test Doubles", "/test-doubles" %>
+        </li>
+        <li>
+          <%= link_to "Route, Controller, Action", "/videos/route-controller-action" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all testing content...", "/testing" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/workflow.svg" %>
+          <h3><%= link_to "Up Your Git Game", "/git" %></h3>
+        </li>
+        <li>
+          <%= link_to "Mastering Git", "/mastering-git" %>
+        </li>
+        <li>
+          <%= link_to "Git Workflow", "/videos/git-workflow" %>
+        </li>
+        <li>
+          <%= link_to "Git/Vim Integration", "/videos/git-vim-and-git" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all Git content...", "/git" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/clean-code.svg" %>
+          <h3><%= link_to "Cleaner Ruby", "/clean-code" %></h3>
+        </li>
+        <li>
+          <%= link_to "Refactoring", "/refactoring" %>
+        </li>
+        <li>
+          <%= link_to "Form Objects", "/videos/form_objects" %>
+        </li>
+        <li>
+          <%= link_to "Ruby Science: Move Method", "/videos/ruby-science-move-method" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all clean code content...", "/clean-code" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/javascript.svg" %>
+          <h3><%= link_to "Learn JavaScript", "/javascript" %></h3>
+        </li>
+        <li>
+          <%= link_to "Intro to React", "/videos/intro-to-react" %>
+        </li>
+        <li>
+          <%= link_to "Intro to Ember", "/videos/intro-to-ember" %>
+        </li>
+        <li>
+          <%= link_to "Unit Testing JavaScript", "/videos/unit-testing-javascript" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all JavaScript content...", "/javascript" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/foundations.svg" %>
+          <h3>Fix Your Code</h3>
+        </li>
+        <li>
+          <%= link_to "Chrome Dev Tools", "/videos/chrome-dev-tools" %>
+        </li>
+        <li>
+          <%= link_to "Debugging", "/videos/debugging-for-fun-and-profit" %>
+        </li>
+        <li>
+          <%= link_to "Code Review", "/videos/tips-for-code-review" %>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <%= image_tag "topics/design.svg" %>
+          <h3><%= link_to "Explore Design", "/design" %></h3>
+        </li>
+        <li>
+          <%= link_to "Design for Developers", "/design-for-developers" %>
+        </li>
+        <li>
+          <%= link_to "The Playbook: Video Edition", "/the-playbook-video-edition" %>
+        </li>
+        <li>
+          <%= link_to "Serving Your Front-End", "/videos/serving-your-front-end" %>
+        </li>
+        <li class="see-all">
+          <%= link_to "See all design content...", "/design" %>
+        </li>
+      </ul>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
- Remove Haskell and iOS
- Focus on workflow, git, vim, Rails
- Add a link to the flashcards

There is now an outer container on the table of contents to contain the h2
header without breaking the `omega(2n)` calculations that set up a nice grid of
topics.

https://trello.com/c/Nxa84IV9
