### PR TITLE
Update the checkout to emphasize GitHub signin

### DIFF
--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -26,10 +26,3 @@ function checkValidGithubUsername(username, element) {
       }
   });
 }
-
-$('.reveal-address').click(function() {
-  $(this).hide();
-  $('.address-info').slideDown(100);
-
-  return false;
-});

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -51,9 +51,9 @@
   }
 
   img {
-    float: left;
     margin-right: 0.8em;
     max-height: 1.4em;
+    vertical-align: middle;
   }
 }
 

--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -5,6 +5,23 @@ body.checkouts-new, body.checkouts-create {
     @include marketing-mobile {
       flex-direction: column;
     }
+
+    .github-auth {
+      .username-password {
+        display: none;
+      }
+
+      #billing-information,
+      .actions {
+        display: none;
+      }
+    }
+
+    .username-password-auth {
+      .github-or-sign-in-buttons {
+        display: none;
+      }
+    }
   }
 
   nav,
@@ -69,7 +86,7 @@ body.checkouts-new, body.checkouts-create {
     margin-bottom: 0;
   }
 
-  .checkout-signin-signup-toggle {
+  .github-or-sign-in-buttons ul {
     display: table;
     margin-bottom: 2em;
     width: 100%;
@@ -81,16 +98,10 @@ body.checkouts-new, body.checkouts-create {
     }
 
     a {
-      background: #f0f0f0;
-      border-radius: 3px;
       display: block;
       margin: 2px;
       padding: 1em;
       text-align: center;
-
-      &:active {
-        background: #ccc;
-      }
     }
   }
 
@@ -153,9 +164,32 @@ body.checkouts-new, body.checkouts-create {
     }
   }
 
-  .address-info {
-    display: none;
-    margin: 3rem 0;
+  .address-fields-wrapper {
+    .address-info,
+    .hide-address {
+      display: none;
+    }
+
+    .reveal-address {
+      display: block;
+      font-style: italic;
+      font-weight: lighter;
+    }
+
+    &.displayed {
+      .address-info {
+        display: block;
+        margin: 3rem 0;
+      }
+
+      .reveal-address {
+        display: none;
+      }
+
+      .hide-address {
+        display: block;
+      }
+    }
   }
 
   .coupon {
@@ -181,12 +215,6 @@ body.checkouts-new, body.checkouts-create {
     }
   }
 
-  .reveal-address {
-    display: block;
-    font-weight: normal;
-    margin: 10px 0;
-  }
-
   @media screen and (max-width: 910px) {
     fieldset ol, #billing-information ol {
       li#checkout_zip_code_input,
@@ -207,12 +235,14 @@ body.checkouts-new, body.checkouts-create {
 }
 
 #billing-information {
-  background-color: $base-background-1;
-  border: 1px solid $base-border-color-1;
-  border-radius: 3px;
-  width: 100%;
-  margin: em(20) 0;
-  padding: em(20);
+  fieldset {
+    background-color: $base-background-1;
+    border: 1px solid $base-border-color-1;
+    border-radius: 3px;
+    margin: 0 0 em(20);
+    padding: em(20);
+    width: 100%;
+  }
 
   h3 {
     color: $gray-3;
@@ -230,7 +260,6 @@ body.checkouts-new, body.checkouts-create {
   }
 
   #credit-card-icons {
-
     img {
       padding: 0 em(5);
 

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -40,6 +40,14 @@ module CheckoutsHelper
     end
   end
 
+  def auth_method_class(checkout)
+    if checkout.signing_up_with_username_and_password?
+      "username-password-auth"
+    else
+      "github-auth"
+    end
+  end
+
   private
 
   def change_plan_link(plan)

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -56,6 +56,10 @@ class Checkout < ActiveRecord::Base
     stripe_coupon_id.present? && !coupon.valid?
   end
 
+  def signing_up_with_username_and_password?
+    [email, name, password, github_username].any?(&:present?)
+  end
+
   private
 
   def issue_with_github_username?

--- a/app/views/checkouts/_billing_information.html.erb
+++ b/app/views/checkouts/_billing_information.html.erb
@@ -1,0 +1,27 @@
+<%= form.inputs id: "billing-information" do %>
+  <%= render "users/address_fields", form: form %>
+
+  <fieldset>
+    <h3>Secure Credit Card Payment</h3>
+    <li id="credit-card-icons">
+      <%= image_tag "icons/visa.png" %>
+      <%= image_tag "icons/master.png" %>
+      <%= image_tag "icons/american_express.png" %>
+      <%= image_tag "icons/discover.png" %>
+    </li>
+    <li class="payment-errors"></li>
+    <li id="checkout_cc_input" class="stripe">
+      <label for="card-number">Card Number</label>
+      <input type="text" size="20" autocomplete="off" id="card-number" class="card-number"/>
+    </li>
+    <li id="checkout_expiration_input" class="stripe">
+      <label>Expiration</label>
+      <%= select_month nil, { prompt: "Month", add_month_numbers: true }, class: "card-expiry-month" %>
+      <%= select_year nil, { prompt: "Year", start_year: Time.zone.today.year, end_year: 10.years.from_now.year }, class: "card-expiry-year" %>
+    </li>
+    <li id="checkout_cvc_input" class="stripe">
+      <label for="card-cvc">CVC</label>
+      <input type="text" size="4" autocomplete="off" id="card-cvc" class="card-cvc"/>
+    </li>
+  </fieldset>
+<% end %>

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -2,65 +2,35 @@
 
   <%= form.semantic_errors %>
 
-  <% if signed_in? %>
-    <h2 class="one-step-away">Hey <%= current_user.first_name %>, you're one step away. Enter payment below to start learning with Upcase now!</h2>
-  <% end %>
-
-  <%= form.inputs do %>
-    <%= hidden_field_tag "coupon_id" %>
-
-    <% if signed_out? %>
-      <ul class="checkout-signin-signup-toggle">
-        <li>
-          <%= link_to "Already have an account? Sign in",
-                      sign_in_path_with_current_path_return_to, class: "cta-button secondary-button" %>
-        </li>
-        <li><%= link_to "Sign up with GitHub", authenticated_on_checkout_path(plan: checkout.plan), class: "cta-button secondary-button" %></li>
-      </ul>
-
-      <%= form.input :name, required: true %>
-      <%= form.input :email, as: :email, required: true %>
-      <%= form.input :password, required: true %>
+  <h2 class="one-step-away">
+    <% if signed_in? %>
+      <%= t("checkouts.one_step_away_authenticated", name: current_user.first_name) %>
+    <% else %>
+      <%= t("checkouts.one_step_away_anonymous") %>
     <% end %>
+  </h2>
 
-    <% if checkout.needs_github_username? %>
-      <%= form.input :github_username, required: true, label: "GitHub username",
-        hint: "Be sure to enter a valid, unique GitHub username. Organizations are not allowed." %>
-    <% end %>
-  <% end %>
+  <%= render "user_information_fields", form: form, checkout: checkout %>
 
-  <%= form.inputs id: 'billing-information' do %>
-    <h3>Secure Credit Card Payment</h3>
-    <li id="credit-card-icons">
-      <%= image_tag "icons/visa.png" %>
-      <%= image_tag "icons/master.png" %>
-      <%= image_tag "icons/american_express.png" %>
-      <%= image_tag "icons/discover.png" %>
-    </li>
-    <li class="payment-errors"></li>
-    <li id="checkout_cc_input" class="stripe">
-      <label for='card-number'>Card Number</label>
-      <input type='text' size='20' autocomplete='off' id='card-number' class='card-number'/>
-    </li>
-    <li id="checkout_expiration_input" class="stripe">
-      <label>Expiration</label>
-      <%= select_month nil, { prompt: 'Month', add_month_numbers: true }, class: 'card-expiry-month' %>
-      <%= select_year nil, { prompt: 'Year', start_year: Time.zone.today.year, end_year: 10.years.from_now.year }, class: 'card-expiry-year' %>
-    </li>
-    <li id="checkout_cvc_input" class="stripe">
-      <label for='card-cvc'>CVC</label>
-      <input type='text' size='4' autocomplete='off' id='card-cvc' class='card-cvc'/>
-    </li>
-  <% end %>
-
-  <%= form.inputs class: 'address-info' do %>
-    <%= render 'users/address_fields', form: form %>
-  <% end %>
+  <%= render "billing_information", form: form %>
 
   <%= form.actions do %>
     <%= form.action :submit, label: "Submit Payment &mdash; #{submit_amount(checkout)}".html_safe,
-      button_html: { class: "subscribe-cta light-bg" } %>
+      button_html: { class: "subscribe-cta light-bg", "data-role": "submit" } %>
   <% end %>
 <% end %>
 
-<%= render partial: 'shared/stripe' %>
+<%= render "shared/stripe" %>
+
+<% content_for :javascript do %>
+  <%= javascript_tag do %>
+    $(function() {
+      var $paymentForm = $(".payment-form");
+
+      $(".toggle-auth").click(function(){
+        $paymentForm.toggleClass("github-auth").toggleClass("username-password-auth");
+        return false;
+      });
+    });
+  <% end %>
+<% end %>

--- a/app/views/checkouts/_user_information_fields.html.erb
+++ b/app/views/checkouts/_user_information_fields.html.erb
@@ -1,0 +1,37 @@
+<%= form.inputs do %>
+  <%= hidden_field_tag "coupon_id" %>
+
+  <% if signed_out? %>
+    <div class="github-or-sign-in-buttons">
+      <ul class="checkout-signin-signup-toggle">
+        <li>
+          <%= link_to authenticated_on_checkout_path(plan: checkout.plan), class: "cta-button subscribe-cta light-bg" do %>
+            <%= image_tag("github-black.svg", class: "logo", alt: "") + t("checkout.sign_up_with_github") %>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to "Already have an account? Sign in",
+            sign_in_path_with_current_path_return_to, class: "cta-button secondary-button" %>
+        </li>
+      </ul>
+
+      <span class="divider">
+        <h4>Prefer to <a href="#" class="toggle-auth"><%= t(".sign_up_with_username_and_password") %></a></h4>
+      </span>
+    </div>
+
+    <div class="username-password">
+      <span class="divider">
+        <h4>Prefer to <a href="#" class="toggle-auth">sign up with GitHub?</a></h4>
+      </span>
+
+      <%= form.input :name, required: true %>
+      <%= form.input :email, as: :email, required: true %>
+      <%= form.input :password, required: true %>
+      <% if checkout.needs_github_username? %>
+        <%= form.input :github_username, required: true, label: "GitHub username",
+          hint: "Be sure to enter a valid, unique GitHub username. Organizations are not allowed." %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -6,13 +6,11 @@
 <% content_for :page_title, "Subscribe to #{@checkout.plan_name}" %>
 
 <div class="checkout-content">
-  <div class="payment-form">
+  <div class="payment-form <%= auth_method_class(@checkout) %>">
     <%= render "checkouts/form", checkout: @checkout %>
     <div class="checkout-notes">
       <h3>thoughtbot no-hassle guarantee</h3>
       <p>If you don't love Upcase, just let us know within 30 days and we’ll refund your money. It’s as simple as that.</p>
-
-      <%= link_to 'Need an address on your receipt?', '#', class: 'reveal-address' %>
     </div>
   </div>
 

--- a/app/views/users/_address_fields.html.erb
+++ b/app/views/users/_address_fields.html.erb
@@ -1,7 +1,27 @@
-<%= form.input :organization %>
-<%= form.input :address1, label: 'Address 1' %>
-<%= form.input :address2, label: 'Address 2' %>
-<%= form.input :city %>
-<%= form.input :state, label: "State / Province" %>
-<%= form.input :zip_code, label: "Postal / Zip Code" %>
-<%= form.input :country, as: :string %>
+<div class="address-fields-wrapper">
+  <%= link_to "Need an address on your receipt?", "#", class: "reveal-address" %>
+
+  <%= form.inputs class: "address-info" do %>
+    <%= link_to "Hide address fields", "#", class: "hide-address" %>
+
+    <%= form.input :organization %>
+    <%= form.input :address1, label: "Address 1" %>
+    <%= form.input :address2, label: "Address 2" %>
+    <%= form.input :city %>
+    <%= form.input :state, label: "State / Province" %>
+    <%= form.input :zip_code, label: "Postal / Zip Code" %>
+    <%= form.input :country, as: :string %>
+  <% end %>
+</div>
+
+
+<% content_for :javascript do %>
+  <%= javascript_tag do %>
+    $addressFieldsWrapper = $('.address-fields-wrapper');
+
+    $('.reveal-address, .hide-address').click(function() {
+      $addressFieldsWrapper.toggleClass("displayed");
+      return false;
+    });
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,13 @@ en:
       flashes:
         accepted: Request received! We'll let you know when the trail is ready.
         declined: Got it. We'll get that trail out of your way.
+  checkouts:
+    user_information_fields:
+      sign_up_with_username_and_password: "sign up with username and password?"
+    one_step_away_authenticated: "Hey %{name}, you're one step away. Enter payment below to start learning with Upcase now!"
+    one_step_away_anonymous: "Almost there - get instant access with expedited checkout!"
   checkout:
+    sign_up_with_github: "Sign up with GitHub"
     flashes:
       already_subscribed: You are already subscribed.
       invalid_coupon: The coupon code %{code} is no longer valid and has been

--- a/spec/helpers/checkouts_helper_spec.rb
+++ b/spec/helpers/checkouts_helper_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe CheckoutsHelper do
+  describe "#auth_method_class" do
+    context "when the user has entered username/password data" do
+      it "returns 'username-password-auth'" do
+        checkout = build_checkout(signing_up_with_username_and_password?: true)
+
+        result = helper.auth_method_class(checkout)
+
+        expect(result).to eq("username-password-auth")
+      end
+    end
+
+    context "when the user has not entered username/password data" do
+      it "returns 'github-auth'" do
+        checkout = build_checkout(signing_up_with_username_and_password?: false)
+
+        result = helper.auth_method_class(checkout)
+
+        expect(result).to eq("github-auth")
+      end
+    end
+  end
+
+  def build_checkout(options)
+    instance_double(Checkout, options)
+  end
+end

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -195,4 +195,20 @@ describe Checkout do
       expect(checkout.needs_github_username?).to be(true)
     end
   end
+
+  context "#signing_up_with_username_and_password?" do
+    %i(email name password github_username).each do |field|
+      it "returns true if #{field} is present" do
+        checkout = Checkout.new(field => "floop")
+
+        expect(checkout.signing_up_with_username_and_password?).to be true
+      end
+    end
+
+    it "returns false if none of those fields are set on user" do
+      checkout = Checkout.new
+
+      expect(checkout.signing_up_with_username_and_password?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Currently the majority of users authenticate with GitHub (rather than username & password auth), but the checkout page is not geared towards this. The GitHub auth button is one of two equal size and visual emphasis buttons, shown above the traditional signup form.

With this change, the GitHub auth button is emphasized, and all other fields are hidden. Users can reveal the more detailed forms if they like, but for the majority case things are streamlined and more clear.

![two-step-checkout](https://cloud.githubusercontent.com/assets/420113/14657612/f4a4edec-065c-11e6-9aec-bdc3d4446ea7.gif)
