### PR TITLE
Update SelectorDepth max to 4 in scss-lint config

### DIFF
--- a/.scss-style.yml
+++ b/.scss-style.yml
@@ -88,7 +88,7 @@ linters:
     severity: warning
   SelectorDepth:
     enabled: true
-    max_depth: 3
+    max_depth: 4
     severity: warning
   SelectorFormat:
     enabled: true


### PR DESCRIPTION
Longer term I'd love to refactor the styles to be more representative of our
current approach, but currently Upcase has a particular style structure where
most stylesheets begin with a `body` class, and all actual styling happens
within this. This means that we are regularly crossing the max selector depth 3
style rule. Currently we've been commenting on and agreeing to allow these
violations, which is not ideal as it puts us in a different mindset with Hound
style comments.

With this change we're bumping up the value for this rule to 4. This should get
us back to a place where we are not regularly commenting on and ignoring style
violations.
