### PR TITLE
Replace menu links for subscriber only content

### DIFF
--- a/app/views/shared/_table_of_contents.html.erb
+++ b/app/views/shared/_table_of_contents.html.erb
@@ -53,7 +53,7 @@
           <%= link_to "Introduction to Dotfiles", "/videos/intro-to-dotfiles" %>
         </li>
         <li>
-          <%= link_to "Vim Integration with tmux", "/videos/tmux-vim-integration" %>
+          <%= link_to "Let's Build a CLI", "/videos/lets-build-a-cli" %>
         </li>
         <li class="see-all">
           <%= link_to "See all workflow content...", "/workflow" %>
@@ -92,7 +92,7 @@
           <%= link_to "Git Workflow", "/videos/git-workflow" %>
         </li>
         <li>
-          <%= link_to "Git/Vim Integration", "/videos/git-vim-and-git" %>
+          <%= link_to "Gitsh - the Git Shell", "/videos/gitsh" %>
         </li>
         <li class="see-all">
           <%= link_to "See all Git content...", "/git" %>


### PR DESCRIPTION
Both the Vim/Tmux & Git/Vim Integration videos are part of trails and
cannot be viewed by guests, instead redirecting them to /sign_in.

This change updates those links to point at two other videos from the Weekly
Iteration, making them accessible.
