### PR TITLE
Do not provide download links for preview videos

### DIFF
--- a/app/assets/stylesheets/_products-show.scss
+++ b/app/assets/stylesheets/_products-show.scss
@@ -57,16 +57,6 @@ body.videos-show {
     }
   }
 
-  @include body-mobile {
-    .assets-wrapper {
-      .assets {
-        .button-mini {
-          @include span-columns(12);
-        }
-      }
-    }
-  }
-
   @media screen and (max-device-width: 800px), screen and (max-width: 800px) {
    .video-headline {
      text-align: left;
@@ -76,11 +66,6 @@ body.videos-show {
   @include body-mobile {
     .text-box-wrapper .get-video {
       width: 80% !important;
-    }
-
-    .assets-wrapper .assets .button-mini {
-      @include span-columns(12);
-      margin-top: 20px;
     }
   }
 }

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -113,9 +113,23 @@
   }
 }
 
-.assets-wrapper {
-  margin-bottom: 1rem;
+.video-player {
+  margin-bottom: $large-spacing;
 
+  .actions {
+    display: flex;
+    align-items: center;
+    margin-top: $base-spacing;
+  }
+
+  @include body-mobile {
+    .download {
+      display: none;
+    }
+  }
+}
+
+.assets-wrapper {
   .assets {
     .asset-download {
       float: left;
@@ -137,8 +151,8 @@
   }
 }
 
-.mark-as-complete {
-  float: right;
+.mark-as-complete form {
+  margin-bottom: 0;
 }
 
 .seek-button-template {

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -48,10 +48,6 @@ class Video < ActiveRecord::Base
     end
   end
 
-  def has_preview_clip?
-    preview_wistia_id.present?
-  end
-
   def has_notes?
     notes.present?
   end

--- a/app/views/clips/_clip.html.erb
+++ b/app/views/clips/_clip.html.erb
@@ -1,13 +1,6 @@
 <div class="wistia-wrapper">
   <%= large_wistia_iframe_for(clip) %>
 </div>
-<section class="assets-wrapper">
-  <div class="assets">
-    <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
-    <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", clip: clip %>
-    <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
-  </div>
-</section>
 
 <% content_for :javascript do %>
   <script src="//fast.wistia.com/assets/external/E-v1.js"></script>

--- a/app/views/clips/_download_links.html.erb
+++ b/app/views/clips/_download_links.html.erb
@@ -1,0 +1,7 @@
+<section class="assets-wrapper">
+  <div class="assets">
+    <%= render 'videos/download_link', download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
+    <%= render 'videos/download_link', download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", clip: clip %>
+    <%= render 'videos/download_link', download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
+  </div>
+</section>

--- a/app/views/clips/_preview_only.html.erb
+++ b/app/views/clips/_preview_only.html.erb
@@ -1,7 +1,0 @@
-<div class="wistia-wrapper">
-  <%= large_wistia_iframe_for(clip) %>
-</div>
-
-<% content_for :javascript do %>
-  <script src="//fast.wistia.com/assets/external/E-v1.js"></script>
-<% end %>

--- a/app/views/pages/aarq-bloopers.html.erb
+++ b/app/views/pages/aarq-bloopers.html.erb
@@ -4,7 +4,7 @@
   </section>
 
   <div class="text-box">
-    <%= render "clips/preview_only", clip: Clip.new("itprspj843") %>
+    <%= render Clip.new("itprspj843") %>
   </div>
 
   <p>

--- a/app/views/shows/show.html.erb
+++ b/app/views/shows/show.html.erb
@@ -17,7 +17,7 @@
 <div class="show-info">
   <% unless has_access_to_shows? %>
     <div>
-      <%= render "clips/preview_only", clip: Clip.new("ol6e0miehm") %>
+      <%= render Clip.new("ol6e0miehm") %>
     </div>
     <%= render "subscribe_cta",
       description: t("show.weekly_iteration_cta"),

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -21,23 +21,24 @@
   <h4 class="text">Video</h4>
 </span>
 
-<% if current_user_has_access_to?(@video) %>
-  <%= render @video.clip %>
-<% else %>
-  <% if @video.has_preview_clip? %>
-    <%= render "clips/preview_only", clip: @video.preview %>
+<div class="video-player">
+  <% if current_user_has_access_to?(@video) %>
+      <%= render @video.clip %>
+
+      <div class="actions">
+        <%= render "clips/download_links", clip: @video.clip %>
+
+        <div class="mark-as-complete">
+          <%= form_tag video_completions_path(@video) do |f| %>
+            <%= submit_tag t("videos.show.mark-as-complete"), class:"small-button" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
   <% else %>
     <%= render @video.preview, name: @video.name %>
   <% end %>
-<% end %>
-
-<% if current_user_has_access_to?(@video) %>
-  <div class="mark-as-complete">
-    <%= form_tag video_completions_path(@video) do |f| %>
-      <%= submit_tag t("videos.show.mark-as-complete"), class:"small-button" %>
-    <% end %>
-  </div>
-<% end %>
+</div>
 
 <% if @video.part_of_trail? %>
   <%= render "trails/progress",

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -102,20 +102,6 @@ describe Video do
     end
   end
 
-  context "has_preview_clip?" do
-    it "returns true if there is a preview clip present" do
-      video = Video.new(preview_wistia_id: "abc124")
-
-      expect(video.has_preview_clip?).to eq(true)
-    end
-
-    it "returns false if there is not a preview clip present" do
-      video = Video.new(preview_wistia_id: "")
-
-      expect(video.has_preview_clip?).to eq(false)
-    end
-  end
-
   context "watchable_name" do
     it "returns the name of the watchable" do
       show = create(:show, name: "A show")


### PR DESCRIPTION
We're seeing a steady steam of errors in airbrake related to the DownloadsController not being able to find the video. This seems to be due to users trying to download the preview videos (shown to non-subscribers when viewing a Weekly Iteration video).

This change removes the download links when showing a preview video. In addition, this allowed for a nice cleanup of the `clip` partial removing the need for a `clip` and `preview_clip` as this partial is now only responsible for displaying the video. Plus, some flexbox FTW!
