### PR TITLE
Don't install Qt5 on Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,3 @@ deployment:
     commands:
       - git remote add staging git@heroku.com:upcase-staging.git
       - ./bin/deploy staging
-
-machine:
-  pre:
-    - sudo apt-get install apt -y
-    - sudo add-apt-repository ppa:beineri/opt-qt551 -y
-    - sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/beineri-opt-qt551-precise.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-    - sudo apt-get update -y; true
-    - sudo apt-get install qt55webkit qt55declarative
-    - echo "source /opt/qt55/bin/qt55-env.sh" >> ~/.circlerc


### PR DESCRIPTION
- It increases the build time by multiple minutes
- It is not _required_ for capybara-webkit yet (though it is recommended) and using Qt4 doesn't seem to affect our tests at all
