### PR TITLE
Remove apt commands to install QT5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,3 @@ deployment:
     commands:
       - git remote add staging git@heroku.com:upcase-staging.git
       - ./bin/deploy staging
-
-machine:
-  pre:
-    - sudo apt-get install apt -y
-    - sudo add-apt-repository ppa:beineri/opt-qt551 -y
-    - sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/beineri-opt-qt551-precise.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-    - sudo apt-get update -y; true
-    - sudo apt-get install qt55webkit qt55declarative
-    - echo "source /opt/qt55/bin/qt55-env.sh" >> ~/.circlerc


### PR DESCRIPTION
Currently we're manually installing Qt5 with each build which dramatically
increases the build time, but it looks like CircleCI has an Unbutu 14.04
(Trusty) container that we can use for our builds, which has QT5 pre-installed.

 https://circleci.com/docs/build-image-trusty/
