### PR TITLE
Restore the download links for videos on mobile

### DIFF
--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -117,8 +117,22 @@
   margin-bottom: $large-spacing;
 
   @include body-mobile {
-    .download {
-      display: none;
+    margin-bottom: $base-spacing;
+  }
+
+  .download-links {
+    display: flex;
+
+    @include body-mobile {
+      flex-direction: column;
+    }
+  }
+
+  .download {
+    margin-right: 1em;
+
+    @include body-mobile {
+      margin-bottom: 1em;
     }
   }
 
@@ -126,27 +140,9 @@
     align-items: center;
     display: flex;
     margin-top: $base-spacing;
-  }
-}
 
-.assets-wrapper {
-  .assets {
-    .asset-download {
-      float: left;
-      margin: 0 20px 0 0;
-    }
-
-    .asset {
-      background-color: #efefef;
-      float: left;
-      margin: 4px 4px 0 0;
-      padding: 10px;
-      width: 20%;
-    }
-
-    a {
-      padding-right: 10px;
-      text-decoration: none;
+    @include body-mobile {
+      align-items: flex-start;
     }
   }
 }

--- a/app/views/clips/_download_links.html.erb
+++ b/app/views/clips/_download_links.html.erb
@@ -1,7 +1,5 @@
-<section class="assets-wrapper">
-  <div class="assets">
-    <%= render "videos/download_link", download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
-    <%= render "videos/download_link", download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", clip: clip %>
-    <%= render "videos/download_link", download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
-  </div>
+<section class="download-links">
+  <%= render "videos/download_link", download_type_key: "OriginalFile", download_type: "original", size_display: "Original (720p)", clip: clip %>
+  <%= render "videos/download_link", download_type_key: "IphoneVideoFile", download_type: "iphone", size_display: "iPhone", clip: clip %>
+  <%= render "videos/download_link", download_type_key: "HdMp4VideoFile", download_type: "hd_mp4", size_display: "HD MP4", clip: clip %>
 </section>


### PR DESCRIPTION
I mistakenly assumed that users were not downloading on mobile and as such I hid
the download links on mobile in ead4c93b, but it sounds like some users were
using the download links on mobile.

This change restores the download links, and also simplifies the DOM and class
structure around the video player.
