### PR TITLE
Install the Heroku Toolbelt on Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  pre:
+    - wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
 test:
   override:
     - bundle exec rake


### PR DESCRIPTION
We switched to a new container that does not have Heroku pre-installed, so we must install it ourselves.
