### PR TITLE
Don't include the analytics JS when masquerading

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,6 +1,6 @@
 module AnalyticsHelper
-  def analytics?
-    ENV["ANALYTICS"].present?
+  def can_use_analytics?
+    ENV["ANALYTICS"].present? && !masquerading?
   end
 
   def identify_hash(user = current_user)

--- a/app/views/shared/_javascript.html.erb
+++ b/app/views/shared/_javascript.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag "application" %>
 
-<% if analytics? %>
+<% if can_use_analytics? %>
   <%= render "analytics" %>
 <% end %>
 

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,19 +1,33 @@
 require "rails_helper"
 
 describe AnalyticsHelper do
-  describe '#analytics?' do
-    it "is true when ENV['ANALYTICS'] is present" do
-      ENV["ANALYTICS"] = "anything"
+  describe "#can_use_analytics?" do
+    context "when an ENV['ANALYTICS'] value is present and not masquerading?" do
+      it "returns true" do
+        ClimateControl.modify ANALYTICS: "anything" do
+          allow(helper).to receive(:masquerading?).and_return(false)
 
-      expect(helper).to be_analytics
-
-      ENV["ANALYTICS"] = nil
+          expect(helper.can_use_analytics?).to eq(true)
+        end
+      end
     end
 
-    it "is false when ENV['ANALYTICS'] is not present" do
-      ENV["ANALYTICS"] = nil
+    context "when we're masquerading" do
+      it "returns false" do
+        allow(helper).to receive(:masquerading?).and_return(true)
 
-      expect(helper).to_not be_analytics
+        expect(helper.can_use_analytics?).to eq(false)
+      end
+    end
+
+    context "when no ENV['ANALYTICS'] value is present" do
+      it "returns false" do
+        ClimateControl.modify ANALYTICS: nil do
+          allow(helper).to receive(:masquerading?).and_return(false)
+
+          expect(helper.can_use_analytics?).to eq(false)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently all analytics continue to fire when masquerading, incorrectly
identifying the masqueraded users as having visited.

This update does not include the JS analytics partial when masquerading to avoid
those. Note, actions taken while masquerading will still act on behalf of the
user, and server side analytics will still be fired. This only updates for
events like "page visited" which some services use to determine activity.
