### PR TITLE
Redirect to /practice after signing in from /join

### DIFF
--- a/app/helpers/landing_helper.rb
+++ b/app/helpers/landing_helper.rb
@@ -1,5 +1,9 @@
 module LandingHelper
   def sales_context?
-    @landing_page || signed_out?
+    landing_page? || signed_out?
+  end
+
+  def landing_page?
+    @landing_page.present?
   end
 end

--- a/app/views/layouts/_marketing_header_links.html.erb
+++ b/app/views/layouts/_marketing_header_links.html.erb
@@ -23,7 +23,11 @@
 
   <% if signed_out? %>
     <li>
-      <%= link_to t("shared.header.sign_in"), sign_in_path_with_current_path_return_to %>
+      <% if landing_page? %>
+        <%= link_to t("shared.header.sign_in"), sign_in_path %>
+      <% else %>
+        <%= link_to t("shared.header.sign_in"), sign_in_path_with_current_path_return_to %>
+      <% end %>
     </li>
   <% end %>
 

--- a/spec/views/layouts/_marketing_header_links.html.erb_spec.rb
+++ b/spec/views/layouts/_marketing_header_links.html.erb_spec.rb
@@ -48,13 +48,26 @@ describe "layouts/_marketing_header_links.html.erb" do
   end
 
   context "when signed_out" do
-    it "renders the sign_in link" do
-      render_header(signed_out: true)
+    context "on a sales landing page" do
+      it "renders the plain sign_in link" do
+        render_header(signed_out: true, landing_page: true)
 
-      expect(rendered).to have_link(
-        t("shared.header.sign_in"),
-        sign_in_path,
-      )
+        expect(rendered).to have_link(
+          t("shared.header.sign_in"),
+          href: sign_in_path,
+        )
+      end
+    end
+
+    context "when on a non-sales page" do
+      it "renders the sign_in link with return_to provided for current_path" do
+        render_header(signed_out: true, landing_page: false)
+
+        expect(rendered).to have_link(
+          t("shared.header.sign_in"),
+          href: sign_in_path_with_return_to,
+        )
+      end
     end
   end
 
@@ -69,9 +82,15 @@ describe "layouts/_marketing_header_links.html.erb" do
     end
   end
 
-  def render_header(signed_out: false, team_page: false, header_cta_link: nil)
+  def render_header(
+    signed_out: false,
+    team_page: false,
+    header_cta_link: nil,
+    landing_page: false
+  )
     allow(view).to receive(:signed_out?).and_return(signed_out)
     allow(view).to receive(:team_page?).and_return(team_page)
+    allow(view).to receive(:landing_page?).and_return(landing_page)
 
     if header_cta_link
       allow(view).to receive(:content_for?).
@@ -83,5 +102,9 @@ describe "layouts/_marketing_header_links.html.erb" do
     end
 
     render
+  end
+
+  def sign_in_path_with_return_to
+    sign_in_path(return_to: "")
   end
 end


### PR DESCRIPTION
Recently we updated the header 'Sign In' link to include a return_to from the
path you clicked it, which then will automatically return users to the page they
were on when they clicked the sign in link.

This works well on content pages like a specific video or the Weekly Iteration
index page, but is likely not desired on the /join or /teams page.

This update will now send users to /practice after signing in on any sales page.
