### PR TITLE
Move the Sign Out link on the my_account page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,11 +1,12 @@
 <% content_for :subject_block do %>
-  <h1>Account<h1>
+  <h1>Account</h1>
+  <%= link_to(t("shared.header.sign_out"), sign_out_path, method: :delete) %>
 <% end %>
 
 <div class="text-box-wrapper right">
   <div class="text-box">
     <%= semantic_form_for current_user, url: edit_my_account_path do |form| %>
-      <%= form.inputs "Your Information [#{link_to("Sign out", sign_out_path, method: :delete)}]" do %>
+      <%= form.inputs "Your Information" do %>
         <%= form.input :name, label: "Your Name", input_html: { placeholder: "Name" } %>
         <%= form.input :bio, label: "About You", as: :text, input_html: { rows: 4 } %>
         <%= form.input :email, as: :email %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,7 @@ en:
       teams: Teams
       search: Search
       sign_in: Sign In
+      sign_out: Sign Out
       trails: Trails
       weekly_iteration: Weekly Iteration
     subscription:


### PR DESCRIPTION
![upcase_by_thoughtbot___learn_web_development_online_2016-05-04_10-55-43_720](https://cloud.githubusercontent.com/assets/4632/15018293/fb0ff54c-11e6-11e6-9c3e-bf8e73bef25f.png)

It's next to the "Your Information" header. Why is it next to the "Your
Information" header? That makes no sense. Move it to the header. People don't
need this all the time, so it doesn't need to be all up in your grill, but it does need to not get lost.

https://trello.com/c/7mKc9Q8W
