### PR TITLE
Remove impossible Rails Admin authentication block

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -7,13 +7,6 @@ EXTENDED_DESCRIPTION_HELP = <<-DESC.strip_heredoc.freeze
 DESC
 
 RailsAdmin.config do |config|
-  config.authenticate_with do
-    unless current_user
-      session[:return_to] = request.url
-      redirect_to "/sign_in", :alert => "You must first log in or sign up before accessing this page."
-    end
-  end
-
   config.authorize_with do
     redirect_to "/", :alert => "You are not authorized to access that page" unless current_user.admin?
   end

--- a/spec/features/admin_creates_deck_spec.rb
+++ b/spec/features/admin_creates_deck_spec.rb
@@ -7,6 +7,12 @@ feature "Admin creates a deck" do
     expect(current_path).to eq(practice_path)
   end
 
+  scenario "is redirected away if not a user" do
+    visit new_admin_deck_path
+
+    expect(current_path).to eq(sign_up_path)
+  end
+
   scenario "successfully" do
     visit admin_decks_path(as: create(:admin))
 


### PR DESCRIPTION
In order to determine whether to authenticate or authorize based on the return value of `current_user`.

If `current_user` is `nil`, then it calls the `authenticate_with` block.

If `current_user` is not `nil`, then it calls the `authorize_with` block.

We have a `Guest` object, so `current_user` is never `nil` -- it's just `Guest`.

Thus, the `authenticate_with` block is never called and can be removed.

This commit also adds a test for a visitor accessing the admin area to confirm that this block is unnecessary.
