### PR TITLE
Don't include comments on unpublished videos

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -79,4 +79,12 @@ class Video < ActiveRecord::Base
   def state_for(user)
     statuses.most_recent_for_user(user).state
   end
+
+  def published?
+    if part_of_trail?
+      trail.published?
+    else
+      published_on <= Date.current
+    end
+  end
 end

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -63,6 +63,10 @@
   </div>
 <% end %>
 
+<% if @video.published? %>
+  <%= render "comments", video: @video %>
+<% end %>
+
 <% if current_user_has_access_to?(@video) %>
   <%= render "seek_buttons", markers: @video.markers %>
 <% end %>

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Video do
+  include VideoHelpers
+
   it { should belong_to(:watchable) }
   it { should have_many(:classifications) }
   it { should have_many(:markers) }
@@ -241,5 +243,45 @@ describe Video do
 
   describe "#download_url" do
     it { should delegate_method(:download_url).to(:clip) }
+  end
+
+  describe "#published?" do
+    context "when the video is part of a show" do
+      context "and the video has a published_on date <= today" do
+        it "returns true" do
+          video = build_stubbed(:video, published_on: Date.current)
+
+          expect(video.published?).to eq(true)
+        end
+      end
+
+      context "and the video has a published_on date in the future" do
+        it "returns false" do
+          video = build_stubbed(:video, published_on: Date.tomorrow)
+
+          expect(video.published?).to eq(false)
+        end
+      end
+    end
+  end
+
+  context "when the video is part of a trail" do
+    context "and the trail is published" do
+      it "returns true" do
+        trail = create(:trail, :published)
+        video = create_video_on_a_trail(trail: trail)
+
+        expect(video.published?).to eq(true)
+      end
+    end
+
+    context "and the trail is not published" do
+      it "returns false" do
+        trail = create(:trail, :unpublished)
+        video = create_video_on_a_trail(trail: trail)
+
+        expect(video.published?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/support/video_helpers.rb
+++ b/spec/support/video_helpers.rb
@@ -1,0 +1,7 @@
+module VideoHelpers
+  def create_video_on_a_trail(trail: create(:trail))
+    video = create(:video)
+    create(:step, trail: trail, completeable: video)
+    video.reload
+  end
+end

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "videos/show" do
+  include VideoHelpers
+
   it "sets the page title to the video title" do
     video = build_stubbed(:video, name: "hello world")
 
@@ -163,6 +165,28 @@ describe "videos/show" do
     end
   end
 
+  describe "comments" do
+    context "when the video is published" do
+      it "renders the comments for the video" do
+        video = build_video(published: true)
+
+        render_video video
+
+        expect(rendered).to have_css("#discourse-comments")
+      end
+    end
+
+    context "when the video is not published" do
+      it "does not render the comments for the video" do
+        video = build_video(published: false)
+
+        render_video video
+
+        expect(rendered).not_to have_css("#discourse-comments")
+      end
+    end
+  end
+
   describe "seek markers" do
     context "when the user has access to the video" do
       it "renders the markers" do
@@ -241,10 +265,10 @@ describe "videos/show" do
     Capybara.string("<div>#{content}</div>")
   end
 
-  def create_video_on_a_trail
-    video = create(:video)
-    create(:step, trail: create(:trail), completeable: video)
-    video.reload
+  def build_video(published:)
+    build_stubbed(:video, :published).tap do |video|
+      allow(video).to receive(:published?).and_return(published)
+    end
   end
 
   def render_video(video, has_access: true, subscriber: false)


### PR DESCRIPTION
The Discourse JavaScript will automatically create a thread for any new videos
it encounters (if what does not already exist). While building a trail, we
don't want to have a topic thread as it will indirectly announce the trail
before it's ready.

With this change, we only include the Discourse comments JS when a video is
published (based on the trail or the video itself).
