### PR TITLE
Remove unused font_assets gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group :development, :test do
 end
 
 group :production, :staging do
-  gem "font_assets"
   gem "rails_stdout_logging"
   gem "skylight"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
     flutie (2.0.0)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
-    font_assets (0.1.11)
-      rack
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     friendly_id (5.1.0)
@@ -399,7 +397,6 @@ DEPENDENCIES
   factory_girl_rails
   flutie
   font-awesome-rails
-  font_assets
   formtastic (~> 3.1.3)
   friendly_id (~> 5.1.0)
   gravatarify (~> 3.1.0)


### PR DESCRIPTION
font_assets was added in 5be072ec96b97ce6e7493a4524a38c9b6a7dc12b to fix an issue with fonts that were loaded from the Cloudfront CDN.

The font_assets configuration was removed in 8179b268351c5dda93dfa2adbeb030b89603bad4 (in December 2014), but the gem was not removed.

Since the site has run fine for a year, on staging and production, without the gem configuration, remove the gem.
