### PR TITLE
Remove comments for videos

### DIFF
--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -63,8 +63,6 @@
   </div>
 <% end %>
 
-<%= render "comments", video: @video %>
-
 <% if current_user_has_access_to?(@video) %>
   <%= render "seek_buttons", markers: @video.markers %>
 <% end %>

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -163,14 +163,6 @@ describe "videos/show" do
     end
   end
 
-  it "renders the comments for the video" do
-    video = build_stubbed(:video)
-
-    render_video video
-
-    expect(rendered).to have_css("#discourse-comments")
-  end
-
   describe "seek markers" do
     context "when the user has access to the video" do
       it "renders the markers" do


### PR DESCRIPTION
Since the URLs for every video just changed, Discourse created new topics for every single video.

As a temporary hotfix, don't render the Discourse javascript for videos.
