### PR TITLE
Fix warning about `TimeoutError`

### DIFF
--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -14,7 +14,7 @@ HTTP_ERRORS = [Timeout::Error,
                Net::HTTPHeaderSyntaxError,
                Net::ProtocolError]
 
-SMTP_SERVER_ERRORS = [TimeoutError,
+SMTP_SERVER_ERRORS = [Timeout::Error,
                       IOError,
                       Net::SMTPUnknownError,
                       Net::SMTPServerBusy,


### PR DESCRIPTION
The `TimeoutError` constant is deprecated in favor of `Timeout::Error`.
