### PR TITLE
Fix favicon display

### DIFF
--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -1,7 +1,7 @@
 <meta charset="utf-8" />
 <title><%= content_for(:page_title).presence || t("layouts.fallback_page_title") %></title>
 <%= render 'layouts/stylesheets' %>
-<link rel="icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" href="/upcase/favicon.ico" type="image/x-icon">
 <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence || t('layouts.fallback_meta_description') %>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="google-site-verification" content="pFoYtgbd6tc74KGxv5yWxu2QTH0oKllYLrYbTt35iNM" />


### PR DESCRIPTION
The layout was still pointing at the unprefixed favicon path. This worked in
production as there is, in fact, a favicon at thougbot.com/favicon.ico, just not
the one we are after.

This change updates the favicon path to include the `/upcase` prefix, allowing
for the correct favicon to be served.
