### PR TITLE
Use rack_rewrite to force SSL, not env config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,8 +30,6 @@ Upcase::Application.configure do
   config.log_level = :info
   config.log_formatter = ::Logger::Formatter.new
 
-  config.force_ssl = true
-
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = MAIL_SETTINGS
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
Previously we had `config.force_ssl = true` which allowed the
`ActionDispath::SSL` middleware to handle SSL redirects, before `Rack::Rewrite`
gets a chance. With the recent domain transition, this means we're introducing
multiple redirects, for example:
- Incoming request to `http://upcase.com`
- `ActionDispath::SSL` redirects to `https://upcase.com`
- `Rack::Rewrite` then redirects to `https://thoughtbot.com/upcase/`

We want to make all redirects single hop, `http://upcase.com` ->
`https://thoughtbot.com/upcase/` in this case, to avoid confusing the google
bots.

In order to allow for single hops, we want the one primary `Rack::Rewrite`
redirect to run the show, handling all of forcing SSL, canonical domain, and
`/upcase` path prefix.

Thus, this PR disables `config.force_ssl`.
