### PR TITLE
Use the old URL when relative videos and comments

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -4,4 +4,10 @@ module VideosHelper
       topic.slug.parameterize
     end
   end
+
+  def upcase_video_url(video)
+    video_url(video).
+      gsub("thoughtbot.com", "upcase.com").
+      gsub("/upcase/", "/")
+  end
 end

--- a/app/views/videos/_comments.html.erb
+++ b/app/views/videos/_comments.html.erb
@@ -2,7 +2,7 @@
 <% unless Rails.env.test? %>
   <script type="text/javascript">
     var discourseUrl = "<%= Forum.url %>";
-    var discourseEmbedUrl = "<%= video_url(video) %>";
+    var discourseEmbedUrl = "<%= upcase_video_url(video) %>";
 
     (function() {
       var d = document.createElement("script"); d.type = "text/javascript"; d.async = true;

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -63,6 +63,8 @@
   </div>
 <% end %>
 
+<%= render "comments", video: @video %>
+
 <% if current_user_has_access_to?(@video) %>
   <%= render "seek_buttons", markers: @video.markers %>
 <% end %>

--- a/spec/helpers/videos_helper_spec.rb
+++ b/spec/helpers/videos_helper_spec.rb
@@ -19,4 +19,14 @@ describe VideosHelper do
       expect(result).to eq("test-driven-development")
     end
   end
+
+  describe "#upcase_video_url" do
+    it "returns a video url as though it were still on upcase.com" do
+      video = double("video", to_s: "test-video")
+
+      result = upcase_video_url(video)
+
+      expect(result).to_not include("/upcase")
+    end
+  end
 end


### PR DESCRIPTION
Making this a PR because I don't want it to get lost in the sea of "I think we had that on a branch at some point". At least as a forgotten-about PR it's easier to find.

The comment system is actually links to threads in the Forum. Since this was
Discourse and was a separate thing, it doesn'y necessarily know about the
domain transition. In order to refer to the same videos that it used to, we
need to massage the URL that we tell the forum that the browser is on so it
serves the right thread.

https://trello.com/c/9DtdIz2J
