### PR TITLE
Render page for /join on / when logged out

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,7 +3,9 @@ class HomesController < ApplicationController
     if signed_in?
       redirect_to onboarding_policy.root_path
     else
-      redirect_to join_path
+      @landing_page = true
+      @topics = LandingPageTopics.new.topics
+      render "subscriptions/new"
     end
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SubscriptionsController < ApplicationController
 
   def new
     @landing_page = true
-    @topics = define_topics
+    @topics = LandingPageTopics.new.topics
   end
 
   def edit
@@ -14,24 +14,5 @@ class SubscriptionsController < ApplicationController
     current_user.subscription.change_plan(sku: params[:plan_id])
     redirect_to my_account_path,
                 notice: I18n.t("subscriptions.flashes.change.success")
-  end
-
-  private
-
-  LandingTopic = Struct.new(:name, :slug, :image, :target)
-
-  def define_topics
-    [
-      ["Clean Code", "clean-code", "clean-code", topic_path("clean-code")],
-      ["Git", "git", "workflow", video_path("git-workflow")],
-      ["Ruby on Rails", "rails", "rails", topic_path("rails")],
-      ["Testing", "testing", "testing", topic_path("testing")],
-      ["iOS", "ios", "ios", topic_path("ios")],
-      ["Haskell", "haskell", "haskell", topic_path("haskell")],
-      ["JavaScript", "javascript", "javascript", topic_path("javascript")],
-      ["Vim", "vim", "vim", topic_path("vim")],
-      ["tmux", "tmux", "workflow", trail_path("tmux")],
-      ["Design", "design", "design", topic_path("design")],
-    ].map { |topic_details| LandingTopic.new(*topic_details) }
   end
 end

--- a/app/models/landing_page_topics.rb
+++ b/app/models/landing_page_topics.rb
@@ -1,0 +1,20 @@
+class LandingPageTopics
+  include Rails.application.routes.url_helpers
+
+  LandingTopic = Struct.new(:name, :slug, :image, :target)
+
+  def topics
+    [
+      ["Clean Code", "clean-code", "clean-code", topic_path("clean-code")],
+      ["Git", "git", "workflow", video_path("git-workflow")],
+      ["Ruby on Rails", "rails", "rails", topic_path("rails")],
+      ["Testing", "testing", "testing", topic_path("testing")],
+      ["iOS", "ios", "ios", topic_path("ios")],
+      ["Haskell", "haskell", "haskell", topic_path("haskell")],
+      ["JavaScript", "javascript", "javascript", topic_path("javascript")],
+      ["Vim", "vim", "vim", topic_path("vim")],
+      ["tmux", "tmux", "workflow", trail_path("tmux")],
+      ["Design", "design", "design", topic_path("design")],
+    ].map { |topic_details| LandingTopic.new(*topic_details) }
+  end
+end

--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -2,6 +2,7 @@
 <title><%= content_for(:page_title).presence || t("layouts.fallback_page_title") %></title>
 <%= render 'layouts/stylesheets' %>
 <link rel="icon" href="/upcase/favicon.ico" type="image/x-icon">
+<%= content_for :additional_head_content %>
 <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence || t('layouts.fallback_meta_description') %>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="google-site-verification" content="pFoYtgbd6tc74KGxv5yWxu2QTH0oKllYLrYbTt35iNM" />

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,5 +1,8 @@
 <% content_for :additional_body_classes, "landing" %>
 <% content_for :sticky_header_height, '450' %>
+<% content_for :additional_head_content do %>
+  <link rel="canonical" href="<%= join_url %>">
+<% end %>
 
 <section class="hero tall-hero">
   <div class="landing-container">

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe HomesController do
   context "the user is not logged in" do
-    it "redirects to /join" do
+    it "renders the content of /join, but stays on /" do
       get :show
 
-      expect(response).to redirect_to join_path
+      expect(response).to render_template("subscriptions/new")
     end
   end
 

--- a/spec/features/admin_creates_deck_spec.rb
+++ b/spec/features/admin_creates_deck_spec.rb
@@ -10,7 +10,7 @@ feature "Admin creates a deck" do
   scenario "is redirected away if not a user" do
     visit new_admin_deck_path
 
-    expect(current_path).to eq(sign_up_path)
+    expect(current_path).to eq(root_path)
   end
 
   scenario "successfully" do


### PR DESCRIPTION
We have links from elsewhere pointing at `https://thoughtbot.com/upcase/`, but
that redirects if you're logged out. In order to bump SEO we should have / and
/join render the same thing, because redirects aren't idea for SEO.

However, splitting urls like that also isn't good _unless!_ we also add a
`link` tag that says they're "really" the same page.

https://trello.com/c/Z5vikWxt
