### PR TITLE
Un-confuse the upgrade to yearly billing

### DIFF
--- a/app/assets/stylesheets/_annual-billing.scss
+++ b/app/assets/stylesheets/_annual-billing.scss
@@ -1,3 +1,7 @@
+.upgrade-button {
+  width: 100%;
+}
+
 .subscription-charge {
   color: $upcase-blue;
   font-weight: 800;

--- a/app/views/annual_billings/new.html.erb
+++ b/app/views/annual_billings/new.html.erb
@@ -30,10 +30,13 @@
     </ul>
 
     <%= button_to \
-      "Switch to annual billing",
+      t(".submit", price: @discounted_annual_payment),
       subscription_path(plan_id: @annual_plan_sku),
       method: "put",
-      form_class: "switch-subscription" %>
+      form_class: "switch-subscription",
+      class: "subscribe-cta upgrade-button",
+      data: { confirm: t(".confirmation", price: @discounted_annual_payment) }
+    %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,10 @@ en:
   attempts:
     flashcard_removed_from_review_queue: Flashcard removed from review queue
     flashcard_saved: Saved flashcard for review
+  annual_billings:
+    new:
+      submit: "Switch to annual billing - $%{price} per member"
+      confirmation: "This will charge you $%{price} and switch you to annualized billing. That's what you wanted, right?"
   authenticating:
     github_signin: Sign in with GitHub
     login_required: You must be signed in to view that page

--- a/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
+++ b/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Subscriber upgrades to annual billing" do
+feature "Subscriber upgrades to annual billing", js: true do
   scenario "Successfully" do
     sign_in_as_user_with_subscription_that_is_eligible_for_annual_upgrade
     click_link "Get two months free"
@@ -8,11 +8,29 @@ feature "Subscriber upgrades to annual billing" do
     expect(page.body).to include("$1188")
     expect(page.body).to include("$990")
 
-    click_button "Switch to annual billing"
+    accept_confirm do
+      click_button I18n.t("annual_billings.new.submit", price: 990)
+    end
 
     annual_plan = Plan.find_by(annual: true)
     expect(page.body).to include(I18n.t("subscriptions.flashes.change.success"))
     expect(page.body).to include(annual_plan.name)
+  end
+
+  scenario "but changes their mind at the last minute" do
+    sign_in_as_user_with_subscription_that_is_eligible_for_annual_upgrade
+    click_link "Get two months free"
+
+    expect(page.body).to include("$1188")
+    expect(page.body).to include("$990")
+
+    dismiss_confirm do
+      click_button I18n.t("annual_billings.new.submit", price: 990)
+    end
+
+    expect(page.body).to include("$1188")
+    expect(page.body).to include("$990")
+    expect(page.body).to include("Get two free months of Upcase")
   end
 
   scenario "user with no subscription doesn't see link" do


### PR DESCRIPTION
A few people have complained that they upgraded to yearly billing without
really intending to. We checked the page out, and the styling and behavior of
the page was, in fact, inconsistent with other places in the application where
we charge you money. This page, for example, looked like it was going to take
you to a "checkout" page or something else.

To fix this, we made the button look like other buttons that actually hit your
card and we added a JS confirmation so people have to mash Go twice.

https://trello.com/c/og3fCvEs

![upcase by thoughtbot learn web development online 2016-05-12 11-44-42](https://cloud.githubusercontent.com/assets/4632/15220829/ee9fffa4-1836-11e6-972d-4168af33d7eb.png)

![upcase by thoughtbot learn web development online 2016-05-12 11-45-10](https://cloud.githubusercontent.com/assets/4632/15220839/fe42b6ae-1836-11e6-96ec-d06cbea3821a.png)
