### PR TITLE
Add dynamic robots.txt to disallow staging

### DIFF
--- a/app/controllers/robots_txts_controller.rb
+++ b/app/controllers/robots_txts_controller.rb
@@ -1,0 +1,11 @@
+class RobotsTxtsController < ApplicationController
+  def show
+    options = { layout: false, content_type: "text/plain" }
+
+    if Rails.env.production?
+      render "default", options
+    else
+      render "disallow_all", options
+    end
+  end
+end

--- a/app/views/robots_txts/default.erb
+++ b/app/views/robots_txts/default.erb
@@ -1,0 +1,4 @@
+# Proprietary German backlinks service.
+# They keep requesting invalid formats.
+User-agent: SEOkicks-Robot
+Disallow: /

--- a/app/views/robots_txts/disallow_all.erb
+++ b/app/views/robots_txts/disallow_all.erb
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Upcase::Application.routes.draw do
 
     use_doorkeeper
 
+    get "/robots.txt" => "robots_txts#show"
+
     scope module: "admin" do
       resources :users, only: [] do
         resource :masquerade, only: :create

--- a/public/upcase/robots.txt
+++ b/public/upcase/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-Agent: *
-# Disallow: /


### PR DESCRIPTION
Currently Google is indexing staging, which can have issues related to duplicate
content & taking up some the total available indexed pages count.

This change introduces a dynamic robots.txt, which on non-production
environments instructs search crawlers to ignore all pages.
