### PR TITLE
Remove unused PRIORITY constant

### DIFF
--- a/app/jobs/github_removal_job.rb
+++ b/app/jobs/github_removal_job.rb
@@ -1,8 +1,6 @@
 class GithubRemovalJob < Struct.new(:repository, :username)
   include ErrorReporting
 
-  PRIORITY = 1
-
   def self.enqueue(repository, username)
     Delayed::Job.enqueue(new(repository, username))
   end


### PR DESCRIPTION
It doesn't appear to have been used at all in our code.

I also checked for a `PRIORITY` constant in the git history for collectiveidea/delayed_job using `git log -S PRIORITY` and it doesn't look like it's used there either.

Thus, I believe that the PRIORITY constant was never actually being used.
