### PR TITLE
Use Google Tag Manager directly, not via Segment

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -10,6 +10,7 @@ GITHUB_KEY=github_key_for_oauth_application
 GITHUB_USER=github_username_for_octokit
 GITHUB_PASSWORD=github_password_for_octokit
 GITHUB_SECRET=github_secret_for_oauth_application
+GOOGLE_TAG_MANAGER_KEY=sample_gtm_key
 KISSMETRICS_API_KEY=api_key
 PAYPAL_PASSWORD=password
 PAYPAL_SIGNATURE=signature

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if Rails.env.production? || Rails.env.staging? %>
+  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= ENV.fetch("GOOGLE_TAG_MANAGER_KEY") %>"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','<%= ENV.fetch("GOOGLE_TAG_MANAGER_KEY") %>');</script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <%= yield(:additional_body_classes) %>
     <%= "landing-page" if encourage_user_to_pay? %>
     ">
+    <%= render "layouts/google_tag_manager" %>
     <%= render "shared/environment_banner" %>
     <%= render "layouts/header" %>
 


### PR DESCRIPTION
After the domain transition we're seeing inconsistent session tracking in Google
Analytics which leads us to believe something has gone awry.

With this change, we're moving the Google Analtyics handling out of Segment and
back into the app code proper (via Google Tag Manager, which acts much like
Segmenet but is hopefully better...)

Per https://developers.google.com/tag-manager/quickstart, GTM is mean to be
added directly after open `<body>` tag.
