### PR TITLE
Allow trails to be associated to multiple Topics

### DIFF
--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -7,8 +7,10 @@ class Trail < ActiveRecord::Base
   validates :name, :description, :topic, presence: true
 
   belongs_to :topic
+  has_many :classifications, as: :classifiable
   has_many :repositories, dependent: :destroy
   has_many :statuses, as: :completeable, dependent: :destroy
+  has_many :topics, through: :classifications
   has_many :users, through: :statuses
   has_many \
     :steps,


### PR DESCRIPTION
This is the first step in migrating from a One-to-many relationship, to a
many-to-many. With this code change in place, we should be able to manually
migrate the data with:

``` ruby
Trail.all.each { |trail| trail.topics << trail.topic } }
```

Following that, we can push another update that removes the database field and
any associated code that expects a `Trail` to have a single `Topic`.
