### PR TITLE
Redirect /videos/integer to /videos/slug

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -11,7 +11,9 @@ class VideosController < ApplicationController
   private
 
   def render_or_redirect
-    if current_user_has_access_to?(@video) || weekly_iteration_video?
+    if params[:id] != @video.slug
+      redirect_to video_path(@video.slug), status: 301
+    elsif current_user_has_access_to?(@video) || weekly_iteration_video?
       render
     else
       redirect_to sign_in_path, notice: I18n.t("authenticating.login_required")

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -60,6 +60,28 @@ describe VideosController do
         end
       end
     end
+
+    context "when video slug is used for param" do
+      it "renders the view" do
+        stub_current_user_with(build_stubbed(:user))
+        video = create_video_on_trail(free_sample: true)
+
+        get :show, id: video.slug
+
+        expect(response).to render_the_show_view
+      end
+    end
+
+    context "when video id is used for param" do
+      it "redirects to video slug version" do
+        stub_current_user_with(build_stubbed(:user))
+        video = create_video_on_trail(free_sample: true)
+
+        get :show, id: video.id
+
+        expect(response).to redirect_to video_path(video.slug)
+      end
+    end
   end
 
   it "doesn't recognize other formats" do


### PR DESCRIPTION
We're seeing duplicate meta descriptions and tags in some tools
for thoughtbot.com for these video pages.

Example:

https://ahrefs.com/dashboard/domain-health/7bbe91838776306dee8019245815e8cd/critical
