### PR TITLE
Add support for "promoting" trails on /practice

### DIFF
--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -460,3 +460,20 @@ $not-started-dot-color: #D8D8D8;
     @extend .secondary-button;
   }
 }
+
+.promoted-trails {
+  border: 1px solid $warmgray;
+  border-radius: $base-border-radius;
+  margin-bottom: $medium-spacing;
+  padding: $base-spacing;
+
+  .trail {
+    margin-bottom: 0;
+  }
+
+  .promo-message {
+    font-size: 1.25em;
+    font-weight: 500;
+    margin-bottom: 1em;
+  }
+}

--- a/app/models/status_finder.rb
+++ b/app/models/status_finder.rb
@@ -3,12 +3,19 @@ class StatusFinder
     @user = user
   end
 
-  def status_for(completeable)
-    statuses[key(completeable.class.name, completeable.id)].try(:first) ||
-      Unstarted.new
+  def current_status_for(completeable)
+    statuses_for(completeable).try(:first) || Unstarted.new
+  end
+
+  def earliest_status_for(completeable)
+    statuses_for(completeable).try(:last) || Unstarted.new
   end
 
   private
+
+  def statuses_for(completeable)
+    statuses[key(completeable.class.name, completeable.id)]
+  end
 
   def statuses
     @statuses ||= find_statuses

--- a/app/models/trail_with_progress.rb
+++ b/app/models/trail_with_progress.rb
@@ -28,7 +28,12 @@ class TrailWithProgress < SimpleDelegator
   end
 
   def status
-    status_finder.status_for(trail)
+    status_finder.current_status_for(trail)
+  end
+
+  def started_on
+    status = status_finder.earliest_status_for(trail)
+    status.try(:created_at).try(:to_date) || Date.tomorrow
   end
 
   def steps_remaining

--- a/app/services/completeable_with_progress_query.rb
+++ b/app/services/completeable_with_progress_query.rb
@@ -36,10 +36,10 @@ class CompleteableWithProgressQuery
   end
 
   def state_for(completeable)
-    status_for(completeable).state
+    current_status_for(completeable).state
   end
 
-  def status_for(completeable)
-    @status_finder.status_for(completeable)
+  def current_status_for(completeable)
+    @status_finder.current_status_for(completeable)
   end
 end

--- a/app/services/practice.rb
+++ b/app/services/practice.rb
@@ -12,12 +12,16 @@ class Practice
     trails.select(&:just_finished?)
   end
 
-  def unstarted_trails
-    trails.select(&:unstarted?)
+  def promoted_unstarted_trails
+    unstarted_trails.select(&:promoted?)
+  end
+
+  def unpromoted_unstarted_trails
+    unstarted_trails.reject(&:promoted?)
   end
 
   def in_progress_trails
-    trails.select(&:in_progress?)
+    trails.select(&:in_progress?).sort_by(&:started_on).reverse
   end
 
   attr_reader :beta_offers
@@ -25,6 +29,10 @@ class Practice
   private
 
   attr_reader :trails
+
+  def unstarted_trails
+    trails.select(&:unstarted?)
+  end
 
   def completed_trails
     trails.select(&:complete?)

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -35,8 +35,16 @@
     <span class="divider">
       <h4 class="text">Your Trails</h4>
     </span>
+    <% if @practice.promoted_unstarted_trails.any? %>
+      <div class="promoted-trails">
+        <h3 class="promo-message"><%= t("trails.promoted_message") %></h3>
+        <% @practice.promoted_unstarted_trails.each do |trail| %>
+          <%= render "trails/incomplete_trail", trail: trail %>
+        <% end %>
+      </div>
+    <% end %>
     <%= render partial: "trails/incomplete_trail", collection: @practice.in_progress_trails, as: :trail %>
-    <%= render partial: "trails/incomplete_trail", collection: @practice.unstarted_trails, as: :trail %>
+    <%= render partial: "trails/incomplete_trail", collection: @practice.unpromoted_unstarted_trails, as: :trail %>
   </section>
 
   <% if @practice.just_finished_trails.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,7 @@ en:
     start_trail: Start trail
     visit_trail: Visit trail
     subscribe: Subscribe
+    promoted_message: "🎉 Check out our newest trail, hot off the presses!"
   users:
     flashes:
       update:

--- a/db/migrate/20160601181617_add_promoted_to_trails.rb
+++ b/db/migrate/20160601181617_add_promoted_to_trails.rb
@@ -1,0 +1,5 @@
+class AddPromotedToTrails < ActiveRecord::Migration
+  def change
+    add_column :trails, :promoted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309200016) do
+ActiveRecord::Schema.define(version: 20160601181617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 20160309200016) do
     t.text     "extended_description"
     t.text     "meta_description",                 default: "",    null: false
     t.text     "page_title",                       default: "",    null: false
+    t.boolean  "promoted",                         default: false, null: false
   end
 
   add_index "trails", ["published"], name: "index_trails_on_published", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -499,6 +499,10 @@ FactoryGirl.define do
       published true
     end
 
+    trait :promoted do
+      promoted true
+    end
+
     trait :unpublished do
       published false
     end

--- a/spec/models/status_finder_spec.rb
+++ b/spec/models/status_finder_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe StatusFinder do
-  describe "#status_for" do
+  describe "#current_status_for" do
     context "with a status in the database" do
       it "returns the state for the given completeable" do
         user = create(:user)
@@ -14,7 +14,7 @@ describe StatusFinder do
         create_status other_user, exercise, Status::IN_PROGRESS
         status_finder = StatusFinder.new(user: user)
 
-        result = status_finder.status_for(exercise)
+        result = status_finder.current_status_for(exercise)
 
         expect(result.state).to eq(Status::COMPLETE)
       end
@@ -26,7 +26,7 @@ describe StatusFinder do
         exercise = create(:exercise)
         status_finder = StatusFinder.new(user: user)
 
-        result = status_finder.status_for(exercise)
+        result = status_finder.current_status_for(exercise)
 
         expect(result.state).to eq(Status::UNSTARTED)
       end
@@ -37,14 +37,53 @@ describe StatusFinder do
         exercise = create(:exercise)
         status_finder = StatusFinder.new(user: Guest.new)
 
-        result = status_finder.status_for(exercise)
+        result = status_finder.current_status_for(exercise)
 
         expect(result.state).to eq(Status::UNSTARTED)
       end
     end
   end
 
-  def create_status(user, exercise, state)
-    create(:status, user: user, completeable: exercise, state: state)
+  describe "#earliest_status_for" do
+    context "with a status in the database" do
+      it "returns the oldest status date for the completeable" do
+        user = create(:user)
+        trail = create(:trail)
+        dates = [1.month.ago, Date.current, 2.weeks.ago]
+        statuses = create_statuses_for_dates(user, trail, dates)
+        status_finder = StatusFinder.new(user: user)
+
+        status = status_finder.earliest_status_for(trail)
+
+        expect(status).to eq(statuses.first)
+      end
+    end
+
+    context "with no status recorded" do
+      it "returns Unstarted" do
+        trail = create(:trail)
+        status_finder = StatusFinder.new(user: Guest.new)
+
+        result = status_finder.earliest_status_for(trail)
+
+        expect(result.state).to eq(Status::UNSTARTED)
+      end
+    end
+  end
+
+  def create_status(user, exercise, state, created_at: Date.current)
+    create(
+      :status,
+      user: user,
+      completeable: exercise,
+      state: state,
+      created_at: created_at,
+    )
+  end
+
+  def create_statuses_for_dates(user, trail, dates)
+    dates.map do |date|
+      create_status(user, trail, Status::IN_PROGRESS, created_at: date)
+    end
   end
 end

--- a/spec/services/practice_spec.rb
+++ b/spec/services/practice_spec.rb
@@ -38,13 +38,14 @@ describe Practice do
     end
   end
 
-  describe "#unstarted_trails" do
-    it "returns trails that the user hasn't started" do
-      started_trail = double("started-trail", unstarted?: false)
-      unstarted_trail = double("unstarted-trail", unstarted?: true)
-      trails = [unstarted_trail, started_trail]
+  describe "#unpromoted_unstarted_trails" do
+    it "returns trails that the user hasn't started and are unpromoted" do
+      started_trail = build_trail(unstarted: false)
+      unstarted_trail = build_trail(unstarted: true)
+      promoted_unstarted_trail = build_trail(unstarted: true, promoted: true)
+      trails = [unstarted_trail, started_trail, promoted_unstarted_trail]
 
-      result = build_practice(trails: trails).unstarted_trails
+      result = build_practice(trails: trails).unpromoted_unstarted_trails
 
       expect(result).to eq([unstarted_trail])
     end
@@ -52,10 +53,11 @@ describe Practice do
 
   describe "#in_progress_trails" do
     it "returns trails the user has started" do
+      today = Date.today
       in_progress_trail =
-        double("in-progress-trail", in_progress?: true)
+        double("in-progress-trail", in_progress?: true, started_on: today)
       not_in_progress_trail =
-        double("not-in-progress-trail", in_progress?: false)
+        double("not-in-progress-trail", in_progress?: false, started_on: today)
 
       result =
         build_practice(trails: [in_progress_trail, not_in_progress_trail]).
@@ -79,5 +81,20 @@ describe Practice do
 
   def build_practice(trails: [], beta_offers: [])
     Practice.new(trails: trails, beta_offers: beta_offers)
+  end
+
+  def build_trail(
+    unstarted: false,
+    in_progress: true,
+    started_on: Date.today,
+    promoted: false
+  )
+    double(
+      "trail",
+      unstarted?: unstarted,
+      in_progress?: in_progress,
+      started_on: started_on,
+      promoted?: promoted,
+    )
   end
 end

--- a/spec/views/practice/show.html.erb_spec.rb
+++ b/spec/views/practice/show.html.erb_spec.rb
@@ -23,6 +23,18 @@ describe "practice/show.html" do
     end
   end
 
+  context "when there is a promoted trail that the user has not started" do
+    it "renders the promoted trail at the top with a promo message" do
+      trail = build_stubbed_promoted_trail_with_progress
+      stub_user_access(subscriber: true)
+
+      render_show promoted_unstarted_trails: [trail]
+
+      expect(rendered).to have_css(".promoted-trails")
+      expect(rendered).to have_content(I18n.t("trails.promoted_message"))
+    end
+  end
+
   context "when a user has activity in trails" do
     it "doesn't show 'view completed' link when it has no completed trails" do
       stub_user_access(subscriber: true)
@@ -62,7 +74,8 @@ describe "practice/show.html" do
       topics: [],
       beta_offers: [],
       in_progress_trails: [],
-      unstarted_trails: [],
+      promoted_unstarted_trails: [],
+      unpromoted_unstarted_trails: [],
       just_finished_trails: [],
       decks: [],
       has_completed_trails?: false
@@ -93,5 +106,12 @@ describe "practice/show.html" do
 
   def have_beta_offers
     have_content("Beta Trails")
+  end
+
+  def build_stubbed_promoted_trail_with_progress
+    build_stubbed(:trail, :promoted).tap do |trail|
+      allow(trail).to receive(:unstarted?).and_return(true)
+      allow(trail).to receive(:steps_remaining).and_return(1)
+    end
   end
 end


### PR DESCRIPTION
When we release a new trail, we typically want to draw subscribers attention to
it. This change allows for "promoting" a specified trail in order to support
this goal.

Specifically:
- Trails now have a `promoted` boolean field
- If a trail is both promoted and unstarted, it is listed first in an emphasized
  box with a promo message
- In progress trails are now sorted by how recently the user started them
  (rather than sorted / grouped by topic)

![promoted](https://cloud.githubusercontent.com/assets/420113/15755525/310e67b4-28cb-11e6-8d3f-be66fd4ae3dd.png)
