### PR TITLE
Upgrade nokogiri to fix a security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     multi_json (1.12.0)
     multi_xml (0.5.5)
@@ -181,8 +181,9 @@ GEM
       sass (>= 3.3)
     nested_form (0.3.2)
     netrc (0.11.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -212,6 +213,7 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    pkg-config (1.1.7)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -453,5 +455,8 @@ DEPENDENCIES
   webmock
   wrapped
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
From bundler-audit:

```
Name: nokogiri
Version: 1.6.7.2
Advisory: CVE-2015-8806
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1473
Title: Denial of service or RCE from libxml2 and libxslt
Solution: upgrade to >= 1.6.8
```
