### PR TITLE
Only install Heroku Toolbelt when deploying

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,3 @@
-machine:
-  pre:
-    - wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
 test:
   override:
     - bundle exec rake
@@ -10,5 +7,6 @@ deployment:
   staging:
     branch: master
     commands:
+      - wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
       - git remote add staging git@heroku.com:upcase-staging.git
       - ./bin/deploy staging


### PR DESCRIPTION
We only need the Heroku Toolbelt to run `bin/deploy`. We only deploy the master branch. Thus, we really only need it when we have a new commit in master, and should not install the Toolbelt for all builds.
