### PR TITLE
Fix nondeterministic spec

### DIFF
--- a/spec/models/status_finder_spec.rb
+++ b/spec/models/status_finder_spec.rb
@@ -71,7 +71,7 @@ describe StatusFinder do
     end
   end
 
-  def create_status(user, exercise, state, created_at: Date.current)
+  def create_status(user, exercise, state, created_at: Time.current)
     create(
       :status,
       user: user,


### PR DESCRIPTION
By setting `created_at` to `Date.current`, the order of the returned records was nondeterministic, since they all had the same `created_at` (because the date doesn't change with each call to `create_status`) and were sorted by `created_at`.

Now we use `Time.current`, which will be different on repeated calls to `create_status`, so ordering by `created_at` will give the expected result.
