### PR TITLE
Always allow users to set / update their password

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,9 +17,7 @@
         <%= form.input :bio, label: "About You", as: :text, input_html: { rows: 4 } %>
         <%= form.input :email, as: :email %>
         <%= form.input :github_username %>
-        <% if !current_user.external_auth? %>
-          <%= form.input :password %>
-        <% end %>
+        <%= form.input :password, label: "Password (not required for GitHub auth)" %>
       <% end %>
 
       <%= form.actions do %>


### PR DESCRIPTION
Because:
- Some users want to use password auth
- We hide the password field on the `my_account` page if you ever log in via
  GitHub

This change:
- Always displays the password field so users can set or update a password
  (regardless of / in addition to using GitHub auth)
