### PR TITLE
Fix Bourbon Sass warnings

### DIFF
--- a/app/assets/stylesheets/_checkouts-new.scss
+++ b/app/assets/stylesheets/_checkouts-new.scss
@@ -250,12 +250,12 @@ body.checkouts-new, body.checkouts-create {
     font-weight: 600;
 
     &:before {
-      @include size(18 24);
+      @include size(18px 24px);
       background: image-url('icons/secure.svg') no-repeat;
       content: "";
       display: inline-block;
-      padding: 0 em(2) 0;
-      vertical-align: -5%;
+      margin-right: 0.5em;
+      vertical-align: -10%;
     }
   }
 

--- a/app/assets/stylesheets/_trails.scss
+++ b/app/assets/stylesheets/_trails.scss
@@ -175,8 +175,8 @@ $not-started-dot-color: #D8D8D8;
 
       &:last-of-type {
         &.complete-exercise .dot {
-          @include size(36);
-          background: image-url('trail-complete-check.svg') center /36px no-repeat;
+          @include size(36px);
+          background: image-url('trail-complete-check.svg') center no-repeat;
         }
       }
 


### PR DESCRIPTION
- Bourbon's `size` mixin requires units for the values passed
- CSS's background property doesn't understand '/36'
- Ref: #1454

The credit card form in production currently looks like this:

<img width="517" alt="screen shot 2016-06-16 at 14 50 47" src="https://cloud.githubusercontent.com/assets/903327/16129201/e1069eaa-33d1-11e6-92ea-f5e373b1ad61.png">

…and now after these changes, like this (note the “lock” icon):

<img width="516" alt="screen shot 2016-06-16 at 14 50 20" src="https://cloud.githubusercontent.com/assets/903327/16129203/e3462ad2-33d1-11e6-8bc2-0203c792fcd3.png">
