### PR TITLE
Fix spacing on the team edit page

### DIFF
--- a/app/assets/stylesheets/_teams-edit.scss
+++ b/app/assets/stylesheets/_teams-edit.scss
@@ -10,6 +10,10 @@ body.teams-edit {
     margin: 0;
     padding: 0;
 
+    .username {
+      margin-left: 1.5em;
+    }
+
     li {
       border: 1px solid $warmgray;
       border-radius: 3px;

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -24,7 +24,7 @@
     <ul class="members">
       <% @team.users.each do |user| %>
         <li class="<%= "owner" if @team.owner?(user) %>">
-          <%= user.name %>
+          <span class="username"><%= user.name %></span>
           <%= link_to(
             "✖",
             membership_path(user),


### PR DESCRIPTION
The existing version of this page had an unfortunate overlap between the `X` and
the team members name (when listing the team members).

This change add some spacing to prevent the overlap.

Before:

![before](https://cloud.githubusercontent.com/assets/420113/16129957/12bf3cc4-33d5-11e6-9a96-3277e19abb6d.png)

After:

![after](https://cloud.githubusercontent.com/assets/420113/16129960/15db92ae-33d5-11e6-839e-be8764b4e0f4.png)
