### PR TITLE
Upgrade Autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,7 @@ gem "mime-types", '~> 2.6', require: 'mime/types/columnar'
 gem "active_model_serializers", "0.8.3"
 gem "acts_as_list", "~> 0.6.0"
 gem "analytics-ruby", "~> 2.0.0", require: "segment/analytics"
-# autoprefixer-rails 6.0+ prints a warning (not an error) about outdated
-# `gradient` usage in rails-admin's CSS. In order to not show the warning, use a
-# lower version until rails-admin has better CSS.
-gem "autoprefixer-rails", "< 6.0"
+gem "autoprefixer-rails", "~> 6.0"
 gem "aws-sdk"
 gem "bourbon", "~> 4.0"
 gem "clearance", "~> 1.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     addressable (2.4.0)
     analytics-ruby (2.0.13)
     arel (6.0.3)
-    autoprefixer-rails (5.2.1.3)
+    autoprefixer-rails (6.3.6.2)
       execjs
     aws-sdk (2.2.36)
       aws-sdk-resources (= 2.2.36)
@@ -117,7 +117,7 @@ GEM
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.7.0)
@@ -383,7 +383,7 @@ DEPENDENCIES
   active_model_serializers (= 0.8.3)
   acts_as_list (~> 0.6.0)
   analytics-ruby (~> 2.0.0)
-  autoprefixer-rails (< 6.0)
+  autoprefixer-rails (~> 6.0)
   aws-sdk
   bourbon (~> 4.0)
   bundler-audit
@@ -459,4 +459,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,1 @@
+remove: false


### PR DESCRIPTION
[This commit](https://github.com/thoughtbot/upcase/commit/a3818fba628251dd17d40afce328e2b0d0158c73) locked `autoprefixer-rails` down below `6.0`, but I believe by setting `remove` to `false` in the Autoprefixer configuration, it will no longer remove old prefixes and we shouldn’t see those warnings.
