### PR TITLE
Remove duplicate meta descriptions

### DIFF
--- a/app/views/application/_head_contents.html.erb
+++ b/app/views/application/_head_contents.html.erb
@@ -3,7 +3,7 @@
 <%= render 'layouts/stylesheets' %>
 <link rel="icon" href="/upcase/favicon.ico" type="image/x-icon">
 <%= content_for :additional_head_content %>
-<meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence || t('layouts.fallback_meta_description') %>" />
+<meta http-equiv="Description" name="Description" content="<%= yield(:meta_description).presence %>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="google-site-verification" content="pFoYtgbd6tc74KGxv5yWxu2QTH0oKllYLrYbTt35iNM" />
 <%= open_graph_tags %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for :additional_body_classes, "landing" %>
 <% content_for :sticky_header_height, '450' %>
 <% content_for :page_title, "Subscribe to Upcase" %>
+<% content_for :meta_description, t('layouts.home_description') %>
 <% content_for :additional_head_content do %>
   <link rel="canonical" href="<%= join_url %>">
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,8 +100,8 @@ en:
   github_logo: GitHub
   layouts:
     app_name: Upcase
-    fallback_meta_description: Join Upcase by thoughtbot. Explore video tutorials, exercises, forum discussions and the community you need to grow as a web developer.
     fallback_page_title: Upcase by thoughtbot | Learn Web Development Online
+    home_description: Join Upcase by thoughtbot. Explore video tutorials, exercises, forum discussions and the community you need to grow as a web developer.
     thoughtbot: thoughtbot
   licenses:
     flashes:


### PR DESCRIPTION
> It is better to have unique meta descriptions
> and even no meta descriptions at all,
> then to show duplicate meta descriptions across pages.

http://searchengineland.com/googles-matt-cutts-dont-duplicate-your-meta-descriptions-177706

We have over 1,000 duplicate meta descriptions across thoughtbot.com.
Most are on the blog but some are on Upcase.

https://ahrefs.com/dashboard/domain-health/7bbe91838776306dee8019245815e8cd/critical

Ahrefs classifies these as "critical".

Remove the fallback site-wide,
and re-use the old fallback text for the home marketing page.
