### PR TITLE
Move subscription analytics tracking to server side

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -16,6 +16,7 @@ class CheckoutsController < ApplicationController
       sign_in_created_user checkout.user
       if success
         session.delete(:coupon)
+        track_subscription(checkout)
         redirect_after_checkout checkout
       else
         @checkout = checkout
@@ -57,6 +58,16 @@ class CheckoutsController < ApplicationController
     else
       yield checkout
     end
+  end
+
+  def track_subscription(checkout)
+    analytics.track_subscribed(
+      context: {
+        campaign: session[:campaign_params],
+      },
+      plan: checkout.plan_sku,
+      revenue: checkout.price,
+    )
   end
 
   def redirect_from_invalid_coupon

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -31,10 +31,6 @@ module AnalyticsHelper
     }
   end
 
-  def purchased_hash
-    campaign_hash.merge(revenue: flash[:purchase_amount])
-  end
-
   def campaign_hash
     {
       context: {

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -2,6 +2,7 @@ class Analytics
   include AnalyticsHelper
 
   SAMPLER = "sampler".freeze
+  SUBSCRIBED_EVENT_NAME = "Subscribed".freeze
   SUBSCRIBER = "subscriber".freeze
   TRACKERS = {
     "Video" => VideoTracker,
@@ -54,6 +55,15 @@ class Analytics
 
   def track_cancelled(reason:)
     track("Cancelled", reason: reason)
+  end
+
+  def track_subscribed(context:, plan:, revenue:)
+    track(
+      SUBSCRIBED_EVENT_NAME,
+      context: context,
+      plan: plan,
+      revenue: revenue,
+    )
   end
 
   def track_subscription_reactivated

--- a/app/views/application/_analytics.html.erb
+++ b/app/views/application/_analytics.html.erb
@@ -2,20 +2,12 @@
   window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
   window.analytics.load("<%= ENV["SEGMENT_KEY"]%>");
 
-  <% if flash[:purchase_amount] %>
-    window.analytics.alias("<%= current_user.id %>");
-  <% end %>
-
   <% if signed_in? %>
     window.analytics.identify(
       '<%= current_user.id %>',
       <%= raw identify_hash.to_json %>,
       <%= raw intercom_hash.to_json %>
       );
-  <% end %>
-
-  <% if flash[:purchase_amount] %>
-    window.analytics.track("Subscribed", <%= raw purchased_hash.to_json %>);
   <% end %>
 
   window.analytics.page(

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -50,32 +50,4 @@ describe AnalyticsHelper do
       )
     end
   end
-
-  describe "#purchased_hash" do
-    it "tracks the purchase amount" do
-      purchase_amount = "29.00"
-      flash[:purchase_amount] = purchase_amount
-
-      expect(purchased_hash[:revenue]).to eq(purchase_amount)
-    end
-
-    context "without campaign params" do
-      it "tracks nil" do
-        expect(purchased_hash[:context]).to eq(campaign: nil)
-      end
-    end
-
-    context "with campaign params" do
-      it "tracks the campaign params" do
-        campaign_params = {
-          utm_source: "twitter",
-          utm_medium: "twitter-ads",
-          utm_campaign: "e123a"
-        }
-        session[:campaign_params] = campaign_params
-
-        expect(purchased_hash[:context]).to eq(campaign: campaign_params)
-      end
-    end
-  end
 end

--- a/spec/views/application/_analytics.html.erb_spec.rb
+++ b/spec/views/application/_analytics.html.erb_spec.rb
@@ -25,22 +25,6 @@ describe "application/_analytics.html.erb" do
     end
   end
 
-  context "when signing up" do
-    it "aliases the user id" do
-      user = build_stubbed(:user)
-      view_stub_with_return(
-        current_user: user,
-        flash: { purchase_amount: 29 },
-        purchased_hash: "",
-        signed_in?: false
-      )
-
-      render
-
-      expect(rendered).to include(%{analytics.alias("#{user.id}")})
-    end
-  end
-
   context 'when signed in' do
     around(:each) do |example|
       ClimateControl.modify INTERCOM_API_SECRET: secret do


### PR DESCRIPTION
https://trello.com/c/PBTwRWPw

We have been noticing that various JS blockers are interfering with
analytics collection. As there's no compelling reason to require
tracking of subscription events on the client, we can move this to the
browser.

This change:
- Adds a tracking event for `Subscribed` to the checkout process
- Removes JS-based tracking of the subscription event
- Removes vestigial helper code previously needed to support
  browser-side subscription tracking
