### PR TITLE
Add support for unsubscribing from emails

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -19,6 +19,7 @@ SECRET_KEY_BASE=development_secret
 SKYLIGHT_AUTHENTICATION=foo
 SPIT_DASHBOARD_PASSWORD=password
 SUPPORT_EMAIL=help@upcase.com
+UNSUBSCRIBE_SECRET_BASE=unsub_sekret
 WIDGETS_API_KEY=api_key
 WISTIA_API_KEY=api_key
 WISTIA_HOST=fast.wistia.com

--- a/app/controllers/unsubscribes_controller.rb
+++ b/app/controllers/unsubscribes_controller.rb
@@ -1,0 +1,26 @@
+class UnsubscribesController < ApplicationController
+  include UnsubscribesHelper
+
+  UNSUBSCRIBE_ERRORS = [
+    ActiveRecord::RecordNotFound,
+    ActiveSupport::MessageVerifier::InvalidSignature,
+  ].freeze
+
+  def show
+    user = find_user_by_token
+    unsubscribe_user(user)
+  rescue *UNSUBSCRIBE_ERRORS
+    render :error, status: :unprocessable_entity
+  end
+
+  private
+
+  def unsubscribe_user(user)
+    user.update! unsubscribed_from_emails: true
+  end
+
+  def find_user_by_token
+    user_id_from_token = unsubscribe_token_verifier.verify(params[:token])
+    User.find user_id_from_token
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,8 @@ class UsersController < Clearance::UsersController
   def create_user_from_params
     params.require(:user).permit(
       :email, :password, :name, :github_username, :bio, :organization,
-      :address1, :address2, :city, :state, :zip_code, :country
+      :address1, :address2, :city, :state, :zip_code, :country,
+      :unsubscribed_from_emails
     )
   end
 

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -14,6 +14,7 @@ module AnalyticsHelper
       scheduled_for_deactivation_on: user.scheduled_for_deactivation_on,
       stripe_customer_url: StripeCustomer.new(user).url,
       subscribed_at: user.subscribed_at,
+      unsubscribed_from_emails: user.unsubscribed_from_emails,
       user_id: user.id,
       username: user.github_username,
     }

--- a/app/helpers/unsubscribes_helper.rb
+++ b/app/helpers/unsubscribes_helper.rb
@@ -1,0 +1,8 @@
+module UnsubscribesHelper
+  def unsubscribe_token_verifier
+    @_unsubscribe_token_verifier ||= ActiveSupport::MessageVerifier.new(
+      ENV.fetch("UNSUBSCRIBE_SECRET_BASE"),
+      digest: "SHA256".freeze,
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ActiveRecord::Base
   )
 
   before_save :clean_github_username
+  after_save :track_update_via_analytics
 
   def first_name
     name.split(" ").first
@@ -152,5 +153,13 @@ class User < ActiveRecord::Base
       compact.
       reject(&:active?).
       max_by(&:deactivated_on)
+  end
+
+  def track_update_via_analytics
+    analytics.track_updated
+  end
+
+  def analytics
+    Analytics.new(self)
   end
 end

--- a/app/views/unsubscribes/error.html.erb
+++ b/app/views/unsubscribes/error.html.erb
@@ -1,0 +1,6 @@
+<h3>Unable to unsubscribe</h3>
+
+<p>
+  Unfortunately we were unable to process your request to unsubscribe.
+  You can directly manage this setting on <%= link_to "your profile page", my_account_path %>.
+</p>

--- a/app/views/unsubscribes/show.html.erb
+++ b/app/views/unsubscribes/show.html.erb
@@ -1,0 +1,6 @@
+<h3>Unsubscribed Successfully</h3>
+
+<p>
+  We've unsubscribed you from email communications. You can manage this setting on
+  <%= link_to "your profile page", my_account_path %> if you wish to change it.
+</p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -18,6 +18,7 @@
         <%= form.input :email, as: :email %>
         <%= form.input :github_username %>
         <%= form.input :password, label: "Password (not required for GitHub auth)" %>
+        <%= form.input :unsubscribed_from_emails %>
       <% end %>
 
       <%= form.actions do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ Upcase::Application.routes.draw do
       )
     end
 
+    get "/unsubscribes/:token" => "unsubscribes#show", as: :unsubscribe
+
     get "/join" => "subscriptions#new", as: :sign_up
     get "/join" => "subscriptions#new", as: :join
     get "/sign_in" => "sessions#new", as: "sign_in"

--- a/db/migrate/20160804181146_add_unsubscribed_from_emails_to_user.rb
+++ b/db/migrate/20160804181146_add_unsubscribed_from_emails_to_user.rb
@@ -1,0 +1,11 @@
+class AddUnsubscribedFromEmailsToUser < ActiveRecord::Migration
+  def change
+    add_column(
+      :users,
+      :unsubscribed_from_emails,
+      :boolean,
+      null: false,
+      default: false,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601215621) do
+ActiveRecord::Schema.define(version: 20160804181146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -355,32 +355,33 @@ ActiveRecord::Schema.define(version: 20160601215621) do
   add_index "trails", ["slug"], name: "index_trails_on_slug", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",              limit: 255
-    t.string   "encrypted_password", limit: 128
-    t.string   "salt",               limit: 128
-    t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128
-    t.boolean  "email_confirmed",                default: true,  null: false
+    t.string   "email",                    limit: 255
+    t.string   "encrypted_password",       limit: 128
+    t.string   "salt",                     limit: 128
+    t.string   "confirmation_token",       limit: 128
+    t.string   "remember_token",           limit: 128
+    t.boolean  "email_confirmed",                      default: true,  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "reference",          limit: 255
-    t.boolean  "admin",                          default: false, null: false
-    t.string   "stripe_customer_id", limit: 255, default: "",    null: false
-    t.string   "github_username",                                null: false
-    t.string   "auth_provider",      limit: 255
+    t.string   "reference",                limit: 255
+    t.boolean  "admin",                                default: false, null: false
+    t.string   "stripe_customer_id",       limit: 255, default: "",    null: false
+    t.string   "github_username",                                      null: false
+    t.string   "auth_provider",            limit: 255
     t.integer  "auth_uid"
-    t.string   "organization",       limit: 255
-    t.string   "address1",           limit: 255
-    t.string   "address2",           limit: 255
-    t.string   "city",               limit: 255
-    t.string   "state",              limit: 255
-    t.string   "zip_code",           limit: 255
-    t.string   "country",            limit: 255
-    t.string   "name",               limit: 255
+    t.string   "organization",             limit: 255
+    t.string   "address1",                 limit: 255
+    t.string   "address2",                 limit: 255
+    t.string   "city",                     limit: 255
+    t.string   "state",                    limit: 255
+    t.string   "zip_code",                 limit: 255
+    t.string   "country",                  limit: 255
+    t.string   "name",                     limit: 255
     t.text     "bio"
     t.integer  "team_id"
     t.string   "utm_source"
-    t.boolean  "completed_welcome",              default: false, null: false
+    t.boolean  "completed_welcome",                    default: false, null: false
+    t.boolean  "unsubscribed_from_emails",             default: false, null: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree

--- a/spec/controllers/unsubscribes_controller_spec.rb
+++ b/spec/controllers/unsubscribes_controller_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe UnsubscribesController do
+  include UnsubscribesHelper
+
+  describe "#show" do
+    context "with a valid unsubscribe token" do
+      it "updates the user's unsubscribe preference" do
+        user = create(:user)
+
+        get :show, token: unsubscribe_token_for(user)
+
+        expect(user.reload).to be_unsubscribed_from_emails
+      end
+    end
+
+    context "with an invalid token" do
+      it "displays a relavant error page and status to the user" do
+        get :show, token: "not-a-real-unsub-token"
+
+        expect(response).to render_template("unsubscribes/error")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the user can't be found" do
+      it "displays a relavant error page and status to the user" do
+        get :show, token: unsubscribe_token_for(double("not-a-user", id: 99999))
+
+        expect(response).to render_template("unsubscribes/error")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  def unsubscribe_token_for(user)
+    unsubscribe_token_verifier.generate(user.id)
+  end
+end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -45,6 +45,7 @@ describe AnalyticsHelper do
         scheduled_for_deactivation_on: nil,
         stripe_customer_url: StripeCustomer.new(user).url,
         subscribed_at: user.subscribed_at,
+        unsubscribed_from_emails: user.unsubscribed_from_emails,
         user_id: user.id,
         username: user.github_username,
       )

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -140,8 +140,10 @@ describe Subscription do
 
         subscription.write_plan(sku: create(:plan).sku)
 
-        expect(Analytics).to have_received(:new).with(subscription.user)
-        expect(analytics_updater).to have_received(:track_updated)
+        expect(Analytics).
+          to have_received(:new).with(subscription.user).at_least(:once)
+        expect(analytics_updater).
+          to have_received(:track_updated).at_least(:once)
       end
     end
 
@@ -155,9 +157,12 @@ describe Subscription do
 
         subscription.write_plan(sku: create(:plan).sku)
 
-        expect(Analytics).to have_received(:new).with(users.first)
-        expect(Analytics).to have_received(:new).with(users.second)
-        expect(analytics_updater).to have_received(:track_updated).twice
+        expect(Analytics).
+          to have_received(:new).with(users.first).at_least(:once)
+        expect(Analytics).
+          to have_received(:new).with(users.second).at_least(:once)
+        expect(analytics_updater).
+          to have_received(:track_updated).at_least(:twice)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,17 @@ describe User do
     end
   end
 
+  context "callbacks" do
+    it "identifies the user with analytics after saving" do
+      user = build(:user)
+      analytics_stub = stub_analytics_for(user)
+
+      user.save
+
+      expect(analytics_stub).to have_received(:track_updated)
+    end
+  end
+
   context "#first_name" do
     it "has a first_name that is the first part of name" do
       user = User.new(name: "first last")

--- a/spec/services/auth_hash_service_spec.rb
+++ b/spec/services/auth_hash_service_spec.rb
@@ -107,6 +107,7 @@ describe AuthHashService, '#find_or_create_user_from_auth_hash' do
   def stub_analytics_tracker
     double("Analytics").tap do |tracker|
       allow(tracker).to receive(:track_account_created)
+      allow(tracker).to receive(:track_updated)
       allow(Analytics).to receive(:new).and_return(tracker)
     end
   end

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -8,4 +8,10 @@ module AnalyticsHelper
       allow(Analytics).to receive(:new).and_return(analytics)
     end
   end
+
+  def stub_analytics_for(user)
+    double("Analytics", track_updated: true).tap do |analytics_stub|
+      allow(Analytics).to receive(:new).with(user).and_return(analytics_stub)
+    end
+  end
 end


### PR DESCRIPTION
This is a foundational change, in preparation for the Weekly Iteration Drip mailer automation work that is in process. With this, we:
- Add an `unsubscribed_from_email` field to the `User` model
- Allow users to manage this setting on their account page
- Add a helper to support generating unsubscribe tokens associated to a user
- Add an `UnsubscribesController` to handle users clicking unsub links
- Add the `unsubscribed_from_email` field to the analytics identify hash (which will cause Intercom to pick up on and respect the unsubscribe)

**Note** None of the existing mailers were viable for including an unsubscribe link as they were related to critical billing and subscription info.
