### PR TITLE
Drip implementation

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 APP_DOMAIN=example.com
+CLEARANCE_COOKIE_NAME=upcase_remember_token
 SECRET_KEY_BASE=test_secret
 SUPPORT_EMAIL=help@example.com
-CLEARANCE_COOKIE_NAME=upcase_remember_token
+WEEKLY_ITERATION_DRIP_MAILER_FROM="Ben from thoughtbot <ben@thoughtbot.com>"

--- a/.sample.env
+++ b/.sample.env
@@ -21,6 +21,7 @@ SKYLIGHT_AUTHENTICATION=foo
 SPIT_DASHBOARD_PASSWORD=password
 SUPPORT_EMAIL=help@upcase.com
 UNSUBSCRIBE_SECRET_BASE=unsub_sekret
+WEEKLY_ITERATION_DRIP_MAILER_FROM="Ben from thoughtbot <ben@thoughtbot.com>"
 WIDGETS_API_KEY=api_key
 WISTIA_API_KEY=api_key
 WISTIA_HOST=fast.wistia.com

--- a/app/jobs/weekly_iteration_mailer_job.rb
+++ b/app/jobs/weekly_iteration_mailer_job.rb
@@ -1,0 +1,28 @@
+class WeeklyIterationMailerJob < ActiveJob::Base
+  include ErrorReporting
+
+  def perform(user_id, video_id)
+    @user_id = user_id
+    @video_id = video_id
+
+    send_weekly_iteration_mailer
+  end
+
+  private
+
+  attr_reader :user_id, :video_id
+
+  def send_weekly_iteration_mailer
+    WeeklyIterationDripMailer.
+      weekly_update(user: user, video: video).
+      deliver_now
+  end
+
+  def user
+    User.find user_id
+  end
+
+  def video
+    Video.find video_id
+  end
+end

--- a/app/mailers/weekly_iteration_drip_mailer.rb
+++ b/app/mailers/weekly_iteration_drip_mailer.rb
@@ -1,0 +1,23 @@
+class WeeklyIterationDripMailer < ActionMailer::Base
+  include UnsubscribesHelper
+
+  default(
+    from: ENV.fetch("WEEKLY_ITERATION_DRIP_MAILER_FROM"),
+    reply_to: ENV.fetch("SUPPORT_EMAIL"),
+  )
+
+  def weekly_update(user:, video:)
+    @unsubscribe_token = unsubscribe_token_verifier.generate(user.id)
+    @user = user
+    @utm_params = {
+      utm_campaign: "#{video.slug}-weekly-drip",
+      utm_medium: "email",
+    }
+    @video = video
+
+    mail(
+      to: user.email,
+      subject: @video.email_subject,
+    )
+  end
+end

--- a/app/models/active_subscribers.rb
+++ b/app/models/active_subscribers.rb
@@ -1,0 +1,37 @@
+class ActiveSubscribers
+  include Enumerable
+
+  def initialize(relation: Subscription.all)
+    @relation = relation
+  end
+
+  def each(&block)
+    subscribers.each(&block)
+  end
+
+  private
+
+  def subscribers
+    active_team_subscribers + active_personal_subscribers
+  end
+
+  def active_team_subscribers
+    active_teams.flat_map(&:users)
+  end
+
+  def active_personal_subscribers
+    subscriptions_for(plans: Plan.individual).map(&:user)
+  end
+
+  def active_teams
+    subscriptions_for(plans: Plan.team).map(&:team)
+  end
+
+  def subscriptions_for(plans:)
+    @relation.
+      active.
+      where(plan: plans).
+      includes(:user).
+      includes(team: :users)
+  end
+end

--- a/app/models/content_recommendation.rb
+++ b/app/models/content_recommendation.rb
@@ -1,0 +1,4 @@
+class ContentRecommendation < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :recommendable, polymorphic: true
+end

--- a/app/models/content_suggestor.rb
+++ b/app/models/content_suggestor.rb
@@ -1,0 +1,25 @@
+class ContentSuggestor
+  def initialize(recommendables:, user:, recommended:)
+    @recommendables = recommendables
+    @status_finder = StatusFinder.new(user: user)
+    @recommended = recommended
+  end
+
+  def next_up
+    first_unseen_recommendable.wrapped
+  end
+
+  private
+
+  attr_reader :recommendables, :recommended, :status_finder
+
+  def unrecommended_recommendables
+    recommendables - recommended
+  end
+
+  def first_unseen_recommendable
+    unrecommended_recommendables.detect do |recommendable|
+      status_finder.current_status_for(recommendable).unstarted?
+    end
+  end
+end

--- a/app/models/recommendable_content.rb
+++ b/app/models/recommendable_content.rb
@@ -1,0 +1,11 @@
+class RecommendableContent < ActiveRecord::Base
+  acts_as_list
+
+  belongs_to :recommendable, polymorphic: true
+
+  validates :position, uniqueness: true
+
+  def self.priority_ordered
+    order(position: :asc)
+  end
+end

--- a/app/services/weekly_iteration_recommender.rb
+++ b/app/services/weekly_iteration_recommender.rb
@@ -1,0 +1,51 @@
+class WeeklyIterationRecommender
+  def initialize(user:, sorted_recommendable_videos:)
+    @user = user
+    @sorted_recommendable_videos = sorted_recommendable_videos
+  end
+
+  def recommend
+    suggestor.
+      next_up.
+      present do |video|
+        create_recommendation(video)
+        enqueue_email_for(video)
+      end.
+      blank { log_no_further_recommendations(user) }
+  end
+
+  private
+
+  attr_reader :user, :sorted_recommendable_videos
+
+  def create_recommendation(video)
+    ContentRecommendation.create!(
+      user: user,
+      recommendable: video,
+    )
+  end
+
+  def enqueue_email_for(video)
+    WeeklyIterationMailerJob.perform_later(user.id, video.id)
+  end
+
+  def suggestor
+    ContentSuggestor.new(
+      user: user,
+      recommendables: sorted_recommendable_videos,
+      recommended: previously_recommended,
+    )
+  end
+
+  def previously_recommended
+    ContentRecommendation.
+      where(user: user).
+      map(&:recommendable)
+  end
+
+  def log_no_further_recommendations(user)
+    Rails.logger.warn(
+      "No further recommendable videos for user: #{user.id} <#{user.email}>",
+    )
+  end
+end

--- a/app/services/weekly_iteration_suggestions.rb
+++ b/app/services/weekly_iteration_suggestions.rb
@@ -1,0 +1,23 @@
+class WeeklyIterationSuggestions < ActiveJob::Base
+  include ErrorReporting
+
+  def initialize(subscribers)
+    @subscribers = subscribers
+    @sorted_recommendable_videos = RecommendableContent.
+      priority_ordered.
+      map(&:recommendable)
+  end
+
+  def send
+    subscribers.each do |subscriber|
+      WeeklyIterationRecommender.new(
+        user: subscriber,
+        sorted_recommendable_videos: sorted_recommendable_videos,
+      ).recommend
+    end
+  end
+
+  private
+
+  attr_reader :subscribers, :sorted_recommendable_videos
+end

--- a/app/views/weekly_iteration_drip_mailer/weekly_update.html.erb
+++ b/app/views/weekly_iteration_drip_mailer/weekly_update.html.erb
@@ -1,0 +1,664 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<style type="text/css">
+  #PreviewIntercomModal .ic_message_content h1,
+  #PreviewIntercomModal .ic_message_content h2 {
+    color: #0072b0 !important;
+  }
+  #PreviewIntercomModal .ic_message_without_image > .ic_message_internals > .ic_message_content {
+    border-color: #0072b0 !important;
+  }
+  #PreviewIntercomModal .ic_user_comment_body {
+    background-color: #0072b0 !important;
+    border-color: #0072b0 !important;
+  }
+  #PreviewIntercomModal .ic_message_content a {
+    color: #0072b0 !important;
+  }
+  #PreviewIntercomModal .ic_message_content a:hover {
+    color: #0072b0 !important;
+  }
+  #PreviewIntercomModal .ic_user_comment_body {
+    background-color: #0072b0 !important;
+    border-color: #0072b0 !important;
+  }
+  .intercom-h2b-button br {
+    display: none;
+  }
+</style>
+<style type="text/css" data-premailer="ignore">
+  /* styles in here will not be inlined. Use for media queries etc */
+  /* force Outlook to provide a "view in browser" menu link. */
+  #outlook a {padding:0;}
+  /* prevent Webkit and Windows Mobile platforms from changing default font sizes.*/
+  body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+  /* force Hotmail to display emails at full width */
+  .ExternalClass {width:100%;}
+  /* force Hotmail to display normal line spacing. http://www.emailonacid.com/forum/viewthread/43/ */
+  .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}
+  /* fix a padding issue on Outlook 07, 10 */
+  table td {border-collapse: collapse;}
+  table {
+    table-layout: fixed;
+  }
+
+  @media only screen and (max-width: 480px)
+  {
+    br.hidden { display: block !important; }
+    td.padding_cell { display: none !important; }
+    table.message_footer_table td {
+      font-size: 11px !important;
+    }
+  }
+  @media only screen and (max-device-width: 480px)
+  {
+    br.hidden { display: block !important; }
+    td.padding_cell { display: none !important; }
+    table.message_footer_table td {
+      font-size: 11px !important;
+    }
+  }
+</style>
+
+<style type="text/css" data-premailer="ignore">
+  /* styles in here will not be inlined. Use for media queries etc */
+  /* force Outlook to provide a "view in browser" menu link. */
+  #outlook a {padding:0;}
+  /* prevent Webkit and Windows Mobile platforms from changing default font sizes.*/
+  body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;}
+  /* force Hotmail to display emails at full width */
+  .ExternalClass {width:100%;}
+  /* force Hotmail to display normal line spacing. http://www.emailonacid.com/forum/viewthread/43/ */
+  .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}
+  /* fix a padding issue on Outlook 07, 10 */
+  table td {border-collapse: collapse;}
+
+  @media only screen and (max-width: 480px)
+  {
+    br.hidden { display: block !important; }
+    td.padding_cell { display: none !important; }
+    table.message_footer_table td {
+      font-size: 11px !important;
+    }
+  }
+  @media only screen and (max-device-width: 480px)
+  {
+    br.hidden { display: block !important; }
+    td.padding_cell { display: none !important; }
+    table.message_footer_table td {
+      font-size: 11px !important;
+    }
+  }
+</style>
+
+<style type="text/css">
+
+  .admin_name b {
+    color: #6f6f6f;
+  }
+
+  .date_cell a {
+    color: #999999;
+  }
+
+  .comment_header_td {
+    width: 100%;
+    background: #2388e0;
+    border: none;
+    font-family: 'Helvetica Neue',Arial,sans-serif
+  }
+
+  .content-td {
+    color: #525252;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+    font-family: Helvetica, Arial, sans-serif;
+  }
+
+  .content-td h1 {
+    font-size: 26px;
+    line-height: 33px;
+    color: #282F33;
+    margin-bottom: 7px;
+    margin-top: 30px;
+    font-weight: normal;
+  }
+
+  .content-td h1 a {
+    color: #282F33;
+  }
+
+  .content-td h2 {
+    font-size: 18px;
+    font-weight: bold;
+    color: #282F33;
+    margin: 30px 0 7px;
+  }
+
+  .content-td h2 a {
+    color: #282F33;
+  }
+
+  .content-td h1 + h2 {
+    margin-top: 0 !important;
+  }
+
+  .content-td h2 + h1 {
+    margin-top: 0 !important;
+  }
+
+  .content-td h3 ,
+  .content-td h4 ,
+  .content-td h5 {
+    font-size: 16px;
+    font-weight: bold;
+    margin-bottom: 5px;
+  }
+
+  .content-td p {
+    margin: 0 0 17px 0;
+    line-height: 1.5;
+  }
+
+  .content-td p img,
+  .content-td h1 img,
+  .content-td h2 img,
+  .content-td li img,
+  .content-td .intercom-h2b-button img {
+    margin: 0;
+    padding: 0;
+  }
+
+  .content-td a {
+    color: #1251ba;
+  }
+
+  .content-td p.intro {
+    font-size: 20px;
+    line-height: 30px;
+  }
+
+  .content-td blockquote {
+    margin: 40px 0;
+    font-style: italic;
+    color: #8C8C8C;
+    font-size: 18px;
+    text-align: center;
+    padding: 0 30px;
+    font-family: Georgia, sans-serif;
+    quotes: none;
+  }
+
+  .content-td blockquote a {
+    color: #8C8C8C;
+  }
+
+  .content-td ul {
+    list-style: disc;
+    margin: 0 0 20px 40px;
+    padding: 0;
+  }
+
+  .content-td ol {
+    list-style: decimal;
+    margin: 0 0 20px 40px;
+    padding: 0;
+  }
+
+  .content-td img {
+    margin: 17px 0;
+    max-width: 100%;
+  }
+
+  .content-td .intercom-container {
+    margin-bottom: 16px;
+  }
+
+  .content-td hr {
+    border: none;
+    border-top: 1px solid #DDD;
+    border-bottom: 0;
+    margin: 50px 30% 50px 30%;
+  }
+
+  table.intercom-container {
+    margin: 17px 0;
+  }
+  table.intercom-container.intercom-align-center {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  table.intercom-container td {
+    background-color: #2388e0;
+    padding: 12px 35px;
+    border-radius: 3px;
+    font-family: Helvetica, Arial, sans-serif;
+    margin: 0;
+  }
+
+  .content-td .intercom-h2b-button {
+    font-size: 14px;
+    color: #FFF;
+    font-weight: bold;
+    display: inline-block;
+    text-decoration: none;
+    background-color: #2388e0;
+    border: none !important;
+
+      padding: 13px 35px;
+
+  }
+
+  a.intercom-h2b-button {
+    background-color: #0E4595;
+    border-radius: 5px;
+    border: 1px solid rgba(0,0,0,0.2);
+    color:#fff;
+    display: inline-block;
+    font-size: 15px;
+    font-weight: bold;
+    min-height: 20px;
+    text-decoration: none;
+  }
+
+  .content-td .intercom-h2b-button:hover {
+    background-color:#459ce9;
+  }
+
+  .message_footer_table .avatar {
+    -ms-interpolation-mode: bicubic;
+    -webkit-background-clip: padding-box;
+    -webkit-border-radius: 20px;
+    background-clip: padding-box;
+    border-radius: 20px;
+    display: inline-block;
+    height: 40px;
+    max-width: 100%;
+    outline: none;
+    text-decoration: none;
+    width: 40px;
+  }
+
+  .powered-by-table .powered-by-text a {
+    font-weight: bold;
+    text-decoration: none;
+    color: #999;
+  }
+
+  .main_wrapper {
+    padding: 0 20px;
+  }
+
+  .margin-arrow {
+    display: none;
+    mso-hide: all;
+    visibility:hidden;
+    width:0;
+    height:0;
+    max-width: 0;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+  }
+
+  .content-td > :first-child {
+    margin-top: 0;
+    padding-top: 0;
+  }
+</style>
+
+
+<style type="text/css" data-premailer="ignore">
+
+  @media screen and (max-width: 635px) {
+    .main-wrap {
+      width: 100% !important;
+    }
+  }
+
+  @media screen and (max-width: 480px) {
+    .content-td {
+      padding: 30px 15px !important;
+    }
+    .content-td h1 {
+      margin-bottom: 5px;
+    }
+    .message_footer_table .space {
+      width: 20px !important;
+    }
+
+    .message_footer_table .arrow-wrap {
+      padding-left: 20px !important;
+    }
+
+    .message_footer_table .admin_name b{
+      display: block !important;
+    }
+
+    .main_wrapper {
+      padding: 0;
+    }
+
+    .image-arrow {
+      display: none !important;
+    }
+
+    .margin-arrow {
+      display: table !important;
+      visibility:visible !important;
+      width: 100% !important;
+      height: auto !important;
+      max-width: none !important;
+      max-height: none !important;
+      opacity: 1 !important;
+      overflow: visible !important;
+    }
+
+    .comment_body {
+      border-bottom: 1px solid #DDD !important;
+    }
+
+    .footer-td-wrapper {
+      display: block !important;
+      width: 100% !important;
+      text-align: left !important;
+    }
+    .footer-td-wrapper .date_cell {
+      text-align: left !important;
+      padding: 15px 0 0 20px !important;
+    }
+  }
+
+</style>
+
+
+<style type="text/css" data-premailer="ignore">
+  .content-td blockquote + * {
+    margin-top: 20px !important;
+  }
+
+  .ExternalClass .content-td h1 {
+    padding: 20px 0 !important;
+  }
+
+  .ExternalClass .content-td h2 {
+    padding: 0 0 5px !important;
+  }
+
+  .ExternalClass .content-td p {
+    padding: 10px 0 !important;
+  }
+
+.ExternalClass .content-td .intercom-container {
+    padding: 5px 0 !important;
+  }
+
+  .ExternalClass .content-td hr + * {
+    padding-top: 30px !important;
+  }
+
+  .ExternalClass .content-td ol ,
+  .ExternalClass .content-td ul {
+    padding: 0 0 20px 40px !important;
+    margin: 0 !important;
+  }
+
+  .ExternalClass .content-td ol li,
+  .ExternalClass .content-td ul li {
+    padding: 3px 0 !important;
+    margin: 0 !important;
+  }
+  .content-td > :first-child {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
+
+  .ExternalClass .content-td > :first-child {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
+</style>
+
+
+
+<style type="text/css">
+  .intercom-align-right {
+  text-align: right !important;
+}
+.intercom-align-center {
+  text-align: center !important;
+}
+.intercom-align-left {
+  text-align: left !important;
+}
+/* Over-ride for RTL */
+.right-to-left .intercom-align-right{
+  text-align: left !important;
+}
+.right-to-left .intercom-align-left{
+  text-align: right !important;
+}
+.right-to-left .intercom-align-left {
+  text-align:right !important;
+}
+.right-to-left li {
+  text-align:right !important;
+  direction: rtl;
+}
+.right-to-left .intercom-align-left img,
+.right-to-left .intercom-align-left .intercom-h2b-button {
+  margin-left: 0 !important;
+}
+.intercom-attachment,
+.intercom-attachments,
+.intercom-attachments td,
+.intercom-attachments th,
+.intercom-attachments tr,
+.intercom-attachments tbody,
+.intercom-attachments .icon,
+.intercom-attachments .icon img {
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.intercom-attachments {
+  margin: 10px 0 !important;
+}
+.intercom-attachments .icon,
+.intercom-attachments .icon img {
+  width: 16px !important;
+  height: 16px !important;
+}
+.intercom-attachments .icon {
+  padding-right: 5px !important;
+}
+.intercom-attachment {
+  display: inline-block !important;
+  margin-bottom: 5px !important;
+}
+
+.intercom-interblocks-content-card {
+  width: 334px;
+  max-height: 136px;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: 20px;
+  font-size: 16px;
+  border: 1px solid #e0e0e0;
+}
+
+.intercom-interblocks-article-icon {
+  width: 22.5%;
+  height: 136px;
+  float: left;
+  background-color: #fafafa;
+  background-image: url('https://static.intercom-mail.com/assets/article_book-1a595be287f73c0d02f548f513bfc831.png');
+  background-repeat: no-repeat;
+  background-size: 32px;
+  background-position: center;
+}
+
+.intercom-interblocks-article-text {
+  width: 77.5%;
+  float: right;
+  background-color: #fff;
+}
+
+.intercom-interblocks-article-title {
+  color: #455a64;
+  height: 40px;
+  margin: 10px 15px;
+  line-height: 1.3;
+  font-weight: bold;
+  overflow: hidden;
+}
+
+.intercom-interblocks-article-body {
+  color: #74848b;
+  height: 30px;
+  margin: 10px 15px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3;
+  overflow: hidden;
+}
+
+.intercom-interblocks-article-author {
+  margin: 10px 15px;
+  height: 24px;
+  line-height: normal;
+}
+
+.intercom-interblocks-article-author-avatar {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+img.intercom-interblocks-article-author-avatar-image {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin: 0;
+  vertical-align: top;
+}
+
+.intercom-interblocks-article-author-name {
+  color: #74848b;
+  line-height: 1.2;
+  margin: 0 0 0 5px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+</style>
+
+
+
+
+</head>
+<body>
+
+
+<table cellpadding="0" cellspacing="0" border="0" class="bgtc personal" align="center" style="border-collapse: collapse; line-height: 100% !important; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding: 0; width: 100% !important; background-color: #f9f9f9;">
+  <tr>
+    <td>
+    <!--[if (gte mso 10)]>
+      <tr>
+      <td>
+      <table style="width: 600px">
+    <![endif]-->
+      <table style="border-collapse: collapse; margin: auto; width: 100%; max-width: 635px; min-width: 320px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" class="main-wrap">
+        <tr>
+          <td valign="top">
+            <table cellpadding="0" cellspacing="0" border="0" class="reply_header_table" style="border-collapse: collapse; color: #c0c0c0; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 13px; line-height: 26px; margin: 0 auto 26px; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%">
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td valign="top" class="main_wrapper">
+
+            <table cellpadding="0" cellspacing="0" border="0" class="comment_wrapper_table admin_comment" align="center" style="-webkit-background-clip: padding-box; -webkit-border-radius: 3px; background-clip: padding-box; border-collapse: collapse; border-radius: 3px; color: #545454; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 13px; line-height: 20px; margin: 0 auto; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%">
+              <tr>
+                <td valign="top" class="comment_wrapper_td">
+                  <table cellpadding="0" cellspacing="0" border="0" class="comment_header" style="border-collapse: separate; border: none; font-size: 1px; height: 2px; line-height: 3px; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%">
+                    <tr>
+                      <td valign="top" class="comment_header_td"> </td>
+                    </tr>
+                  </table>
+                  <table cellpadding="0" cellspacing="0" border="0" class="comment_body" style="-webkit-background-clip: padding-box; -webkit-border-radius: 0 0 3px 3px; background-clip: padding-box; border-collapse: collapse; border-color: #dddddd; border-radius: 0 0 3px 3px; border-style: solid; border-width: 0 1px 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-bottom: none">
+                    <tr>
+                      <td class="comment_body_td content-td" style="-webkit-background-clip: padding-box; -webkit-border-radius: 0 0 3px 3px; background-clip: padding-box; border-radius: 0 0 3px 3px; color: #525252; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 15px; line-height: 22px; overflow: hidden; padding: 40px 40px 30px; background-color: white;">
+
+
+<p>Hi <%= @user.first_name %>,</p>
+
+<p><%= @video.email_body_text %></p>
+
+<p style="text-align: center">
+<ic-block data-generated-at="14775965965790.22154604114587806" data-type="button" data-link-url="<%= video_url(@video, @utm_params) %>" data-text="Check it Out" data-id="block-ember4053" data-align="center"><zws>&#8203;</zws><insert contenteditable="false"><insert-point></insert-point></insert><a class="intercom-h2b-button" href="<%= video_url(@video, @utm_params) %>" contenteditable="false"><%= @video.email_cta_label %></a><insert contenteditable="false"><insert-point></insert-point></insert><zws>&#8203;</zws></ic-block>
+</p>
+
+
+                      </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+
+                <div class="margin-arrow">
+                  <table cellpadding="0" cellspacing="0" border="0" class="message_footer_table margin-arrow" align="center" style="border-collapse: collapse; color: #545454; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 13px; line-height: 20px; margin: 0 auto; max-width: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%">
+                    <tr>
+                      <td valign="top" width="80" class="arrow-wrap" style="color: #272727; height: 18px; text-align: left; padding-left: 40px;">
+                        <img alt="Triangle" class="image_fix" height="18" src="https://marketing.intercomassets.com/assets/email/personal/triangle-8747882e9ef8882f9bc057241fd3c049.png" style="-ms-interpolation-mode: bicubic; display: inline-block; max-width: 100%; outline: none; text-decoration: none; margin-top: -1px;" width="40">
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+                <table cellpadding="0" cellspacing="0" border="0" class="message_footer_table" align="center" style="border-collapse: collapse; color: #545454; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 13px; line-height: 20px; margin: 0 auto; max-width: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%">
+                  <tr>
+                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td class="footer-td-wrapper">
+                          <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse; color: #545454; font-family: 'Helvetica Neue',Arial,sans-serif; font-size: 13px; line-height: 20px; margin: 0 auto; max-width: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%" class="message_footer_table">
+                            <tr>
+                              <td valign="middle" align="right" class="date_cell" style="color: #999999; text-align: right; font-size: 11px;">
+
+Not interested in receiving content from Upcase?
+<%= link_to "Unsubscribe", unsubscribe_url(token: @unsubscribe_token) %>
+
+                              </td>
+                            </tr>
+<tr>
+                          </tr>
+</table>
+                        </td>
+                      </tr>
+                    </table>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td valign="top" height="20"></td>
+            </tr>
+          </table>
+          <!--[if (gte mso 10)]>
+            </td>
+            </tr>
+            </table>
+          <![endif]-->
+        </td>
+      </tr>
+    </table>
+
+</body>
+</html>

--- a/app/views/weekly_iteration_drip_mailer/weekly_update.text.erb
+++ b/app/views/weekly_iteration_drip_mailer/weekly_update.text.erb
@@ -1,0 +1,9 @@
+Hi <%= @user.first_name %>,
+
+<%= @video.email_body_text %>
+
+<%= @video.email_cta_label %>:
+<%= video_url(@video, @utm_params) %>
+
+Not interested? Stop receiving emails:
+<%= unsubscribe_url(token: @unsubscribe_token) %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -172,6 +172,12 @@ RailsAdmin.config do |config|
         field :markers
       end
 
+      group :weekly_iteration do
+        field :email_subject
+        field :email_body_text
+        field :email_cta_label
+      end
+
       group :seo do
         field :meta_description do
           help META_DESCRIPTION_HELP

--- a/db/migrate/20160727183445_create_content_recommendations.rb
+++ b/db/migrate/20160727183445_create_content_recommendations.rb
@@ -1,0 +1,17 @@
+class CreateContentRecommendations < ActiveRecord::Migration
+  def change
+    create_table :content_recommendations do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+      t.references :recommendable, polymorphic: true, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index(
+      :content_recommendations,
+      [:user_id, :recommendable_type, :recommendable_id],
+      name: "index_content_recommendations_on_recommendable_and_user",
+      unique: true,
+    )
+  end
+end

--- a/db/migrate/20160803180148_create_recommendable_contents.rb
+++ b/db/migrate/20160803180148_create_recommendable_contents.rb
@@ -1,0 +1,17 @@
+class CreateRecommendableContents < ActiveRecord::Migration
+  def change
+    create_table :recommendable_contents do |t|
+      t.integer :recommendable_id, null: false
+      t.string :recommendable_type, null: false
+      t.integer :position, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index(
+      :recommendable_contents,
+      [:recommendable_type, :recommendable_id],
+      name: "rec_contents_on_rec_type_rec_id",
+    )
+  end
+end

--- a/db/migrate/20161025154304_add_mailer_fields_to_videos.rb
+++ b/db/migrate/20161025154304_add_mailer_fields_to_videos.rb
@@ -1,0 +1,7 @@
+class AddMailerFieldsToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :email_subject, :string
+    add_column :videos, :email_body_text, :string
+    add_column :videos, :email_cta_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804181146) do
+ActiveRecord::Schema.define(version: 20161025154304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,17 @@ ActiveRecord::Schema.define(version: 20160804181146) do
   end
 
   add_index "collaborations", ["repository_id", "user_id"], name: "index_collaborations_on_repository_id_and_user_id", unique: true, using: :btree
+
+  create_table "content_recommendations", force: :cascade do |t|
+    t.integer  "user_id",            null: false
+    t.integer  "recommendable_id",   null: false
+    t.string   "recommendable_type", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "content_recommendations", ["user_id", "recommendable_type", "recommendable_id"], name: "index_content_recommendations_on_recommendable_and_user", unique: true, using: :btree
+  add_index "content_recommendations", ["user_id"], name: "index_content_recommendations_on_user_id", using: :btree
 
   create_table "decks", force: :cascade do |t|
     t.string   "title",                            null: false
@@ -263,6 +274,16 @@ ActiveRecord::Schema.define(version: 20160804181146) do
   end
 
   add_index "rails_admin_histories", ["item", "table", "month", "year"], name: "index_rails_admin_histories", using: :btree
+
+  create_table "recommendable_contents", force: :cascade do |t|
+    t.integer  "recommendable_id",   null: false
+    t.string   "recommendable_type", null: false
+    t.integer  "position",           null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "recommendable_contents", ["recommendable_type", "recommendable_id"], name: "rec_contents_on_rec_type_rec_id", using: :btree
 
   create_table "statuses", force: :cascade do |t|
     t.integer  "completeable_id",                                       null: false
@@ -457,6 +478,9 @@ ActiveRecord::Schema.define(version: 20160804181146) do
     t.boolean  "accessible_without_subscription",             default: false
     t.text     "meta_description",                            default: "",    null: false
     t.text     "page_title",                                  default: "",    null: false
+    t.string   "email_subject"
+    t.string   "email_body_text"
+    t.string   "email_cta_label"
   end
 
   add_index "videos", ["slug"], name: "index_videos_on_slug", unique: true, using: :btree
@@ -466,6 +490,7 @@ ActiveRecord::Schema.define(version: 20160804181146) do
   add_foreign_key "attempts", "users", on_delete: :cascade
   add_foreign_key "beta_replies", "beta_offers", column: "offer_id"
   add_foreign_key "beta_replies", "users"
+  add_foreign_key "content_recommendations", "users"
   add_foreign_key "markers", "videos", on_delete: :cascade
 
   create_view :latest_attempts,  sql_definition: <<-SQL

--- a/lib/tasks/send_weekly_iteration_suggestions.rake
+++ b/lib/tasks/send_weekly_iteration_suggestions.rake
@@ -1,0 +1,6 @@
+namespace :weekly_iteration_suggestions do
+  desc "Enqueues email jobs for every acrtive subscriber with recommendable TWI episodes to watch"
+  task send: :environment do
+    WeeklyIterationSuggestions.new(ActiveSubscribers.new).send
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -410,7 +410,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :video do
+  factory :video, aliases: [:recommendable] do
     association :watchable, factory: :show
     sequence(:name) { |n| "Video #{n}" }
     wistia_id '1194803'
@@ -562,5 +562,15 @@ FactoryGirl.define do
   factory :marker do
     anchor "configuration-options"
     time 322
+  end
+
+  factory :content_recommendation do
+    recommendable
+    user
+  end
+
+  factory :recommendable_content do
+    sequence(:position)
+    recommendable
   end
 end

--- a/spec/jobs/weekly_iteration_mailer_job_spec.rb
+++ b/spec/jobs/weekly_iteration_mailer_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe WeeklyIterationMailerJob do
+  it_behaves_like "a Delayed Job that notifies Honeybadger about errors"
+
+  describe "#perform" do
+    it "sends an email to specified user for the video" do
+      user = create(:user)
+      video = create(:video)
+      mailer_stub = stub_mail_method(WeeklyIterationDripMailer, :weekly_update)
+
+      WeeklyIterationMailerJob.perform_later(user.id, video.id)
+
+      expect(WeeklyIterationDripMailer).to have_received(:weekly_update).with(
+        user: user,
+        video: video,
+      )
+      expect(mailer_stub).to have_received(:deliver_now)
+    end
+  end
+end

--- a/spec/mailers/weekly_iteration_drip_mailer_spec.rb
+++ b/spec/mailers/weekly_iteration_drip_mailer_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe WeeklyIterationDripMailer do
+  describe "#weekly_update" do
+    it "comes from Ben Orenstein" do
+      message = build_message
+
+      expect(message).
+        to deliver_from("Ben from thoughtbot <ben@thoughtbot.com>")
+    end
+
+    it "replies to the generic Upcase email" do
+      message = build_message
+
+      expect(message).to reply_to(ENV.fetch("SUPPORT_EMAIL"))
+    end
+
+    it "delivers to the specified user's email" do
+      email = "whatevs@example.com"
+      user = build(:user, email: email)
+
+      message = build_message(user: user)
+
+      expect(message).to deliver_to(email)
+    end
+
+    it "contains the video's email subject in the subject field" do
+      subject = "Weekly Iteration: Ruby like a boss"
+      video = build_stubbed(:video, email_subject: subject)
+
+      message = build_message(video: video)
+
+      expect(message).to have_subject(video.email_subject)
+    end
+
+    it "contains a link to the specified Weekly Iteration" do
+      slug = "ruby-like-a-boss"
+      video = build(:video, slug: slug)
+
+      message = build_message(video: video)
+
+      expect(message).to have_body_text(slug)
+      expect(message).to have_body_text("utm_medium=email")
+      expect(message).to have_body_text(
+        "utm_campaign=#{video.slug}-weekly-drip",
+      )
+    end
+
+    it "contains a summary and CTA of the video" do
+      video = build_stubbed(
+        :video,
+        email_cta_label: "The CTA",
+        email_body_text: "The body",
+      )
+
+      message = build_message(video: video)
+
+      expect(message).to have_body_text("The CTA")
+      expect(message).to have_body_text("The body")
+      expect(message).to have_body_text("unsubscribe")
+    end
+  end
+
+  def build_message(user: build_stubbed(:user), video: build_stubbed(:video))
+    WeeklyIterationDripMailer.weekly_update(user: user, video: video)
+  end
+end

--- a/spec/models/active_subscribers_spec.rb
+++ b/spec/models/active_subscribers_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe ActiveSubscribers do
+  it "finds personal plan subscribers" do
+    user = create(:user, name: "personal")
+    create(:subscription, user: user)
+
+    expect(active_subscriber_names).to eq([user.name])
+  end
+
+  it "finds members of active teams" do
+    team_leader = create(:user, name: "team leader")
+    team_member = create(:user, name: "team member")
+    sub = create(:team_subscription, user: team_leader)
+    create(:team, subscription: sub, users: [team_leader, team_member])
+
+    expect(active_subscriber_names).to match_array(
+      [team_leader.name, team_member.name],
+    )
+  end
+
+  it "ignores deactivated subscriptions" do
+    user = create(:user, name: "inactive")
+    create(:inactive_subscription, user: user)
+
+    expect(active_subscriber_names).to eq([])
+  end
+
+  def active_subscriber_names
+    ActiveSubscribers.new.map(&:name)
+  end
+end

--- a/spec/models/content_recommendation_spec.rb
+++ b/spec/models/content_recommendation_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+describe ContentRecommendation do
+  it { should belong_to(:user) }
+  it { should belong_to(:recommendable) }
+end

--- a/spec/models/content_suggestor_spec.rb
+++ b/spec/models/content_suggestor_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe ContentSuggestor do
+  describe "#next_up" do
+    context "when the user has not viewed any Weekly Iterations" do
+      it "returns the first Weekly Iteration in the set sequence" do
+        first_video, second_video = build_stubbed_list(:video, 2)
+        suggester = build_content_suggester(
+          recommendables: [first_video, second_video],
+        )
+
+        result = suggester.next_up.unwrap
+
+        expect(result).to eq(first_video)
+      end
+    end
+
+    context "when the user has viewed some Weekly Iterations in the sequence" do
+      it "returns the first unseen Weekly Iteration in the set sequence" do
+        first_video, second_video = create_list(:video, 2)
+        user = create(:user)
+        create(:status, user: user, completeable: first_video)
+        suggester = build_content_suggester(
+          user: user,
+          recommendables: [first_video, second_video, nil],
+        )
+
+        result = suggester.next_up.unwrap
+
+        expect(result).to eq(second_video)
+      end
+    end
+
+    context "when the user has viewed all Weekly Iterations in the sequence" do
+      it "returns nil" do
+        video = create(:video)
+        user = create(:user)
+        create(:status, user: user, completeable: video)
+        suggester = build_content_suggester(
+          user: user,
+          recommendables: [video],
+        )
+
+        result = suggester.next_up
+
+        expect(result).to be_blank
+      end
+    end
+
+    context "when we've already recommended a given video" do
+      it "recommends the next in the sequence" do
+        first_video, second_video = create_list(:video, 2)
+        user = create(:user)
+        suggester = build_content_suggester(
+          user: user,
+          recommendables: [first_video, second_video],
+          recommended: [first_video],
+        )
+
+        result = suggester.next_up.unwrap
+
+        expect(result).to eq(second_video)
+      end
+    end
+
+    def build_content_suggester(
+      user: build_stubbed(:user),
+      recommended: [],
+      recommendables:
+    )
+      ContentSuggestor.new(
+        user: user,
+        recommendables: recommendables,
+        recommended: recommended,
+      )
+    end
+  end
+end

--- a/spec/models/recommendable_content_spec.rb
+++ b/spec/models/recommendable_content_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe RecommendableContent do
+  it { should belong_to(:recommendable) }
+
+  describe "uniqueness criteria" do
+    before { create(:recommendable_content) }
+
+    it { should validate_uniqueness_of(:position) }
+  end
+
+  describe ".priority_ordered" do
+    it "returns the recommendable_content in position order" do
+      first, second, third = create_list(:recommendable_content, 3)
+
+      third.insert_at(1)
+      ordered = RecommendableContent.priority_ordered
+
+      expect(ordered).to match_array([third, first, second])
+    end
+  end
+end

--- a/spec/services/weekly_iteration_recommender_spec.rb
+++ b/spec/services/weekly_iteration_recommender_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe WeeklyIterationRecommender do
+  describe "#recommend" do
+    context "with video to recommend" do
+      it "creates a recommendation" do
+        user = create(:user)
+        video = create(:video)
+
+        expect do
+          WeeklyIterationRecommender.new(
+            user: user,
+            sorted_recommendable_videos: [video],
+          ).recommend
+        end.to change { ContentRecommendation.count }.by(1)
+      end
+
+      it "enqueues email job" do
+        user = create(:user)
+        video = create(:video)
+        allow(WeeklyIterationMailerJob).
+          to receive(:perform_later).
+          with(user.id, video.id)
+
+        WeeklyIterationRecommender.new(
+          user: user,
+          sorted_recommendable_videos: [video],
+        ).recommend
+
+        expect(WeeklyIterationMailerJob).to have_received(:perform_later)
+      end
+    end
+
+    context "with no video to recommend" do
+      it "doesn't create a recommendation" do
+        user = create(:user)
+        video = create(:video)
+        create(:content_recommendation, recommendable: video, user: user)
+
+        expect do
+          WeeklyIterationRecommender.new(
+            user: user,
+            sorted_recommendable_videos: [video],
+          ).recommend
+        end.not_to change { ContentRecommendation.count }
+      end
+
+      it "doesn't enqueue email job" do
+        user = create(:user)
+        video = create(:video)
+        create(:content_recommendation, recommendable: video, user: user)
+        allow(WeeklyIterationMailerJob).
+          to receive(:perform_later).
+          with(user.id, video.id)
+
+        WeeklyIterationRecommender.new(
+          user: user,
+          sorted_recommendable_videos: [video],
+        ).recommend
+
+        expect(WeeklyIterationMailerJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+end

--- a/spec/services/weekly_iteration_suggestions_spec.rb
+++ b/spec/services/weekly_iteration_suggestions_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe WeeklyIterationSuggestions do
+  describe "#perform" do
+    it "calls WeeklyIterationRecommender for each user" do
+      user = create(:user)
+      video = create(:recommendable_content).recommendable
+
+      recommender = stub_weekly_iteration_recommender_with(
+        user: user,
+        sorted_recommendable_videos: [video],
+      )
+
+      WeeklyIterationSuggestions.new([user]).send
+
+      expect(recommender).to have_received(:recommend).once
+    end
+  end
+
+  def stub_weekly_iteration_recommender_with(args)
+    double("recommender", recommend: true).tap do |recommender|
+      allow(WeeklyIterationRecommender).
+        to receive(:new).
+        with(args).
+        and_return(recommender)
+    end
+  end
+end


### PR DESCRIPTION
- Adds a `RecommendableContent` model to persist the ordered sequence of
  WI to recommend
- Adds a `ContentRecommendation` model to persist previous
  recommendations
- Adds a `ContentSuggester` class to calculate the `next_up`
  recommendation for a user based on what that user has seen and what
  has been recommended
- Adds a mailer and a background job class to wrap that mailer.
- Add Video TWI fields for automated emails
- Add `EnqueueWeeklyIterationEmailsJob` and `WeeklyIterationRecommender`
  entry points to be called by a weekly background job, that enqueues a
  job per suggestion email per person
- Use Intercom HTML template

https://trello.com/c/hIDNQBNg/181-implement-weekly-iteration-drip
