### PR TITLE
Update User#eligible_for_annual_upgrade? conditions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user_is_subscription_owner?
 
   def current_user_is_eligible_for_annual_upgrade?
-    current_user.subscriber? &&
-      current_user.eligible_for_annual_upgrade?
+    current_user.eligible_for_annual_upgrade?
   end
   helper_method :current_user_is_eligible_for_annual_upgrade?
 


### PR DESCRIPTION
`User#eligible_for_annual_upgrade?` implies `User#subscriber?`. We don't
need to do that check in `ApplicationController`.

@nilcolor found the repetition and syntactic difference confusing and
proposed this improvement. Thank you!

[fixes #1555]
