### PR TITLE
Use team `stripe_customer_id` instead of users in Subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,7 +6,6 @@ class Subscription < ActiveRecord::Base
   has_one :team, dependent: :destroy
 
   delegate :name, to: :plan, prefix: true
-  delegate :stripe_customer_id, to: :user
 
   validates :plan_id, presence: true
   validates :plan_type, presence: true
@@ -30,6 +29,14 @@ class Subscription < ActiveRecord::Base
 
   def active?
     deactivated_on.nil?
+  end
+
+  def stripe_customer_id
+    if team.present?
+      team.owner.stripe_customer_id
+    else
+      user.stripe_customer_id
+    end
   end
 
   def scheduled_for_deactivation?

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -5,8 +5,6 @@ describe Subscription do
   it { should belong_to(:plan) }
   it { should belong_to(:user) }
 
-  it { should delegate(:stripe_customer_id).to(:user) }
-
   it { should validate_presence_of(:plan_id) }
   it { should validate_presence_of(:plan_type) }
   it { should validate_presence_of(:user_id) }
@@ -19,6 +17,24 @@ describe Subscription do
       billed_3_days_from_now = create(:subscription, next_payment_on: Date.current + 3.days)
 
       expect(Subscription.next_payment_in_2_days).to eq [billed_2_days_from_now]
+    end
+  end
+
+  describe "#stripe_customer_id" do
+    it "should return users stripe customer id if they are not on a team" do
+      user = create(:user, :with_subscription, stripe_customer_id: "cus_123")
+
+      expect(user.subscription.stripe_customer_id). to eq("cus_123")
+    end
+
+    it "should return team stripe customer id if users are a part of a team" do
+      owner = create(:user,
+                     :with_team_subscription,
+                     stripe_customer_id: "team_123")
+      team = owner.team
+      user = create(:user, team: team, stripe_customer_id: "cus_123")
+
+      expect(user.subscription.stripe_customer_id). to eq("team_123")
     end
   end
 


### PR DESCRIPTION
Problem:
* When editing members of a team, the stripe update fails sometimes
with an InvalidRequestError. This is because the `stripe_customer_id`
of the user is blank `""`.

Solution:
* When a users subscription is a team subscription,
`subscription.stripe_customer_id` should be returning the team owners
`stripe_customer_id` instead of the users, since the users plan is
through the owner.