### PR TITLE
Update ruby version to 2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ DEPENDENCIES
   wrapped
 
 RUBY VERSION
-   ruby 2.3.0p0
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.3


### PR DESCRIPTION
Although the Ruby Version was updated here https://github.com/thoughtbot/upcase/commit/396c452a78c467e2cb914b11d9c221cc790ea268, the Gemfile.lock was never updated, causing the builds to fail on staging. 