### PR TITLE
Order trails by priority on topic pages

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -24,7 +24,7 @@ class Topic < ActiveRecord::Base
   end
 
   def published_trails
-    trails.published
+    trails.published.order(:priority)
   end
 
   def to_param

--- a/db/migrate/20161122192547_add_priority_to_trail.rb
+++ b/db/migrate/20161122192547_add_priority_to_trail.rb
@@ -1,0 +1,5 @@
+class AddPriorityToTrail < ActiveRecord::Migration
+  def change
+    add_column :trails, :priority, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161028180937) do
+ActiveRecord::Schema.define(version: 20161122192547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,6 +370,7 @@ ActiveRecord::Schema.define(version: 20161028180937) do
     t.text     "meta_description",                 default: "",    null: false
     t.text     "page_title",                       default: "",    null: false
     t.boolean  "promoted",                         default: false, null: false
+    t.integer  "priority"
   end
 
   add_index "trails", ["published"], name: "index_trails_on_published", using: :btree

--- a/spec/features/subscriber_views_topic_spec.rb
+++ b/spec/features/subscriber_views_topic_spec.rb
@@ -14,4 +14,17 @@ feature "Subscriber views a topic" do
     expect(page).to have_content(video.name)
     expect(page).to have_content(trail.name)
   end
+
+  scenario "and sees priority trails first" do
+    topic = create(:topic, :explorable)
+    subscriber = create(:subscriber)
+    not_priority_trail = create(:trail, :published, :video)
+    priority_trail = create(:trail, :published, :video, priority: 1)
+    topic.trails << not_priority_trail
+    topic.trails << priority_trail
+
+    visit topic_path(topic, as: subscriber)
+
+    expect(priority_trail.name).to appear_before(not_priority_trail.name)
+  end
 end


### PR DESCRIPTION
We want to show trails in a logical order on the topic pages, like
having intro trails show up first, so that users know where to start.