### PR TITLE
Use the utm_source stored in the session

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 //= require fastclick
 //= require readmore
 //= require extended_description
-//= require tapas
 
 $(function() {
   hljs.initHighlightingOnLoad();

--- a/app/assets/javascripts/tapas.js
+++ b/app/assets/javascripts/tapas.js
@@ -1,5 +1,0 @@
-function getUrlParam(name) {
-  if(name=(new RegExp('[?&]'+encodeURIComponent(name)+'=([^&]*)')).exec(location.search)) {
-    return decodeURIComponent(name[1]);
-  }
-}

--- a/app/views/pages/tapas.html.erb
+++ b/app/views/pages/tapas.html.erb
@@ -17,14 +17,8 @@
       <input type="email" name="fields[email]" value="" placeholder="Email Address"/>
       <input type="hidden" name="fields[manages_developers]" value="false"/>
       <label><input type="checkbox" name="fields[manages_developers]" value="true"/>Check this box if you manage other developers</label>
-      <input type="hidden" name="fields[utm_source]" value="" id="utm_source" />
+      <input type="hidden" name="fields[utm_source]" value="<%= session[:campaign_params][:utm_source] %>" id="utm_source" />
       <input type="submit" name="submit" value="Keep Me In The Loop" data-drip-attribute="sign-up-button" />
     </fieldset>
   </form>
 </section>
-
-<% content_for :javascript do %>
-  <script type="text/javascript">
-    $("#utm_source").val(getUrlParam("utm_source"));
-  </script>
-<% end %>


### PR DESCRIPTION
This is better than the approach in 2c073b6, because it persists across
requests (and requires no JavaScript).