### PR TITLE
Upgrade user to team plan from admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -5,6 +5,10 @@ EXTENDED_DESCRIPTION_HELP = <<-DESC.strip_heredoc.freeze
   Detailed additional description. Hidden on initial render,
   but available by clicking 'Read more' link.
 DESC
+TEAM_CONVERSION_HELP = <<-DESC.strip_heredoc.freeze
+  Submitting a new team name will convert individual subscription to a new team
+  and team account
+DESC
 
 RailsAdmin.config do |config|
   config.authorize_with do
@@ -73,6 +77,12 @@ RailsAdmin.config do |config|
       field :bio
       field :github_username
       field :stripe_customer_id
+
+      group :convert_to_team do
+        field :team_name do
+          help TEAM_CONVERSION_HELP
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,32 @@ describe User do
     end
   end
 
+  context "#team_name" do
+    it "creates a new team" do
+      user = create(:user, :with_subscription)
+      user.subscription.stub(:change_plan)
+
+      user.team_name = "team name"
+      user.save
+
+      expect(user.team).to be_present
+      expect(user.team.owner).to eq user
+      expect(user.team.name).to eq "team name"
+    end
+
+    it "changes the subscription plan" do
+      user = create(:user, :with_subscription)
+      subscription = user.subscription
+      allow(subscription).to receive(:change_plan).with(sku: Plan::TEAM_SKU)
+
+      user.team_name = "team name"
+      user.save
+
+      expect(subscription).
+        to have_received(:change_plan).with(sku: Plan::TEAM_SKU)
+    end
+  end
+
   context "#first_name" do
     it "has a first_name that is the first part of name" do
       user = User.new(name: "first last")


### PR DESCRIPTION
Currently there are some manual hoops to jump through to get a "normal" user to

1. Create and be part of a team
2. Change their subscription plan, both in the database and stripe, to a team plan

This commit adds a field to the user's edit form in rails_admin that
accepts a new team name. If a team name is given, the right steps will
be performed to upgrade the plan, create the team, etc.