### PR TITLE
Handle deprecation warning for stub with :should

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,7 +35,7 @@ describe User do
   context "#team_name" do
     it "creates a new team" do
       user = create(:user, :with_subscription)
-      user.subscription.stub(:change_plan)
+      allow(user.subscription).to receive(:change_plan)
 
       user.team_name = "team name"
       user.save


### PR DESCRIPTION
Fixes:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly
enabling the syntax is deprecated. Use the new `:expect` syntax or
explicitly enable `:should` instead. 