### PR TITLE
Referall SaaSquatch integration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Clearance::Controller
 
   protect_from_forgery with: :exception
-  before_filter :capture_campaign_params
+  before_filter :capture_campaign_params, :apply_referral_coupon
 
   def current_user
     super || Guest.new
@@ -41,6 +41,11 @@ class ApplicationController < ActionController::Base
       current_user.subscription.owner?(current_user)
   end
   helper_method :current_user_is_subscription_owner?
+
+  def current_user_is_subscriber?
+    current_user.subscriber?
+  end
+  helper_method :current_user_is_subscriber?
 
   def current_user_is_eligible_for_annual_upgrade?
     current_user.eligible_for_annual_upgrade?
@@ -86,6 +91,12 @@ class ApplicationController < ActionController::Base
     end
   end
   helper_method :github_auth_path
+
+  def apply_referral_coupon
+    if params[:rsCode].present?
+      redirect_to coupon_path(params[:rsCode])
+    end
+  end
 
   def capture_campaign_params
     session[:campaign_params] ||= {

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -35,7 +35,7 @@
 
 <% content_for :javascript do -%>
   <script type="text/javascript">
-    // this identifies your website in the createToken call below
+  // this identifies your website in the createToken call below
   Stripe.setPublishableKey('<%= STRIPE_PUBLIC_KEY %>');
 
   function stripeResponseHandler(status, response) {

--- a/app/views/shared/_javascript.html.erb
+++ b/app/views/shared/_javascript.html.erb
@@ -6,6 +6,10 @@
 
 <%= yield :javascript %>
 
+<% if current_user_is_subscriber? %>
+  <%= render "shared/squatch_js" %>
+<% end %>
+
 <% if Rails.env.test? || Rails.env.cucumber? %>
   <%= javascript_tag do %>
     jQuery.fx.off = true;

--- a/app/views/shared/_squatch_js.html.erb
+++ b/app/views/shared/_squatch_js.html.erb
@@ -1,0 +1,16 @@
+<script>
+  <%# init SaaSquatch, get refererring user set up and ready to share %>
+  var _sqh = _sqh || [];
+
+  _sqh.push(['init', {
+    tenant_alias:        '<%= ENV.fetch('SAASQUATCH_TENANT_ALIAS', 'test_avjjgmdtno1cs') %>',
+    account_id:          '<%= current_user.stripe_customer_id %>',
+    payment_provider_id: '<%= current_user.stripe_customer_id %>',
+    user_id:             '<%= current_user.id %>',
+    email:               '<%= current_user.email %>',
+    first_name:          '<%= current_user.first_name %>',
+    last_name:           '<%= current_user.last_name %>'
+  }]);
+
+  (function(){ function l(){ var s=document.createElement("script"); s.type="text/javascript"; s.async=true; s.src=location.protocol+"//d2rcp9ak152ke1.cloudfront.net/assets/javascripts/squatch.min.js"; var t=document.getElementsByTagName("script")[0]; t.parentNode.insertBefore(s,t) } if(window.attachEvent){ window.attachEvent("onload",l) } else { window.addEventListener("load",l,false) } })();
+</script>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -53,6 +53,10 @@
       <% end %>
       <%= link_to "View all invoices", subscriber_invoices_path, class: "invoices" %>
     </ol>
+
+    <h3><%= t(".refer_a_friend") %></h3>
+    <p><%= t(".referral_benefits", percent: ENV.fetch("REFERRAL_DISCOUNT", "10")) %></p>
+    <%= link_to t(".referral_link"), "#", class: "cta-button squatchpop" %>
   <% end %>
 
   <% if current_team %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,9 @@ en:
       have_any_questions: Have any questions?
       here_to_help: We're here to help, so feel free to send any questions in and we'll get back to you right away.
       contact_us: Contact us
+      refer_a_friend: Refer a friend
+      referral_benefits: "Referring a friend or colleague to Upcase will give both you, and them, a %{percent}% discount on next month's bill."
+      referral_link: Create your referral code
     resubscribe:
       plea_html: We get it, things change. But if you want to come back, we have your card on file, and you just have to click this button. Oh, and if you want to change your card beforehand, <a href="%{billing_url}">you can do that right here</a>.
       call_to_action: Resubscribe


### PR DESCRIPTION
## For those that would like to REFER friends and colleagues.

I've added some copy and a button to the side bar of the account page as the CTA for kicking off the sharing/referral process. The percentage displayed in the view can be customized with the `REFERRAL_DISCOUNT` env var.

<img src="https://cloud.githubusercontent.com/assets/28194/23083572/59cf6c10-f52c-11e6-898e-19564b2b95ed.jpg" width=300>

### When that button is clicked the user will see the following:

![upcase_by_thoughtbot___learn_web_development_online_](https://cloud.githubusercontent.com/assets/28194/23083621/8f6f1dca-f52c-11e6-890b-8e22366bd389.jpg)

***

## For those that are being referred

1. They will get a shortened link that will redirect them to the page we designate as the landing page (set up in the SaaSquatch portal/dashboard).  Currently it is set to `https://(staging.)thoughtbot.com/upcase/join`.

2. That shortened link contains the coupon code, so we grab it, and redirect through the coupons endpoint and turn them back around to the homepage with the querystring now cleared out.

Once they make their way to the checkout page they will then see the coupon applied.

![subscribe_to_professional](https://cloud.githubusercontent.com/assets/28194/23083738/1c6881ee-f52d-11e6-9d79-010e900c187c.jpg)
