### PR TITLE
Switch annual subscription link in header to affiliate/referral promotion

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,9 +44,14 @@ module ApplicationHelper
     "http://robots.thoughtbot.com/tags/#{topic.slug}"
   end
 
+  def current_user_is_subscription_owner?
+    current_user.subscriber? &&
+      current_user.subscription.owner?(current_user)
+  end
+
   def show_upgrade_to_annual_cta?
     current_user_is_subscription_owner? &&
-      current_user_is_eligible_for_annual_upgrade?
+      current_user.eligible_for_annual_upgrade?
   end
 
   def encourage_user_to_pay?

--- a/app/views/layouts/_header_links.html.erb
+++ b/app/views/layouts/_header_links.html.erb
@@ -15,9 +15,9 @@
     <li class="discuss">
       <%= link_to t("shared.header.forum"), Forum.url %>
     </li>
-    <% if show_upgrade_to_annual_cta? %>
-      <li class="annual">
-        <%= render "shared/annual_billing" %>
+    <% if current_user_is_subscription_owner? %>
+      <li class="refer-friend">
+        <%= link_to t("shared.header.referral_link"), "#", class: "squatchpop" %>
       </li>
     <% end %>
     <li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -59,6 +59,12 @@
     <%= link_to t(".referral_link"), "#", class: "cta-button squatchpop" %>
   <% end %>
 
+  <% if show_upgrade_to_annual_cta? %>
+    <h3><%= t(".annual_plan_title") %></h3>
+    <p><%= t(".annual_plan_benefits") %></p>
+    <%= link_to t(".annual_plan_link"), new_annual_billing_path, class: "cta-button" %>
+  <% end %>
+
   <% if current_team %>
     <h3>Your Team</h3>
     <%= render current_team %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,7 @@ en:
       sign_out: Sign Out
       trails: Trails
       weekly_iteration: Weekly Iteration
+      referral_link: Refer a Friend and Get a Discount
     subscription:
       name: Upcase
     subscriptions:
@@ -266,6 +267,9 @@ en:
       refer_a_friend: Refer a friend
       referral_benefits: "Referring a friend or colleague to Upcase will give both you, and them, a %{percent}% discount on next month's bill."
       referral_link: Create your referral code
+      annual_plan_title: Switch to annual Plan
+      annual_plan_benefits: If you upgrade to annual billing you'll get 12 months of Upcase for the price of 10 months. That's a 17% discount!
+      annual_plan_link: Get two months free!
     resubscribe:
       plea_html: We get it, things change. But if you want to come back, we have your card on file, and you just have to click this button. Oh, and if you want to change your card beforehand, <a href="%{billing_url}">you can do that right here</a>.
       call_to_action: Resubscribe

--- a/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
+++ b/spec/features/subscriber_upgrades_to_annual_billing_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Subscriber upgrades to annual billing", js: true do
   scenario "Successfully" do
     sign_in_as_user_with_subscription_that_is_eligible_for_annual_upgrade
-    click_link "Get two months free"
+    visit new_annual_billing_path
 
     expect(page.body).to include("$1188")
     expect(page.body).to include("$990")
@@ -19,7 +19,7 @@ feature "Subscriber upgrades to annual billing", js: true do
 
   scenario "but changes their mind at the last minute" do
     sign_in_as_user_with_subscription_that_is_eligible_for_annual_upgrade
-    click_link "Get two months free"
+    visit new_annual_billing_path
 
     expect(page.body).to include("$1188")
     expect(page.body).to include("$990")
@@ -31,19 +31,6 @@ feature "Subscriber upgrades to annual billing", js: true do
     expect(page.body).to include("$1188")
     expect(page.body).to include("$990")
     expect(page.body).to include("Get two free months of Upcase")
-  end
-
-  scenario "user with no subscription doesn't see link" do
-    sign_in
-
-    expect_to_not_see_upgrade_link
-  end
-
-  scenario "visitor doesn't see link" do
-    create(:plan)
-    visit root_path
-
-    expect_to_not_see_upgrade_link
   end
 
   def last_email

--- a/spec/views/layouts/_header_links.html.erb_spec.rb
+++ b/spec/views/layouts/_header_links.html.erb_spec.rb
@@ -17,18 +17,6 @@ describe "layouts/_header_links.html.erb" do
     CSS
   end
 
-  context "when user is the subscription owner" do
-    it "shows an annual upsell link" do
-      render(
-        current_user_has_active_subscription: true,
-        current_user_is_subscription_owner: true,
-        signed_in: true
-      )
-
-      expect(rendered).to have_content(call_to_action_label)
-    end
-  end
-
   context "when user is not the subscription owner" do
     it "does not show an annual upsell link" do
       render(


### PR DESCRIPTION
To give the referral program a little further visibility we can put it in the header and move the monthly to annual up-sell into the account page (in sidebar)