### PR TITLE
Add optimizely to the layout pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head prefix="og: http://ogp.me/ns#">
+    <%- if Rails.env.production? %>
+      <script src="https://cdn.optimizely.com/js/8273439110.js"></script>
+    <% end %>
     <%= render "application/head_contents" %>
     <% if signed_in? %>
       <%= render "layouts/hide_drip_widget_for_signed_in_users" %>

--- a/app/views/layouts/marketing.html.erb
+++ b/app/views/layouts/marketing.html.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <%- if Rails.env.production? %>
+      <script src="https://cdn.optimizely.com/js/8273439110.js"></script>
+    <% end %>
     <meta charset="utf-8" />
     <meta name="ROBOTS" content="NOODP" />
     <meta name="viewport" content="width=device-width, initial-scale=1,


### PR DESCRIPTION
Per Optimizely's instructions:

>Copy the code below and paste it immediately after your opening <head> tag. Include this snippet on every page that should run this project's experiments or be tracked as a goal.

`<script src="https://cdn.optimizely.com/js/8273439110.js"></script>`