### PR TITLE
Use page title to populate event name for segment

### DIFF
--- a/app/views/layouts/marketing.html.erb
+++ b/app/views/layouts/marketing.html.erb
@@ -9,7 +9,9 @@
     <meta name="google-site-verification"
       content="<%= ENV.fetch("GOOGLE_SITE_VERIFICATION") %>" />
     <%= open_graph_tags %>
-    <title><%= t(".page_title") %></title>
+    <title>
+      <%= content_for(:page_title).presence || t(".page_title") %>
+    </title>
     <%= stylesheet_link_tag :marketing, media: "all" %>
     <%= favicon_link_tag "favicon.ico" %>
     <link rel="canonical" href="https://thoughtbot.com/upcase" />

--- a/app/views/marketing/show.html.erb
+++ b/app/views/marketing/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for(:page_title, t(".page_title")) %>
+
 <main>
   <section class="hero hero--upcase-background">
     <%= inline_svg("welcome/upcase-logo--hero.svg") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,7 +102,6 @@ en:
     app_name: Upcase
     fallback_page_title: Upcase by thoughtbot | Learn Web Development Online
     marketing:
-      page_title: Upcase by thoughtbot | Learn Web Development Online
       description: Join Upcase by thoughtbot. Explore video tutorials,
         exercises, forum discussions and the community you need to grow as a web
         developer.
@@ -128,6 +127,7 @@ en:
       hero_uvp_html: We turn <strong>junior developers into ass-kicking name
         takers.</strong> We're not a bootcamp, we're a finishing school.
       language_flash: Thanks for signing up. We will be in touch!
+      page_title: Upcase by thoughtbot | Learn Web Development Online
       start_learning: Start Learning Today
       have_a_team: Have a team?
   pages:


### PR DESCRIPTION
https://trello.com/c/KnST3XnG/221-track-landing-on-marketing-pages-as-events

To be able to use event based conversion, i.e someone views page X, then takes action Y, in Amplitude, we need to pass an event name. Our analytics uses `content_for(:page_title)` to send a valid name to segment for page tracking. This PR should set up our marketing pages to be tracked by Segment, and then used for event tracking in Amplitude. 