### PR TITLE
Fix "/join" path and consolidate sign_up + join

### DIFF
--- a/app/views/products/_locked.html.erb
+++ b/app/views/products/_locked.html.erb
@@ -10,7 +10,7 @@
     </span>
 
     <%= link_to t(".get_access_by_joining"),
-      join_path,
+      sign_up_path,
       class: 'upgrade-link' %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,8 +63,7 @@ Upcase::Application.routes.draw do
       post "intercom-unsubscribes", to: "intercom_unsubscribes#create"
     end
 
-    get "/join" => "subscriptions#new", as: :sign_up
-    get "/join" => "subscriptions#new", as: :join
+    get "/join" => "checkouts#new", plan: "professional", as: :sign_up
     get "/sign_in" => "sessions#new", as: "sign_in"
     delete "/sign_out" => "sessions#destroy", as: "sign_out"
 

--- a/spec/features/subscriber_views_weekly_iteration_spec.rb
+++ b/spec/features/subscriber_views_weekly_iteration_spec.rb
@@ -41,7 +41,7 @@ feature "subscriber views weekly iteration" do
   end
 
   def preview_cta
-    I18n.t("watchables.preview.cta", subscribe_url: join_path).html_safe
+    I18n.t("watchables.preview.cta", subscribe_url: sign_up_path).html_safe
   end
 
   matcher :have_video_status do |status|

--- a/spec/requests/sign_up_redirect_spec.rb
+++ b/spec/requests/sign_up_redirect_spec.rb
@@ -4,6 +4,6 @@ describe "User_signup redirect" do
   it "redirects to join path" do
     get "/upcase/sign_up"
 
-    expect(response).to redirect_to join_path
+    expect(response).to redirect_to sign_up_path
   end
 end

--- a/spec/views/trails/_completeable_preview.html.erb_spec.rb
+++ b/spec/views/trails/_completeable_preview.html.erb_spec.rb
@@ -33,6 +33,6 @@ describe "trails/_completeablel_preview.html" do
   end
 
   def have_get_access_by_joining_link
-    have_link I18n.t("products.locked.get_access_by_joining"), href: join_path
+    have_link I18n.t("products.locked.get_access_by_joining"), href: sign_up_path
   end
 end


### PR DESCRIPTION
/upcase/join was a broken link so this commit fixes that and points it
to the correct action - checkouts#new (with the professional plan).

In addition - there were two path helpers both referring to "/join" that
have now been consolidated to one - `sign_up`. References to `join_path`
have been changed to use `sign_up_path`.