### PR TITLE
StripeCustomerFinder catches "No customer" error

### DIFF
--- a/app/services/stripe_customer_finder.rb
+++ b/app/services/stripe_customer_finder.rb
@@ -9,7 +9,7 @@ class StripeCustomerFinder
   def retrieve(customer_id)
     Stripe::Customer.retrieve(customer_id)
   rescue Stripe::InvalidRequestError => e
-    if has_whitelisted_error?(e)
+    if dev? && has_whitelisted_error?(e)
       generate_fake_customer(customer_id)
     else
       raise
@@ -18,12 +18,11 @@ class StripeCustomerFinder
 
   private
 
-  def has_whitelisted_error?(error)
-    stripe_environent_error?(error) &&
-      Rails.env.in?(%w[test development])
+  def dev?
+    Rails.env.development?
   end
 
-  def stripe_environent_error?(error)
+  def has_whitelisted_error?(error)
     error.message.include?(SIMILAR_OBJECT_ERROR) ||
       error.message.include?(NO_CUSTOMER_ERROR)
   end

--- a/spec/services/stripe_customer_finder_spec.rb
+++ b/spec/services/stripe_customer_finder_spec.rb
@@ -53,7 +53,7 @@ describe StripeCustomerFinder do
   end
 
   def stripe_error_message
-    "Hark! An error! #{StripeCustomerFinder::ERROR_MESSAGE}"
+    "Hark! An error! #{StripeCustomerFinder::SIMILAR_OBJECT_ERROR}"
   end
 
   def in_environment(env)


### PR DESCRIPTION
... in test and development environments. Until now whenever this
service object was hit in development mode it would fail because the
particular "no such customer" error is not handled. This commit checks
if in both test OR dev and will provide a fake customer object.

Also add a subscription to the "customer".