### PR TITLE
Re-implement cancellation reason

### DIFF
--- a/app/assets/stylesheets/components/_cancellation.scss
+++ b/app/assets/stylesheets/components/_cancellation.scss
@@ -12,7 +12,7 @@
     }
 
     input {
-      background-color: $red;
+      background: $red none;
     }
   }
 }

--- a/app/controllers/subscriber/cancellations_controller.rb
+++ b/app/controllers/subscriber/cancellations_controller.rb
@@ -6,7 +6,10 @@ class Subscriber::CancellationsController < ApplicationController
   end
 
   def create
-    @cancellation = Cancellation.new(subscription: current_user.subscription)
+    @cancellation = Cancellation.new(
+      subscription: current_user.subscription,
+      reason: cancellation_params[:reason],
+    )
 
     if @cancellation.schedule
       redirect_to(
@@ -16,5 +19,11 @@ class Subscriber::CancellationsController < ApplicationController
     else
       render :new
     end
+  end
+
+  private
+
+  def cancellation_params
+    params.require(:cancellation).permit(:reason)
   end
 end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -1,8 +1,11 @@
 class Cancellation
   include ActiveModel::Model
 
-  def initialize(subscription:)
+  attr_accessor :reason
+
+  def initialize(subscription:, reason: "")
     @subscription = subscription
+    @reason = reason
   end
 
   def schedule
@@ -46,7 +49,7 @@ class Cancellation
   def track_cancelled
     Analytics.
       new(@subscription.user).
-      track_cancelled
+      track_cancelled(reason: reason)
   end
 
   def record_date_when_subscription_will_deactivate

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -53,8 +53,8 @@ class Analytics
     track("Authenticated on checkout")
   end
 
-  def track_cancelled
-    track("Cancelled")
+  def track_cancelled(reason:)
+    track("Cancelled", reason: reason)
   end
 
   def track_paused

--- a/app/views/subscriber/cancellations/new.html.erb
+++ b/app/views/subscriber/cancellations/new.html.erb
@@ -37,12 +37,21 @@
     </p>
 
     <p>
-      If you're sure you won't want to come back Upcase in the future, choose
+      If you're sure you won't want to come back to Upcase in the future, choose
       this option.
     </p>
 
-    <p>
-      <%= link_to t("subscriptions.confirm_cancel"), subscriber_cancellation_path, class: 'cta-button', method: :post %>
-    </p>
+    <%= semantic_form_for(
+      @cancellation,
+      url: [:subscriber, :cancellation],
+      html: { class: "cancellation-feedback" }
+    ) do |form| %>
+      <%= form.inputs do %>
+        <%= form.input :reason, as: :text, label: t("subscriptions.reason"), hint: t("subscriptions.reason_explanation") %>
+      <% end %>
+      <%= form.actions do %>
+        <%= form.action :submit, label: t("subscriptions.confirm_cancel") %>
+      <% end %>
+    <% end %>
   </article>
 </div>

--- a/spec/features/user_cancels_subscription_spec.rb
+++ b/spec/features/user_cancels_subscription_spec.rb
@@ -10,9 +10,13 @@ feature "User cancels a subscription" do
 
     visit my_account_path
     click_link I18n.t("subscriptions.cancel")
-    click_link I18n.t("subscriptions.confirm_cancel")
+    fill_in "cancellation_reason", with: "I didn't like it"
+    click_button I18n.t("subscriptions.confirm_cancel")
 
     expect(page).to have_content I18n.t("subscriptions.flashes.cancel.success")
-    expect(analytics).to(have_tracked("Cancelled"))
+    expect(analytics).to(
+      have_tracked("Cancelled").
+      with_properties(reason: "I didn't like it"),
+    )
   end
 end

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -41,7 +41,8 @@ describe Cancellation do
 
       expect(stripe_customer.subscriptions.first).to have_received(:delete)
       expect(analytics).to have_tracked("Cancelled").
-        for_user(subscription.user)
+        for_user(subscription.user).
+        with_properties(reason: "reason")
     end
 
     it "retrieves the customer correctly" do
@@ -89,7 +90,8 @@ describe Cancellation do
         expect(subscription.user_clicked_cancel_button_on).
           to eq Date.current
         expect(analytics).to have_tracked("Cancelled").
-          for_user(subscription.user)
+          for_user(subscription.user).
+          with_properties(reason: "reason")
       end
     end
 
@@ -137,8 +139,8 @@ describe Cancellation do
     end
   end
 
-  def build_cancellation(subscription: create(:subscription))
-    Cancellation.new(subscription: subscription)
+  def build_cancellation(subscription: create(:subscription), reason: "reason")
+    Cancellation.new(subscription: subscription, reason: reason)
   end
 
   def subscription

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -220,12 +220,12 @@ describe Analytics do
   end
 
   describe "#track_cancelled" do
-    it "tracks that the user cancelled along with their email" do
-      analytics_instance.track_cancelled
+    it "tracks that the user cancelled along with the reason and their email" do
+      analytics_instance.track_cancelled(reason: "No good")
 
       expect(analytics).to have_tracked("Cancelled").
         for_user(user).
-        with_properties(email: user.email)
+        with_properties(reason: "No good", email: user.email)
     end
   end
 


### PR DESCRIPTION
This adds back a form field to enter a cancellation reason when a user cancels their accounts, which was removed as part of #1720.

There was initially a separate page for the cancellation form, and the reason was required. Here I made it so that it's on the same page, along with the option to pause, and is not required. I also only included it for cancellation and not for pause. Not sure if we'd want anything different for any of this?

![screen shot 2017-06-30 at 11 41 24 am](https://user-images.githubusercontent.com/5531038/27749603-1712c0e6-5d89-11e7-964b-b283350a64eb.png)

