### PR TITLE
Update Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     nenv (0.3.0)
     nested_form (0.3.2)
     netrc (0.11.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
We're getting security errors on CI because of vulnerabilities in the
Nokogiri version. This updates it.