### PR TITLE
Add API endpoint to request weekly iteration videos

### DIFF
--- a/app/controllers/api/v1/videos_controller.rb
+++ b/app/controllers/api/v1/videos_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::VideosController < ApiController
+  def index
+    show = find_show
+    render json: { videos: show.videos }
+  end
+
+  private
+
+  def find_show
+    Show.friendly.find(params[:show_id])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Upcase::Application.routes.draw do
     namespace :api do
       namespace :v1 do
         resources :exercises, only: [:update]
+        resources :shows, only: [] do
+          resources :videos, only: [:index]
+        end
 
         post(
           "exercises/:exercise_uuid/status" => "statuses#create",

--- a/spec/requests/api/v1/weekly_iteration_videos_spec.rb
+++ b/spec/requests/api/v1/weekly_iteration_videos_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe "weekly iteration videos" do
+  context "when unauthenticated" do
+    it "returns a list of weekly iteration videos" do
+      show = create(:the_weekly_iteration)
+      video = create(:video, watchable: show)
+
+      get "/upcase/api/v1/shows/the-weekly-iteration/videos"
+
+      expect(response).to be_success
+      expect(response_json).to match({
+        "videos" => [
+          a_hash_including("id" => video.id),
+        ]
+      })
+    end
+  end
+
+  def response_json
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/api/v1/weekly_iteration_videos_spec.rb
+++ b/spec/requests/api/v1/weekly_iteration_videos_spec.rb
@@ -9,11 +9,11 @@ describe "weekly iteration videos" do
       get "/upcase/api/v1/shows/the-weekly-iteration/videos"
 
       expect(response).to be_success
-      expect(response_json).to match({
+      expect(response_json).to match(
         "videos" => [
           a_hash_including("id" => video.id),
-        ]
-      })
+        ],
+      )
     end
   end
 


### PR DESCRIPTION
Introduces a new `Api::V1::VideosController` with an `index` action to list weekly iteration videos (along with other shows). This is a jumping off point to allow the Upcase mobile app to browse and play videos.