### PR TITLE
Update subscription new path

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -29,7 +29,7 @@ class CollaborationsController < ApplicationController
       yield
     else
       redirect_to(
-        new_subscription_path,
+        root_path,
         notice: t("subscriptions.flashes.subscription_required")
       )
     end

--- a/app/controllers/forum_sessions_controller.rb
+++ b/app/controllers/forum_sessions_controller.rb
@@ -18,7 +18,7 @@ class ForumSessionsController < ApplicationController
   def must_have_forum_access
     unless current_user.has_access_to?(Forum)
       redirect_to(
-        new_subscription_url,
+        root_path,
         notice: I18n.t(
           "products.subscribe_cta",
           offering_type: "forum",

--- a/app/views/products/_subscription.html.erb
+++ b/app/views/products/_subscription.html.erb
@@ -2,7 +2,10 @@
   <div class="subscription-cta">
     <h2><%= t("#{offering.offering_type}.preview_cta") %></h2>
     <div class="license">
-      <%= link_to new_subscription_path, class: 'license-button button subscription-button' do %>
+      <%= link_to(
+        root_path,
+        class: 'license-button button subscription-button'
+      ) do %>
         Subscribe to <%= t('shared.subscription.name') %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Upcase::Application.routes.draw do
     resource :forum_sessions, only: :new
     resources :payments, only: [:new]
     resources :signups, only: [:create]
-    resource :subscription, only: [:new, :edit, :update]
+    resource :subscription, only: [:edit, :update]
     resources :coupons, only: :show
     resources :topics, only: :index, constraints: { format: "css" }
     resources :onboardings, only: :create

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -47,13 +47,13 @@ describe CollaborationsController do
     end
 
     context "as a visitor" do
-      it "redirects to the sign up page" do
+      it "redirects to the landing page" do
         repository = stub_repository
 
         post :create, repository_id: repository.to_param
 
         expect(repository).not_to have_received(:add_collaborator)
-        expect(controller).to redirect_to(new_subscription_path)
+        expect(controller).to redirect_to(root_path)
         expect(controller).to set_flash.to(
           I18n.t("subscriptions.flashes.subscription_required")
         )

--- a/spec/controllers/forum_sessions_controller_spec.rb
+++ b/spec/controllers/forum_sessions_controller_spec.rb
@@ -39,14 +39,14 @@ describe ForumSessionsController do
     end
 
     context "when logged in but not subscribed" do
-      it "redirects to new_subscription_url" do
+      it "redirects to the landing page" do
         user = build_stubbed(:user)
         stub_current_user_with(user)
 
         get :new, sso: "ssohash", sig: "sig"
 
         should deny_access(
-          redirect: new_subscription_url,
+          redirect: root_path,
           flash: I18n.t(
             "products.subscribe_cta",
             offering_type: "forum",


### PR DESCRIPTION
https://trello.com/c/N1eIeBZh/238-bad-route-newsubscriptionpath

The old subscriptions/new path was the landing page. We have since
changed that to our high_voltage landing page. This PR will adjust the
routes to redirect the old subscriptions/new routes to the new
high_voltage landing page.