### PR TITLE
Update video durations based on Wistia Data

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -87,4 +87,12 @@ class Video < ActiveRecord::Base
       published_on <= Date.current
     end
   end
+
+  def update_duration(duration = nil)
+    if duration.present?
+      update(length_in_minutes: duration)
+    else
+      VideoDurationUpdater.update_duration(self)
+    end
+  end
 end

--- a/app/services/video_duration_updater.rb
+++ b/app/services/video_duration_updater.rb
@@ -1,0 +1,50 @@
+class VideoDurationUpdater
+  ROUNDING_LIMIT = 10
+  def self.update_all_durations
+    new.update_all_durations
+  end
+
+  def self.update_duration(video)
+    new.update_duration(video)
+  end
+
+  def update_all_durations
+    wistia_response = wistia_client.list
+    names_and_durations = names_and_durations(wistia_response)
+    names_and_durations.each_pair do |name, duration|
+      Video.find_by(name: name)&.update(length_in_minutes: duration)
+    end
+  end
+
+  def update_duration(video)
+    wistia_response = wistia_client.show(video.wistia_id)
+    length_in_minutes = seconds_to_minutes(wistia_response["duration"])
+    video.update(length_in_minutes: length_in_minutes)
+  end
+
+  private
+
+  def wistia_client
+    @_wistia_client ||= WistiaApiClient::Media.new
+  end
+
+  def names_and_durations(data)
+    data.reduce({}) do |aggregator, video|
+      aggregator.merge(get_duration(video))
+    end
+  end
+
+  def get_duration(data)
+    { data["name"] => seconds_to_minutes(data["duration"]) }
+  end
+
+  def seconds_to_minutes(seconds)
+    minutes = (seconds / 60).to_i
+    seconds_remaining = seconds % 60
+    if seconds_remaining < ROUNDING_LIMIT
+      minutes
+    else
+      minutes + 1
+    end
+  end
+end

--- a/lib/tasks/wistia.rake
+++ b/lib/tasks/wistia.rake
@@ -1,0 +1,5 @@
+namespace :wistia do
+  task update_video_durations: :environment do
+    VideoDurationUpdater.update_all_durations
+  end
+end

--- a/lib/wistia_api_client/media.rb
+++ b/lib/wistia_api_client/media.rb
@@ -1,0 +1,46 @@
+module WistiaApiClient
+  class Media
+    WISTIA_API_URL = ENV.fetch("WISTIA_API_HOST")
+    DEFAULT_API_TOKEN = ENV.fetch("WISTIA_API_KEY")
+
+    def initialize(api_token: DEFAULT_API_TOKEN)
+      @api_token = api_token
+    end
+
+    def list(limit: 100, starting_page: 1)
+      uri = URI("#{WISTIA_API_URL}/medias.json")
+      list_response(uri: uri, page: starting_page, limit: limit)
+    end
+
+    def show(wistia_id)
+      uri = URI("#{WISTIA_API_URL}/medias/#{wistia_id}.json")
+      request = make_request(uri: uri)
+      JSON.parse(request.body)
+    end
+
+    private
+
+    attr_reader :api_token
+
+    def list_response(uri:, limit: 100, page: 1)
+      uri.query = "page=#{page}&limit=#{limit}"
+      response = make_request(uri: uri)
+
+      parsed_response = JSON.parse(response.body)
+
+      if parsed_response.blank?
+        []
+      else
+        parsed_response + list_response(uri: uri, page: page + 1, limit: limit)
+      end
+    end
+
+    def make_request(uri:)
+      request = Net::HTTP::Get.new(uri)
+      request.basic_auth("api", api_token)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      http.request(request)
+    end
+  end
+end

--- a/spec/lib/wistia_api_client/media_spec.rb
+++ b/spec/lib/wistia_api_client/media_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+require "openssl"
+
+RSpec.describe WistiaApiClient::Media do
+  describe "#list" do
+    it "returns a parsed JSON response" do
+      media_client = described_class.new
+
+      result = media_client.list
+
+      expect(result).to respond_to :each
+      expect(result.first).to respond_to :keys
+    end
+
+    it "combines multi-page responses into a single response" do
+      media_client = described_class.new
+
+      result = media_client.list(limit: 1, starting_page: 1)
+
+      expect(result.size).to eq 3
+    end
+  end
+
+  describe "#show" do
+    it "returns a parsed JSON response for a single media object" do
+      media_client = described_class.new
+      wistia_id = "123foo"
+
+      result = media_client.show(wistia_id)
+
+      expect(result["type"]).to eq "Video"
+      expect(result.keys).to include("name", "duration", "hashed_id")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,7 @@ Capybara.app = HostMap.new(
   "www.example.com" => Capybara.app,
   "127.0.0.1" => Capybara.app,
   "github.com" => FakeGithub,
+  "api.wistia.com" => FakeWistia,
   "exercises.upcase.com" => FakeUpcaseExercises,
   "localhost" => FakeUpcaseExercises
 )

--- a/spec/services/video_duration_updater_spec.rb
+++ b/spec/services/video_duration_updater_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+describe VideoDurationUpdater do
+  include WistiaApiClientStubs
+
+  describe ".update_all_durations" do
+    context "when videos exist in Wistia and locally" do
+      it "updates the length_in_minutes attributes for all videos in wistia" do
+        video1 = create(
+          :video,
+          name: "Vim for Rails Developers",
+          length_in_minutes: nil,
+        )
+        video2 = create(
+          :video,
+          name: "humans present tmux",
+          length_in_minutes: 17,
+        )
+        wistia_response = [
+          {
+            "name" => video1.name,
+            "duration" => 3600,
+            "hashed_id" => video1.wistia_id,
+          },
+          {
+            "name" =>  video2.name,
+            "duration" => 578,
+            "hashed_id" => video2.wistia_id,
+          },
+        ]
+        stub_wistia_api_client(response: wistia_response)
+
+        described_class.update_all_durations
+        video1.reload
+        video2.reload
+
+        expect(video1.length_in_minutes).to eq 60
+        expect(video2.length_in_minutes).to eq 10
+      end
+    end
+
+    context "when Wistia returns videos that don't exist locally" do
+      it "skips them" do
+        local_video = create(:video, length_in_minutes: nil)
+        wistia_response = [
+          {
+            "name" => "Vim for Rails Developers",
+            "duration" => 3600.05,
+            "hashed_id" => "947f4c35d9",
+          },
+          {
+            "name" => "chrome-dev-tools.mov",
+            "duration" => 630,
+            "hashed_id" => "04ccec11ed",
+          },
+          {
+            "name" => local_video.name,
+            "duration" => 1500,
+            "hashed_id" => "m4keb3li3v3",
+          },
+        ]
+        stub_wistia_api_client(response: wistia_response)
+
+        described_class.update_all_durations
+        local_video.reload
+
+        expect(local_video.length_in_minutes).to eq 25
+      end
+    end
+  end
+
+  describe "#update_duration" do
+    context "when duration is only 10 seconds above the nearest minute" do
+      it "rounds down when updating the video's length in minutes" do
+        video = create(:video, length_in_minutes: nil)
+        show_response = {
+          "name" => video.name,
+          "duration" => 68,
+          "hashed_id" => "m4keb3li3v3",
+        }
+        stub_wistia_api_client(response: show_response)
+
+        described_class.update_duration(video)
+        video.reload
+
+        expect(video.length_in_minutes).to eq 1
+      end
+    end
+
+    context "when duration more than 10 seconds above the nearest minute" do
+      it "rounds up when updating the video's length in minutes" do
+        video = create(:video, length_in_minutes: nil)
+        show_response = {
+          "name" => video.name,
+          "duration" => 71,
+          "hashed_id" => "m4keb3li3v3",
+        }
+        stub_wistia_api_client(response: show_response)
+
+        described_class.update_duration(video)
+        video.reload
+
+        expect(video.length_in_minutes).to eq 2
+      end
+    end
+
+    it "updates the passed in video's duration with the retrieved value" do
+      video = create(
+        :video,
+        wistia_id: "foo",
+        name: "humans present refactoring",
+        length_in_minutes: nil,
+      )
+
+      described_class.update_duration(video)
+      video.reload
+
+      expect(video.length_in_minutes).to eq 71
+    end
+  end
+end

--- a/spec/support/fake_wistia.rb
+++ b/spec/support/fake_wistia.rb
@@ -2,7 +2,7 @@ require 'sinatra/base'
 require 'capybara_discoball'
 
 class FakeWistia < Sinatra::Base
-  get '/oembed.json' do
+  get "/oembed.json" do
     headers 'Access-Control-Allow-Origin' => '*'
     {
       html: "<iframe class='wistia_embed'></iframe>",
@@ -10,9 +10,94 @@ class FakeWistia < Sinatra::Base
       duration: 120
     }.to_json
   end
+
+  get "/medias.json" do
+    page = params.fetch("page", 1).to_i
+    limit = params.fetch("limit", 2).to_i
+    paginate(
+      collection: medias,
+      page: page,
+      limit: limit,
+    )
+  end
+
+  get "/medias/:id.json" do
+    media.merge(hashed_id: params[:id]).to_json
+  end
+
+  def media
+    {
+      "name": "humans present refactoring",
+      "type": "Video",
+      "duration": 4236.57,
+      "hashed_id": "91c694636a",
+      "status": "ready",
+      "project": {
+        "id": 133321,
+        "name": "Human Presents Refactoring",
+        "hashed_id": "8a28fa23f6",
+      },
+    }
+  end
+
+  def medias
+    [
+      {
+        "id": 1194803,
+        "name": "Vim for Rails Developers",
+        "type": "Video",
+        "duration": 3600.05,
+        "hashed_id": "947f4c35d9",
+        "section": "Vim for Rails Developers",
+        "project": {
+          "id": 130407,
+          "name": "Vim-related",
+          "hashed_id": "a70b2f2ee5",
+        },
+      },
+      {
+        "id": 1211825,
+        "name": "chrome-dev-tools.mov",
+        "type": "Video",
+        "duration": 630,
+        "hashed_id": "04ccec11ed",
+        "status": "ready",
+        "project": {
+          "id": 133307,
+          "name": "Chrome Developer Tips",
+          "hashed_id": "b0f6587735",
+        },
+      },
+      {
+        "id": 1211765,
+        "name": "humans present tmux",
+        "type": "Video",
+        "duration": 1593,
+        "hashed_id": "18c640ef8f",
+        "status": "ready",
+        "project": {
+          "id": 133293,
+          "name": "Humans Present TMUX medium",
+          "hashed_id": "03dfc83301",
+        },
+      },
+    ]
+  end
+
+  def paginate(collection:, page:, limit:)
+    starting_index = (page - 1) * limit
+    if starting_index > (collection.size / limit) + 1
+      "[]"
+    else
+      collection[starting_index..-1].
+        take(limit).
+        to_json
+    end
+  end
 end
 
 FakeWistiaRunner = Capybara::Discoball::Runner.new(FakeWistia) do |server|
   url = "http://#{server.host}:#{server.port}"
   ENV['WISTIA_HOST'] = url
+  ENV['WISTIA_API_HOST'] = url
 end

--- a/spec/support/wistia_client.rb
+++ b/spec/support/wistia_client.rb
@@ -1,0 +1,8 @@
+module WistiaApiClientStubs
+  def stub_wistia_api_client(response:)
+    client = instance_double("WistiaApiClient::Media")
+    allow(client).to receive(:list).and_return(response)
+    allow(client).to receive(:show).and_return(response)
+    allow(WistiaApiClient::Media).to receive(:new).and_return(client)
+  end
+end


### PR DESCRIPTION
This PR backfills adds a Rake task that backfills the `length_in_minutes` attribute on `Video` records. It enables us to display an estimated time-to-complete for all trails if we decide it's worthwhile experimenting with the Intermediate Rails 5 trail in #1758. Key changes:
- Create a wrapper for the Wistia API in `WistiaApiClient`
- Create a FakeWistia for sample paginated replies
- Create a `VideoDuration` service that can either update all video durations or a single duration
- Create a Wistia `update_video_durations` rake task that will launch the service. 