### PR TITLE
Add basic http auth for staging environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def on_staging?
-    Rails.env.production? && ENV.fetch("HEROKU_APP_NAME", "").include?("staging")
+    ENV.fetch("HEROKU_APP_NAME", "").include?("staging")
   end
 
   def analytics


### PR DESCRIPTION
- Users were able to access content by signing up for a test account on
the staging site.
- Protect the staging site by requiring devs to login