### PR TITLE
Remove absolute and fixed positioning for header flash

### DIFF
--- a/app/assets/stylesheets/components/_flashes.scss
+++ b/app/assets/stylesheets/components/_flashes.scss
@@ -1,15 +1,6 @@
 .flashes {
   text-align: center;
 
-  .header-flash & {
-    @include position(absolute, 0 0 null 0);
-    z-index: 25;
-
-    @include marketing-fullsize {
-      position: fixed;
-    }
-  }
-
   .pricing & {
     margin: 1em 0;
     padding: 0;


### PR DESCRIPTION
- Because of positioning and z-index the flash over the header rendered
nav links un-clickable even after the flash disappeared.
- Removing positioning and z-index displays the flash below the header
so nav remains visible and clickable.

![screen shot 2017-11-05 at 1 53 16 pm](https://user-images.githubusercontent.com/11186572/32497564-f26d60ca-c39a-11e7-9da3-7df0eecbe418.png)

@Euraldius I know this changes the design of the notification, but I feel that it's a nicer experience to not cover up important links in the nav.
