### PR TITLE
Make links and cta more visible in the nav

### DIFF
--- a/app/views/layouts/_header_application_links.html.erb
+++ b/app/views/layouts/_header_application_links.html.erb
@@ -43,7 +43,7 @@
 
       <% unless current_user.subscriber? %>
         <li id="site_nav_call_to_action">
-          <%= link_to professional_checkout_path, class: "site-nav__cta" do %>
+          <%= link_to professional_checkout_path, class: "site-nav__button" do %>
             <%= t("shared.subscriptions.single_user") %>
           <% end %>
         </li>

--- a/app/views/shared/_masquerade_link.html.erb
+++ b/app/views/shared/_masquerade_link.html.erb
@@ -1,4 +1,5 @@
 <li><%= link_to "Stop Masquerading",
                 masquerade_path,
                 title: "Masquerading #{current_user.email}",
-                method: :delete %></li>
+                method: :delete,
+                class: "site-nav__link" %></li>


### PR DESCRIPTION
Previously, the join upcase cta(when a user is logged in but not subscribed) and the stop masquerading links were blending into the nav:
![screen shot 2018-01-19 at 11 39 51 am](https://user-images.githubusercontent.com/11186572/35161289-b75eb630-fd0d-11e7-9b45-db065cc1831c.png)

By adding site nav link and button classes they are more visible/prominent:
![screen shot 2018-01-19 at 11 39 32 am](https://user-images.githubusercontent.com/11186572/35161305-c8d02778-fd0d-11e7-8700-74900e01ed62.png)

Related trello card:
https://trello.com/c/Ixng9Hse/250-when-user-is-logged-in-but-not-subscribed-join-upcase-link-in-nav-is-not-visible