### PR TITLE
Upgrade migrations class syntax

### DIFF
--- a/db/migrate/20100810204907_clearance_create_users.rb
+++ b/db/migrate/20100810204907_clearance_create_users.rb
@@ -1,4 +1,4 @@
-class ClearanceCreateUsers < ActiveRecord::Migration
+class ClearanceCreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       t.string   :email

--- a/db/migrate/20100816200505_create_courses.rb
+++ b/db/migrate/20100816200505_create_courses.rb
@@ -1,4 +1,4 @@
-class CreateCourses < ActiveRecord::Migration
+class CreateCourses < ActiveRecord::Migration[4.2]
   def self.up
     create_table :courses do |t|
       t.string :name, :price, :location, :null => false, :default => ''

--- a/db/migrate/20100816200755_create_sections.rb
+++ b/db/migrate/20100816200755_create_sections.rb
@@ -1,4 +1,4 @@
-class CreateSections < ActiveRecord::Migration
+class CreateSections < ActiveRecord::Migration[4.2]
   def self.up
     create_table :sections do |t|
       t.belongs_to :course

--- a/db/migrate/20100819151115_add_registration_link_to_sections.rb
+++ b/db/migrate/20100819151115_add_registration_link_to_sections.rb
@@ -1,4 +1,4 @@
-class AddRegistrationLinkToSections < ActiveRecord::Migration
+class AddRegistrationLinkToSections < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sections, :registration_link, :string, :null => false, :default => ''
   end

--- a/db/migrate/20100823201314_add_chargify_to_users.rb
+++ b/db/migrate/20100823201314_add_chargify_to_users.rb
@@ -1,4 +1,4 @@
-class AddChargifyToUsers < ActiveRecord::Migration
+class AddChargifyToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :customer_id, :string, :default => ''
     add_column :users, :first_name, :string, :default => ''

--- a/db/migrate/20100827151304_create_registrations.rb
+++ b/db/migrate/20100827151304_create_registrations.rb
@@ -1,4 +1,4 @@
-class CreateRegistrations < ActiveRecord::Migration
+class CreateRegistrations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :registrations do |t|
       t.belongs_to :user, :section

--- a/db/migrate/20100907181652_add_admin_to_user.rb
+++ b/db/migrate/20100907181652_add_admin_to_user.rb
@@ -1,4 +1,4 @@
-class AddAdminToUser < ActiveRecord::Migration
+class AddAdminToUser < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :admin, :boolean, :default => false, :null => false
     add_index :users, :admin

--- a/db/migrate/20100907194846_add_location_name_to_courses.rb
+++ b/db/migrate/20100907194846_add_location_name_to_courses.rb
@@ -1,4 +1,4 @@
-class AddLocationNameToCourses < ActiveRecord::Migration
+class AddLocationNameToCourses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :courses, :location_name, :string, :default => ''
   end

--- a/db/migrate/20100908155003_create_teachers.rb
+++ b/db/migrate/20100908155003_create_teachers.rb
@@ -1,4 +1,4 @@
-class CreateTeachers < ActiveRecord::Migration
+class CreateTeachers < ActiveRecord::Migration[4.2]
   def self.up
     create_table :teachers do |t|
       t.string :name, :gravatar_hash

--- a/db/migrate/20100909132700_create_section_teachers.rb
+++ b/db/migrate/20100909132700_create_section_teachers.rb
@@ -1,4 +1,4 @@
-class CreateSectionTeachers < ActiveRecord::Migration
+class CreateSectionTeachers < ActiveRecord::Migration[4.2]
   def self.up
     create_table :section_teachers do |t|
       t.belongs_to :section, :teacher

--- a/db/migrate/20100910153615_add_email_to_teachers.rb
+++ b/db/migrate/20100910153615_add_email_to_teachers.rb
@@ -1,4 +1,4 @@
-class AddEmailToTeachers < ActiveRecord::Migration
+class AddEmailToTeachers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :teachers, :email, :string, :default => ''
   end

--- a/db/migrate/20100916145619_create_questions.rb
+++ b/db/migrate/20100916145619_create_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :questions do |table|
       table.column :course_id, :integer

--- a/db/migrate/20100917161421_create_resources.rb
+++ b/db/migrate/20100917161421_create_resources.rb
@@ -1,4 +1,4 @@
-class CreateResources < ActiveRecord::Migration
+class CreateResources < ActiveRecord::Migration[4.2]
   def self.up
     create_table :resources do |table|
       table.column :course_id, :integer

--- a/db/migrate/20100920190916_replace_registration_link_with_chargify_id_on_sections.rb
+++ b/db/migrate/20100920190916_replace_registration_link_with_chargify_id_on_sections.rb
@@ -1,4 +1,4 @@
-class ReplaceRegistrationLinkWithChargifyIdOnSections < ActiveRecord::Migration
+class ReplaceRegistrationLinkWithChargifyIdOnSections < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :sections, :registration_link
     add_column :sections, :chargify_id, :string

--- a/db/migrate/20100927144003_change_default_to_true_for_email_confirmed_on_users.rb
+++ b/db/migrate/20100927144003_change_default_to_true_for_email_confirmed_on_users.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultToTrueForEmailConfirmedOnUsers < ActiveRecord::Migration
+class ChangeDefaultToTrueForEmailConfirmedOnUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_column :users, :email_confirmed, :boolean, :default => true
   end

--- a/db/migrate/20101005171739_create_follow_ups.rb
+++ b/db/migrate/20101005171739_create_follow_ups.rb
@@ -1,4 +1,4 @@
-class CreateFollowUps < ActiveRecord::Migration
+class CreateFollowUps < ActiveRecord::Migration[4.2]
   def self.up
     create_table :follow_ups do |t|
       t.string :email

--- a/db/migrate/20101203155002_ensure_maximum_students.rb
+++ b/db/migrate/20101203155002_ensure_maximum_students.rb
@@ -1,4 +1,4 @@
-class EnsureMaximumStudents < ActiveRecord::Migration
+class EnsureMaximumStudents < ActiveRecord::Migration[4.2]
   def self.up
     change_column :courses, :maximum_students, :integer, :default => 12, :null => false
   end

--- a/db/migrate/20110221184349_remove_chargify_from_sections.rb
+++ b/db/migrate/20110221184349_remove_chargify_from_sections.rb
@@ -1,4 +1,4 @@
-class RemoveChargifyFromSections < ActiveRecord::Migration
+class RemoveChargifyFromSections < ActiveRecord::Migration[4.2]
   def self.up
     change_table :sections do |t|
       t.remove :chargify_id

--- a/db/migrate/20110221205746_add_freshbook_fields_to_users.rb
+++ b/db/migrate/20110221205746_add_freshbook_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddFreshbookFieldsToUsers < ActiveRecord::Migration
+class AddFreshbookFieldsToUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table :users do |t|
       t.string  :phone

--- a/db/migrate/20110222194149_create_freshbooks_invoice_id_on_registration.rb
+++ b/db/migrate/20110222194149_create_freshbooks_invoice_id_on_registration.rb
@@ -1,4 +1,4 @@
-class CreateFreshbooksInvoiceIdOnRegistration < ActiveRecord::Migration
+class CreateFreshbooksInvoiceIdOnRegistration < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrations, :freshbooks_invoice_id, :integer
   end

--- a/db/migrate/20110223163553_add_freshbooks_invoice_url_to_registrations.rb
+++ b/db/migrate/20110223163553_add_freshbooks_invoice_url_to_registrations.rb
@@ -1,4 +1,4 @@
-class AddFreshbooksInvoiceUrlToRegistrations < ActiveRecord::Migration
+class AddFreshbooksInvoiceUrlToRegistrations < ActiveRecord::Migration[4.2]
   def self.up
     change_table :registrations do |t|
       t.string :freshbooks_invoice_url

--- a/db/migrate/20110302154219_create_coupons.rb
+++ b/db/migrate/20110302154219_create_coupons.rb
@@ -1,4 +1,4 @@
-class CreateCoupons < ActiveRecord::Migration
+class CreateCoupons < ActiveRecord::Migration[4.2]
   def self.up
     create_table :coupons do |t|
       t.string :code

--- a/db/migrate/20110302155621_add_active_to_coupons.rb
+++ b/db/migrate/20110302155621_add_active_to_coupons.rb
@@ -1,4 +1,4 @@
-class AddActiveToCoupons < ActiveRecord::Migration
+class AddActiveToCoupons < ActiveRecord::Migration[4.2]
   def self.up
     add_column :coupons, :active, :boolean, :null => false, :default => true
   end

--- a/db/migrate/20110302175223_change_course_price_to_integer.rb
+++ b/db/migrate/20110302175223_change_course_price_to_integer.rb
@@ -1,4 +1,4 @@
-class ChangeCoursePriceToInteger < ActiveRecord::Migration
+class ChangeCoursePriceToInteger < ActiveRecord::Migration[4.2]
   def self.up
     add_column :courses, :price_int, :integer, :null => true, :default => nil
     execute <<-SQL

--- a/db/migrate/20110302180019_add_coupon_to_registration.rb
+++ b/db/migrate/20110302180019_add_coupon_to_registration.rb
@@ -1,4 +1,4 @@
-class AddCouponToRegistration < ActiveRecord::Migration
+class AddCouponToRegistration < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrations, :coupon_id, :integer
   end

--- a/db/migrate/20110331193625_add_short_description_to_courses.rb
+++ b/db/migrate/20110331193625_add_short_description_to_courses.rb
@@ -1,4 +1,4 @@
-class AddShortDescriptionToCourses < ActiveRecord::Migration
+class AddShortDescriptionToCourses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :courses, :short_description, :string
   end

--- a/db/migrate/20110412201102_add_external_registration_url_to_courses.rb
+++ b/db/migrate/20110412201102_add_external_registration_url_to_courses.rb
@@ -1,4 +1,4 @@
-class AddExternalRegistrationUrlToCourses < ActiveRecord::Migration
+class AddExternalRegistrationUrlToCourses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :courses, :external_registration_url, :string
   end

--- a/db/migrate/20110413175544_change_question_answer_to_text.rb
+++ b/db/migrate/20110413175544_change_question_answer_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeQuestionAnswerToText < ActiveRecord::Migration
+class ChangeQuestionAnswerToText < ActiveRecord::Migration[4.2]
   def self.up
     change_column :questions, :answer, :text
   end

--- a/db/migrate/20110413180426_remove_resources.rb
+++ b/db/migrate/20110413180426_remove_resources.rb
@@ -1,4 +1,4 @@
-class RemoveResources < ActiveRecord::Migration
+class RemoveResources < ActiveRecord::Migration[4.2]
   def self.up
     drop_table :resources
   end

--- a/db/migrate/20110429145538_upgrade_clearance_to_diesel.rb
+++ b/db/migrate/20110429145538_upgrade_clearance_to_diesel.rb
@@ -1,4 +1,4 @@
-class UpgradeClearanceToDiesel < ActiveRecord::Migration
+class UpgradeClearanceToDiesel < ActiveRecord::Migration[4.2]
   def self.up
     change_table(:users) do |t|
     end

--- a/db/migrate/20110620184954_downcase_emails.rb
+++ b/db/migrate/20110620184954_downcase_emails.rb
@@ -1,4 +1,4 @@
-class DowncaseEmails < ActiveRecord::Migration
+class DowncaseEmails < ActiveRecord::Migration[4.2]
   def self.up
     update "update users set email = LOWER(email)"
   end

--- a/db/migrate/20110621014509_add_timestamps_to_questions.rb
+++ b/db/migrate/20110621014509_add_timestamps_to_questions.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToQuestions < ActiveRecord::Migration
+class AddTimestampsToQuestions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :questions, :created_at, :datetime
     add_column :questions, :updated_at, :datetime

--- a/db/migrate/20110627200215_add_position_to_courses.rb
+++ b/db/migrate/20110627200215_add_position_to_courses.rb
@@ -1,4 +1,4 @@
-class AddPositionToCourses < ActiveRecord::Migration
+class AddPositionToCourses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :courses, :position, :integer
   end

--- a/db/migrate/20110628164932_initialize_acts_as_list_for_courses.rb
+++ b/db/migrate/20110628164932_initialize_acts_as_list_for_courses.rb
@@ -1,4 +1,4 @@
-class InitializeActsAsListForCourses < ActiveRecord::Migration
+class InitializeActsAsListForCourses < ActiveRecord::Migration[4.2]
   def self.up
     execute <<-SQL
       CREATE SEQUENCE list_import START 1;

--- a/db/migrate/20110630144103_remove_terms_of_service_from_courses.rb
+++ b/db/migrate/20110630144103_remove_terms_of_service_from_courses.rb
@@ -1,4 +1,4 @@
-class RemoveTermsOfServiceFromCourses < ActiveRecord::Migration
+class RemoveTermsOfServiceFromCourses < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :courses, :terms_of_service
   end

--- a/db/migrate/20110812214043_create_audiences.rb
+++ b/db/migrate/20110812214043_create_audiences.rb
@@ -1,4 +1,4 @@
-class CreateAudiences < ActiveRecord::Migration
+class CreateAudiences < ActiveRecord::Migration[4.2]
   def self.up
     create_table :audiences do |t|
       t.string :name

--- a/db/migrate/20110914152250_add_notified_at_to_follow_ups.rb
+++ b/db/migrate/20110914152250_add_notified_at_to_follow_ups.rb
@@ -1,4 +1,4 @@
-class AddNotifiedAtToFollowUps < ActiveRecord::Migration
+class AddNotifiedAtToFollowUps < ActiveRecord::Migration[4.2]
   def self.up
     add_column :follow_ups, :notified_at, :datetime
   end

--- a/db/migrate/20110921121033_change_public_column_default_in_courses.rb
+++ b/db/migrate/20110921121033_change_public_column_default_in_courses.rb
@@ -1,4 +1,4 @@
-class ChangePublicColumnDefaultInCourses < ActiveRecord::Migration
+class ChangePublicColumnDefaultInCourses < ActiveRecord::Migration[4.2]
   def self.up
     change_column_default :courses, :public, true
     execute "UPDATE courses SET public='true';"

--- a/db/migrate/20110922094953_add_seats_available_to_sections.rb
+++ b/db/migrate/20110922094953_add_seats_available_to_sections.rb
@@ -1,4 +1,4 @@
-class AddSeatsAvailableToSections < ActiveRecord::Migration
+class AddSeatsAvailableToSections < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sections, :seats_available, :integer
   end

--- a/db/migrate/20120131225937_move_users_to_registration.rb
+++ b/db/migrate/20120131225937_move_users_to_registration.rb
@@ -1,4 +1,4 @@
-class MoveUsersToRegistration < ActiveRecord::Migration
+class MoveUsersToRegistration < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrations, :email, :string
     add_column :registrations, :billing_email, :string

--- a/db/migrate/20120202001630_add_comments_to_registrations.rb
+++ b/db/migrate/20120202001630_add_comments_to_registrations.rb
@@ -1,4 +1,4 @@
-class AddCommentsToRegistrations < ActiveRecord::Migration
+class AddCommentsToRegistrations < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrations, :comments, :text
   end

--- a/db/migrate/20120202132518_add_paid_to_registrations.rb
+++ b/db/migrate/20120202132518_add_paid_to_registrations.rb
@@ -1,4 +1,4 @@
-class AddPaidToRegistrations < ActiveRecord::Migration
+class AddPaidToRegistrations < ActiveRecord::Migration[4.2]
   def self.up
     add_column :registrations, :paid, :boolean, :null => false, :default => false
     add_index :registrations, :paid

--- a/db/migrate/20120207183947_add_start_at_and_stop_at_to_sections.rb
+++ b/db/migrate/20120207183947_add_start_at_and_stop_at_to_sections.rb
@@ -1,4 +1,4 @@
-class AddStartAtAndStopAtToSections < ActiveRecord::Migration
+class AddStartAtAndStopAtToSections < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sections, :start_at, :time
     add_column :sections, :stop_at, :time

--- a/db/migrate/20120319205750_create_topics.rb
+++ b/db/migrate/20120319205750_create_topics.rb
@@ -1,4 +1,4 @@
-class CreateTopics < ActiveRecord::Migration
+class CreateTopics < ActiveRecord::Migration[4.2]
   def change
     create_table :topics do |t|
       t.timestamps       null: false

--- a/db/migrate/20120324163715_create_products.rb
+++ b/db/migrate/20120324163715_create_products.rb
@@ -1,4 +1,4 @@
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[4.2]
   def self.up
     create_table :products do |t|
       t.string :name

--- a/db/migrate/20120324181739_create_purchases.rb
+++ b/db/migrate/20120324181739_create_purchases.rb
@@ -1,4 +1,4 @@
-class CreatePurchases < ActiveRecord::Migration
+class CreatePurchases < ActiveRecord::Migration[4.2]
   def self.up
     create_table :purchases do |t|
       t.belongs_to  :product

--- a/db/migrate/20120324192441_rename_price_to_individual_price.rb
+++ b/db/migrate/20120324192441_rename_price_to_individual_price.rb
@@ -1,4 +1,4 @@
-class RenamePriceToIndividualPrice < ActiveRecord::Migration
+class RenamePriceToIndividualPrice < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :products, :price, :individual_price
   end

--- a/db/migrate/20120325133855_add_fulfillment_methods_to_products.rb
+++ b/db/migrate/20120325133855_add_fulfillment_methods_to_products.rb
@@ -1,4 +1,4 @@
-class AddFulfillmentMethodsToProducts < ActiveRecord::Migration
+class AddFulfillmentMethodsToProducts < ActiveRecord::Migration[4.2]
   def self.up
     add_column :products, :fulfillment_method, :string
     add_column :products, :github_team, :integer

--- a/db/migrate/20120325145448_add_terms_to_products.rb
+++ b/db/migrate/20120325145448_add_terms_to_products.rb
@@ -1,4 +1,4 @@
-class AddTermsToProducts < ActiveRecord::Migration
+class AddTermsToProducts < ActiveRecord::Migration[4.2]
   def self.up
     add_column :products, :terms, :text
   end

--- a/db/migrate/20120325145758_add_lookup_to_purchases.rb
+++ b/db/migrate/20120325145758_add_lookup_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddLookupToPurchases < ActiveRecord::Migration
+class AddLookupToPurchases < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :lookup, :string
     add_index :purchases, :lookup

--- a/db/migrate/20120325152749_add_coupon_to_purchase.rb
+++ b/db/migrate/20120325152749_add_coupon_to_purchase.rb
@@ -1,4 +1,4 @@
-class AddCouponToPurchase < ActiveRecord::Migration
+class AddCouponToPurchase < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :coupon_id, :integer
   end

--- a/db/migrate/20120325155519_add_readers_to_purchase.rb
+++ b/db/migrate/20120325155519_add_readers_to_purchase.rb
@@ -1,4 +1,4 @@
-class AddReadersToPurchase < ActiveRecord::Migration
+class AddReadersToPurchase < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :readers, :text
   end

--- a/db/migrate/20120326013213_add_paid_to_purchases.rb
+++ b/db/migrate/20120326013213_add_paid_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddPaidToPurchases < ActiveRecord::Migration
+class AddPaidToPurchases < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :paid, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20120326014034_add_payment_method_to_purchases.rb
+++ b/db/migrate/20120326014034_add_payment_method_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddPaymentMethodToPurchases < ActiveRecord::Migration
+class AddPaymentMethodToPurchases < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :payment_method, :string, :default => "stripe", :null => false
   end

--- a/db/migrate/20120327143007_add_discount_type_to_coupons.rb
+++ b/db/migrate/20120327143007_add_discount_type_to_coupons.rb
@@ -1,4 +1,4 @@
-class AddDiscountTypeToCoupons < ActiveRecord::Migration
+class AddDiscountTypeToCoupons < ActiveRecord::Migration[4.2]
   def self.up
     add_column :coupons, :discount_type, :string, :default => "percentage", :null => false
     rename_column :coupons, :percentage, :amount

--- a/db/migrate/20120327155654_add_questions_to_products.rb
+++ b/db/migrate/20120327155654_add_questions_to_products.rb
@@ -1,4 +1,4 @@
-class AddQuestionsToProducts < ActiveRecord::Migration
+class AddQuestionsToProducts < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :products, :terms, :questions
     add_column :products, :terms, :text

--- a/db/migrate/20120327165819_internationalize_purchases.rb
+++ b/db/migrate/20120327165819_internationalize_purchases.rb
@@ -1,4 +1,4 @@
-class InternationalizePurchases < ActiveRecord::Migration
+class InternationalizePurchases < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :country, :string
   end

--- a/db/migrate/20120329154310_create_articles.rb
+++ b/db/migrate/20120329154310_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration[4.2]
   def change
     create_table :articles do |t|
       t.timestamps              null: false

--- a/db/migrate/20120329161804_create_articles_topics_join_table.rb
+++ b/db/migrate/20120329161804_create_articles_topics_join_table.rb
@@ -1,4 +1,4 @@
-class CreateArticlesTopicsJoinTable < ActiveRecord::Migration
+class CreateArticlesTopicsJoinTable < ActiveRecord::Migration[4.2]
   def change
     create_table :articles_topics, id: false do |t|
       t.integer :article_id, null: false

--- a/db/migrate/20120411235358_rename_topics_body_to_body_html.rb
+++ b/db/migrate/20120411235358_rename_topics_body_to_body_html.rb
@@ -1,4 +1,4 @@
-class RenameTopicsBodyToBodyHtml < ActiveRecord::Migration
+class RenameTopicsBodyToBodyHtml < ActiveRecord::Migration[4.2]
   def change
     rename_column :topics, :body, :body_html
   end

--- a/db/migrate/20120411235902_rename_articles_body_to_body_html.rb
+++ b/db/migrate/20120411235902_rename_articles_body_to_body_html.rb
@@ -1,4 +1,4 @@
-class RenameArticlesBodyToBodyHtml < ActiveRecord::Migration
+class RenameArticlesBodyToBodyHtml < ActiveRecord::Migration[4.2]
   def change
     rename_column :articles, :body, :body_html
   end

--- a/db/migrate/20120416150909_add_payment_transaction_id_to_purchases.rb
+++ b/db/migrate/20120416150909_add_payment_transaction_id_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddPaymentTransactionIdToPurchases < ActiveRecord::Migration
+class AddPaymentTransactionIdToPurchases < ActiveRecord::Migration[4.2]
   def self.up
     add_column :purchases, :payment_transaction_id, :string
   end

--- a/db/migrate/20120422130428_create_authors.rb
+++ b/db/migrate/20120422130428_create_authors.rb
@@ -1,4 +1,4 @@
-class CreateAuthors < ActiveRecord::Migration
+class CreateAuthors < ActiveRecord::Migration[4.2]
   def change
     create_table :authors do |t|
       t.timestamps null: false

--- a/db/migrate/20120422164936_add_author_to_article.rb
+++ b/db/migrate/20120422164936_add_author_to_article.rb
@@ -1,4 +1,4 @@
-class AddAuthorToArticle < ActiveRecord::Migration
+class AddAuthorToArticle < ActiveRecord::Migration[4.2]
   def change
     add_column :articles, :author_id, :integer, null: false
     add_index :articles, :author_id

--- a/db/migrate/20120424205118_change_article_author_allow_null.rb
+++ b/db/migrate/20120424205118_change_article_author_allow_null.rb
@@ -1,4 +1,4 @@
-class ChangeArticleAuthorAllowNull < ActiveRecord::Migration
+class ChangeArticleAuthorAllowNull < ActiveRecord::Migration[4.2]
   def up
     change_column :articles, :author_id, :integer, null: true
   end

--- a/db/migrate/20120424212920_change_topics_add_null_cols.rb
+++ b/db/migrate/20120424212920_change_topics_add_null_cols.rb
@@ -1,4 +1,4 @@
-class ChangeTopicsAddNullCols < ActiveRecord::Migration
+class ChangeTopicsAddNullCols < ActiveRecord::Migration[4.2]
   def up
     change_column :topics, :body_html, :text, null: true
   end

--- a/db/migrate/20120504151240_add_alternative_description_to_product.rb
+++ b/db/migrate/20120504151240_add_alternative_description_to_product.rb
@@ -1,4 +1,4 @@
-class AddAlternativeDescriptionToProduct < ActiveRecord::Migration
+class AddAlternativeDescriptionToProduct < ActiveRecord::Migration[4.2]
   def self.up
     add_column :products, :alternative_description, :text
   end

--- a/db/migrate/20120511223948_create_downloads.rb
+++ b/db/migrate/20120511223948_create_downloads.rb
@@ -1,4 +1,4 @@
-class CreateDownloads < ActiveRecord::Migration
+class CreateDownloads < ActiveRecord::Migration[4.2]
   def self.up
     create_table :downloads do |t|
       t.integer :product_id

--- a/db/migrate/20120517145653_add_wistia_id_to_product.rb
+++ b/db/migrate/20120517145653_add_wistia_id_to_product.rb
@@ -1,4 +1,4 @@
-class AddWistiaIdToProduct < ActiveRecord::Migration
+class AddWistiaIdToProduct < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :wistia_id, :string
   end

--- a/db/migrate/20120522210821_add_image_to_courses.rb
+++ b/db/migrate/20120522210821_add_image_to_courses.rb
@@ -1,4 +1,4 @@
-class AddImageToCourses < ActiveRecord::Migration
+class AddImageToCourses < ActiveRecord::Migration[4.2]
   def change
     add_column :courses, :course_image_file_name, :string
     add_column :courses, :course_image_file_size, :string

--- a/db/migrate/20120522210822_add_image_to_products.rb
+++ b/db/migrate/20120522210822_add_image_to_products.rb
@@ -1,4 +1,4 @@
-class AddImageToProducts < ActiveRecord::Migration
+class AddImageToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :product_image_file_name, :string
     add_column :products, :product_image_file_size, :string

--- a/db/migrate/20120525153806_add_published_at_to_articles.rb
+++ b/db/migrate/20120525153806_add_published_at_to_articles.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToArticles < ActiveRecord::Migration
+class AddPublishedAtToArticles < ActiveRecord::Migration[4.2]
   def change
     add_column :articles, :published_at, :date, null: false
   end

--- a/db/migrate/20120525171246_add_count_to_topics.rb
+++ b/db/migrate/20120525171246_add_count_to_topics.rb
@@ -1,4 +1,4 @@
-class AddCountToTopics < ActiveRecord::Migration
+class AddCountToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :count, :integer
 

--- a/db/migrate/20120530203434_create_rails_admin_histories_table.rb
+++ b/db/migrate/20120530203434_create_rails_admin_histories_table.rb
@@ -1,4 +1,4 @@
-class CreateRailsAdminHistoriesTable < ActiveRecord::Migration
+class CreateRailsAdminHistoriesTable < ActiveRecord::Migration[4.2]
    def self.up
      create_table :rails_admin_histories do |t|
        t.text :message # title, name, or object_id

--- a/db/migrate/20120531203257_change_articles_published_at_to_published_on.rb
+++ b/db/migrate/20120531203257_change_articles_published_at_to_published_on.rb
@@ -1,4 +1,4 @@
-class ChangeArticlesPublishedAtToPublishedOn < ActiveRecord::Migration
+class ChangeArticlesPublishedAtToPublishedOn < ActiveRecord::Migration[4.2]
   def up
     rename_column :articles, :published_at, :published_on
   end

--- a/db/migrate/20120601204935_create_classifications.rb
+++ b/db/migrate/20120601204935_create_classifications.rb
@@ -1,4 +1,4 @@
-class CreateClassifications < ActiveRecord::Migration
+class CreateClassifications < ActiveRecord::Migration[4.2]
   def change
     create_table :classifications do |t|
       t.integer :topic_id

--- a/db/migrate/20120712195855_add_featured_flag_to_topics.rb
+++ b/db/migrate/20120712195855_add_featured_flag_to_topics.rb
@@ -1,4 +1,4 @@
-class AddFeaturedFlagToTopics < ActiveRecord::Migration
+class AddFeaturedFlagToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :featured, :boolean, default: false, null: false
   end

--- a/db/migrate/20120713141337_multiple_videos_on_products.rb
+++ b/db/migrate/20120713141337_multiple_videos_on_products.rb
@@ -1,4 +1,4 @@
-class MultipleVideosOnProducts < ActiveRecord::Migration
+class MultipleVideosOnProducts < ActiveRecord::Migration[4.2]
   def up
     create_table :videos do |t|
       t.integer :product_id

--- a/db/migrate/20120717194121_add_addresses_to_sections.rb
+++ b/db/migrate/20120717194121_add_addresses_to_sections.rb
@@ -1,4 +1,4 @@
-class AddAddressesToSections < ActiveRecord::Migration
+class AddAddressesToSections < ActiveRecord::Migration[4.2]
   def up
     add_column :sections, :address, :string
     add_column :sections, :city, :string

--- a/db/migrate/20120803150234_url_encode_topic_slugs.rb
+++ b/db/migrate/20120803150234_url_encode_topic_slugs.rb
@@ -1,4 +1,4 @@
-class UrlEncodeTopicSlugs < ActiveRecord::Migration
+class UrlEncodeTopicSlugs < ActiveRecord::Migration[4.2]
   def up
     topics = select_all("select id, name from topics")
     topics.each do |topic|

--- a/db/migrate/20120806193215_add_purchases_to_users.rb
+++ b/db/migrate/20120806193215_add_purchases_to_users.rb
@@ -1,4 +1,4 @@
-class AddPurchasesToUsers < ActiveRecord::Migration
+class AddPurchasesToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :user_id, :integer
   end

--- a/db/migrate/20120806194223_add_stripe_customer_to_users.rb
+++ b/db/migrate/20120806194223_add_stripe_customer_to_users.rb
@@ -1,4 +1,4 @@
-class AddStripeCustomerToUsers < ActiveRecord::Migration
+class AddStripeCustomerToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :stripe_customer, :string
   end

--- a/db/migrate/20120806203351_add_github_username_to_user.rb
+++ b/db/migrate/20120806203351_add_github_username_to_user.rb
@@ -1,4 +1,4 @@
-class AddGithubUsernameToUser < ActiveRecord::Migration
+class AddGithubUsernameToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :github_username, :string
   end

--- a/db/migrate/20120808192548_add_users_to_registrations.rb
+++ b/db/migrate/20120808192548_add_users_to_registrations.rb
@@ -1,4 +1,4 @@
-class AddUsersToRegistrations < ActiveRecord::Migration
+class AddUsersToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :user_id, :integer
   end

--- a/db/migrate/20120811185001_add_omniauth_fields.rb
+++ b/db/migrate/20120811185001_add_omniauth_fields.rb
@@ -1,4 +1,4 @@
-class AddOmniauthFields < ActiveRecord::Migration
+class AddOmniauthFields < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :auth_provider, :string
     add_column :users, :auth_uid, :integer

--- a/db/migrate/20120813150430_add_one_time_use_only_to_coupons.rb
+++ b/db/migrate/20120813150430_add_one_time_use_only_to_coupons.rb
@@ -1,4 +1,4 @@
-class AddOneTimeUseOnlyToCoupons < ActiveRecord::Migration
+class AddOneTimeUseOnlyToCoupons < ActiveRecord::Migration[4.2]
   def change
     add_column :coupons, :one_time_use_only, :boolean, default: false, null: false
   end

--- a/db/migrate/20120814155007_add_paid_price_to_purchases.rb
+++ b/db/migrate/20120814155007_add_paid_price_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddPaidPriceToPurchases < ActiveRecord::Migration
+class AddPaidPriceToPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :paid_price, :integer
   end

--- a/db/migrate/20120814184318_move_reminder_email_to_sections.rb
+++ b/db/migrate/20120814184318_move_reminder_email_to_sections.rb
@@ -1,4 +1,4 @@
-class MoveReminderEmailToSections < ActiveRecord::Migration
+class MoveReminderEmailToSections < ActiveRecord::Migration[4.2]
   def up
     add_column :sections, :reminder_email, :text
     remove_column :courses, :reminder_email

--- a/db/migrate/20120904202527_remove_this_week_in_open_source_content.rb
+++ b/db/migrate/20120904202527_remove_this_week_in_open_source_content.rb
@@ -1,4 +1,4 @@
-class RemoveThisWeekInOpenSourceContent < ActiveRecord::Migration
+class RemoveThisWeekInOpenSourceContent < ActiveRecord::Migration[4.2]
   def up
     execute <<-SQL
       DELETE FROM "articles"

--- a/db/migrate/20121008191901_add_external_products.rb
+++ b/db/migrate/20121008191901_add_external_products.rb
@@ -1,4 +1,4 @@
-class AddExternalProducts < ActiveRecord::Migration
+class AddExternalProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :external_purchase_url, :text
     add_column :products, :external_purchase_name, :string

--- a/db/migrate/20121011150603_update_product_type_on_products.rb
+++ b/db/migrate/20121011150603_update_product_type_on_products.rb
@@ -1,4 +1,4 @@
-class UpdateProductTypeOnProducts < ActiveRecord::Migration
+class UpdateProductTypeOnProducts < ActiveRecord::Migration[4.2]
   def up
     execute <<-SQL
       UPDATE products

--- a/db/migrate/20121011194514_rename_topic_body_html_to_trail_map.rb
+++ b/db/migrate/20121011194514_rename_topic_body_html_to_trail_map.rb
@@ -1,4 +1,4 @@
-class RenameTopicBodyHtmlToTrailMap < ActiveRecord::Migration
+class RenameTopicBodyHtmlToTrailMap < ActiveRecord::Migration[4.2]
   def up
     remove_column :topics, :body_html
     add_column :topics, :trail_map, :text

--- a/db/migrate/20121018141435_add_promo_location_to_products_and_courses.rb
+++ b/db/migrate/20121018141435_add_promo_location_to_products_and_courses.rb
@@ -1,4 +1,4 @@
-class AddPromoLocationToProductsAndCourses < ActiveRecord::Migration
+class AddPromoLocationToProductsAndCourses < ActiveRecord::Migration[4.2]
   def change
     add_column :courses, :promo_location, :string
     add_column :products, :promo_location, :string

--- a/db/migrate/20121024185508_create_announcements.rb
+++ b/db/migrate/20121024185508_create_announcements.rb
@@ -1,4 +1,4 @@
-class CreateAnnouncements < ActiveRecord::Migration
+class CreateAnnouncements < ActiveRecord::Migration[4.2]
   def change
     create_table :announcements do |t|
       t.timestamps null: false

--- a/db/migrate/20121102201114_add_index_on_section_id_and_teacher_id_to_section_teachers.rb
+++ b/db/migrate/20121102201114_add_index_on_section_id_and_teacher_id_to_section_teachers.rb
@@ -1,4 +1,4 @@
-class AddIndexOnSectionIdAndTeacherIdToSectionTeachers < ActiveRecord::Migration
+class AddIndexOnSectionIdAndTeacherIdToSectionTeachers < ActiveRecord::Migration[4.2]
   def up
     change_table :section_teachers do |t|
       t.remove_index :section_id

--- a/db/migrate/20121107203712_create_episodes.rb
+++ b/db/migrate/20121107203712_create_episodes.rb
@@ -1,4 +1,4 @@
-class CreateEpisodes < ActiveRecord::Migration
+class CreateEpisodes < ActiveRecord::Migration[4.2]
   def change
     create_table :episodes do |t|
       t.string :title

--- a/db/migrate/20121113204545_add_file_size_to_episodes.rb
+++ b/db/migrate/20121113204545_add_file_size_to_episodes.rb
@@ -1,4 +1,4 @@
-class AddFileSizeToEpisodes < ActiveRecord::Migration
+class AddFileSizeToEpisodes < ActiveRecord::Migration[4.2]
   def change
     add_column :episodes, :file_size, :integer
   end

--- a/db/migrate/20121114193521_episodes_use_numbers_for_info.rb
+++ b/db/migrate/20121114193521_episodes_use_numbers_for_info.rb
@@ -1,4 +1,4 @@
-class EpisodesUseNumbersForInfo < ActiveRecord::Migration
+class EpisodesUseNumbersForInfo < ActiveRecord::Migration[4.2]
   def up
     remove_column :episodes, :size
     remove_column :episodes, :length

--- a/db/migrate/20121205125237_introduce_purchaseable.rb
+++ b/db/migrate/20121205125237_introduce_purchaseable.rb
@@ -1,4 +1,4 @@
-class IntroducePurchaseable < ActiveRecord::Migration
+class IntroducePurchaseable < ActiveRecord::Migration[4.2]
   def up
     add_column :purchases, :purchaseable_id, :integer
     add_column :purchases, :purchaseable_type, :string

--- a/db/migrate/20121205132428_add_company_price_to_courses.rb
+++ b/db/migrate/20121205132428_add_company_price_to_courses.rb
@@ -1,4 +1,4 @@
-class AddCompanyPriceToCourses < ActiveRecord::Migration
+class AddCompanyPriceToCourses < ActiveRecord::Migration[4.2]
   def up
     rename_column :courses, :price, :individual_price
     add_column :courses, :company_price, :integer

--- a/db/migrate/20121205134905_add_terms_to_courses.rb
+++ b/db/migrate/20121205134905_add_terms_to_courses.rb
@@ -1,4 +1,4 @@
-class AddTermsToCourses < ActiveRecord::Migration
+class AddTermsToCourses < ActiveRecord::Migration[4.2]
   def change
     add_column :courses, :terms, :text
   end

--- a/db/migrate/20121205142035_make_videos_and_download_polymorphic.rb
+++ b/db/migrate/20121205142035_make_videos_and_download_polymorphic.rb
@@ -1,4 +1,4 @@
-class MakeVideosAndDownloadPolymorphic < ActiveRecord::Migration
+class MakeVideosAndDownloadPolymorphic < ActiveRecord::Migration[4.2]
   def up
     rename_column :videos, :product_id, :purchaseable_id
     add_column :videos, :purchaseable_type, :string

--- a/db/migrate/20121205155722_add_comments_to_purchases.rb
+++ b/db/migrate/20121205155722_add_comments_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddCommentsToPurchases < ActiveRecord::Migration
+class AddCommentsToPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :comments, :text
   end

--- a/db/migrate/20121206131343_add_billing_email_to_purchases.rb
+++ b/db/migrate/20121206131343_add_billing_email_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddBillingEmailToPurchases < ActiveRecord::Migration
+class AddBillingEmailToPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :billing_email, :string
   end

--- a/db/migrate/20121207130152_move_registrations_to_purchases.rb
+++ b/db/migrate/20121207130152_move_registrations_to_purchases.rb
@@ -1,4 +1,4 @@
-class MoveRegistrationsToPurchases < ActiveRecord::Migration
+class MoveRegistrationsToPurchases < ActiveRecord::Migration[4.2]
   def up
     insert "insert into purchases (variant, name, email, organization, address1, address2, city, state, zip_code, created_at, updated_at, lookup, coupon_id, paid, payment_method, user_id, paid_price, purchaseable_id, purchaseable_type, comments, billing_email) (select 'individual', first_name || ' ' || last_name, email, organization, address1, address2, registrations.city, registrations.state, registrations.zip_code, registrations.created_at, registrations.updated_at, md5(registrations.id || first_name || last_name), coupon_id, paid, 'freshbooks', user_id, individual_price, section_id, 'Section', comments, billing_email from registrations, sections, courses where registrations.section_id=sections.id and sections.course_id=courses.id)"
     drop_table :registrations

--- a/db/migrate/20121212214215_add_discounts_to_products.rb
+++ b/db/migrate/20121212214215_add_discounts_to_products.rb
@@ -1,4 +1,4 @@
-class AddDiscountsToProducts < ActiveRecord::Migration
+class AddDiscountsToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :discount_percentage, :integer, default: 0, null: false
     add_column :products, :discount_title, :string, default: "", null: false

--- a/db/migrate/20121213154515_enforce_zerio_prices_on_products.rb
+++ b/db/migrate/20121213154515_enforce_zerio_prices_on_products.rb
@@ -1,4 +1,4 @@
-class EnforceZerioPricesOnProducts < ActiveRecord::Migration
+class EnforceZerioPricesOnProducts < ActiveRecord::Migration[4.2]
   def up
     change_column_default :products, :individual_price, 0
     change_column_default :products, :company_price, 0

--- a/db/migrate/20121214194659_add_downloads_count_to_episodes.rb
+++ b/db/migrate/20121214194659_add_downloads_count_to_episodes.rb
@@ -1,4 +1,4 @@
-class AddDownloadsCountToEpisodes < ActiveRecord::Migration
+class AddDownloadsCountToEpisodes < ActiveRecord::Migration[4.2]
   def change
     add_column :episodes, :downloads_count, :integer, default: 0, null: false
   end

--- a/db/migrate/20130102163245_create_delayed_jobs.rb
+++ b/db/migrate/20130102163245_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, :force => true do |table|
       table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20130109163143_add_online_to_courses.rb
+++ b/db/migrate/20130109163143_add_online_to_courses.rb
@@ -1,4 +1,4 @@
-class AddOnlineToCourses < ActiveRecord::Migration
+class AddOnlineToCourses < ActiveRecord::Migration[4.2]
   def change
     add_column :courses, :online, :boolean, null: false, default: false
   end

--- a/db/migrate/20130109204805_rename_courses_to_workshops.rb
+++ b/db/migrate/20130109204805_rename_courses_to_workshops.rb
@@ -1,4 +1,4 @@
-class RenameCoursesToWorkshops < ActiveRecord::Migration
+class RenameCoursesToWorkshops < ActiveRecord::Migration[4.2]
   def change
     rename_table :courses, :workshops
 

--- a/db/migrate/20130115210038_remove_image_columns_from_workshops.rb
+++ b/db/migrate/20130115210038_remove_image_columns_from_workshops.rb
@@ -1,4 +1,4 @@
-class RemoveImageColumnsFromWorkshops < ActiveRecord::Migration
+class RemoveImageColumnsFromWorkshops < ActiveRecord::Migration[4.2]
   def self.up
     change_table :workshops do |t|
       t.remove :course_image_file_name

--- a/db/migrate/20130116181759_remove_audiences.rb
+++ b/db/migrate/20130116181759_remove_audiences.rb
@@ -1,4 +1,4 @@
-class RemoveAudiences < ActiveRecord::Migration
+class RemoveAudiences < ActiveRecord::Migration[4.2]
   def up
     remove_column :workshops, :audience_id
     drop_table :audiences

--- a/db/migrate/20130122220646_add_alternate_prices_to_products_and_workshops.rb
+++ b/db/migrate/20130122220646_add_alternate_prices_to_products_and_workshops.rb
@@ -1,4 +1,4 @@
-class AddAlternatePricesToProductsAndWorkshops < ActiveRecord::Migration
+class AddAlternatePricesToProductsAndWorkshops < ActiveRecord::Migration[4.2]
   def change
     %w(workshops products).each do |table|
       add_column table, :alternate_individual_price, :integer

--- a/db/migrate/20130123020624_products_and_sections_are_watchable.rb
+++ b/db/migrate/20130123020624_products_and_sections_are_watchable.rb
@@ -1,4 +1,4 @@
-class ProductsAndSectionsAreWatchable < ActiveRecord::Migration
+class ProductsAndSectionsAreWatchable < ActiveRecord::Migration[4.2]
   def up
     rename_column :videos, :purchaseable_type, :watchable_type
     rename_column :videos, :purchaseable_id, :watchable_id

--- a/db/migrate/20130123024544_add_active_on_day_to_videos.rb
+++ b/db/migrate/20130123024544_add_active_on_day_to_videos.rb
@@ -1,4 +1,4 @@
-class AddActiveOnDayToVideos < ActiveRecord::Migration
+class AddActiveOnDayToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :active_on_day, :integer, null: false, default: 0
   end

--- a/db/migrate/20130129030408_add_order_to_videos.rb
+++ b/db/migrate/20130129030408_add_order_to_videos.rb
@@ -1,4 +1,4 @@
-class AddOrderToVideos < ActiveRecord::Migration
+class AddOrderToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :order, :integer, default: 0, null: false
   end

--- a/db/migrate/20130129030943_rename_videos_order_to_position.rb
+++ b/db/migrate/20130129030943_rename_videos_order_to_position.rb
@@ -1,4 +1,4 @@
-class RenameVideosOrderToPosition < ActiveRecord::Migration
+class RenameVideosOrderToPosition < ActiveRecord::Migration[4.2]
   def up
     rename_column :videos, :order, :position
   end

--- a/db/migrate/20130129200950_add_resources_to_workshops.rb
+++ b/db/migrate/20130129200950_add_resources_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddResourcesToWorkshops < ActiveRecord::Migration
+class AddResourcesToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :resources, :text, null: false, default: ''
   end

--- a/db/migrate/20130129204939_add_video_chat_url_to_workshops.rb
+++ b/db/migrate/20130129204939_add_video_chat_url_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddVideoChatUrlToWorkshops < ActiveRecord::Migration
+class AddVideoChatUrlToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :video_chat_url, :string
   end

--- a/db/migrate/20130129210956_create_events.rb
+++ b/db/migrate/20130129210956_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :events do |t|
       t.belongs_to :workshop, null: false

--- a/db/migrate/20130130194019_create_subscriptions.rb
+++ b/db/migrate/20130130194019_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriptions do |t|
       t.integer :user_id

--- a/db/migrate/20130205182040_add_body_to_articles.rb
+++ b/db/migrate/20130205182040_add_body_to_articles.rb
@@ -1,4 +1,4 @@
-class AddBodyToArticles < ActiveRecord::Migration
+class AddBodyToArticles < ActiveRecord::Migration[4.2]
   def change
     add_column :articles, :body, :text
   end

--- a/db/migrate/20130205183241_articles_tumblr_url_allows_nil.rb
+++ b/db/migrate/20130205183241_articles_tumblr_url_allows_nil.rb
@@ -1,4 +1,4 @@
-class ArticlesTumblrUrlAllowsNil < ActiveRecord::Migration
+class ArticlesTumblrUrlAllowsNil < ActiveRecord::Migration[4.2]
   def up
     change_column :articles, :tumblr_url, :string, null: true
   end

--- a/db/migrate/20130205194322_remove_authors.rb
+++ b/db/migrate/20130205194322_remove_authors.rb
@@ -1,4 +1,4 @@
-class RemoveAuthors < ActiveRecord::Migration
+class RemoveAuthors < ActiveRecord::Migration[4.2]
   def up
     remove_column :articles, :author_id
     drop_table :authors

--- a/db/migrate/20130207161342_rename_tumblr_url_to_external_url.rb
+++ b/db/migrate/20130207161342_rename_tumblr_url_to_external_url.rb
@@ -1,4 +1,4 @@
-class RenameTumblrUrlToExternalUrl < ActiveRecord::Migration
+class RenameTumblrUrlToExternalUrl < ActiveRecord::Migration[4.2]
   def up
     rename_column :articles, :tumblr_url, :external_url
   end

--- a/db/migrate/20130214152955_add_draft_to_articles.rb
+++ b/db/migrate/20130214152955_add_draft_to_articles.rb
@@ -1,4 +1,4 @@
-class AddDraftToArticles < ActiveRecord::Migration
+class AddDraftToArticles < ActiveRecord::Migration[4.2]
   def change
     add_column :articles, :draft, :boolean, default: false, null: false
   end

--- a/db/migrate/20130226192252_remove_pricing_a_b_test_columns.rb
+++ b/db/migrate/20130226192252_remove_pricing_a_b_test_columns.rb
@@ -1,4 +1,4 @@
-class RemovePricingABTestColumns < ActiveRecord::Migration
+class RemovePricingABTestColumns < ActiveRecord::Migration[4.2]
   def up
     remove_column :products, :alternate_company_price
     remove_column :products, :alternate_individual_price

--- a/db/migrate/20130303193633_remove_promo_location_from_products_and_workshops.rb
+++ b/db/migrate/20130303193633_remove_promo_location_from_products_and_workshops.rb
@@ -1,4 +1,4 @@
-class RemovePromoLocationFromProductsAndWorkshops < ActiveRecord::Migration
+class RemovePromoLocationFromProductsAndWorkshops < ActiveRecord::Migration[4.2]
   def up
     remove_column :products, :promo_location
     remove_column :workshops, :promo_location

--- a/db/migrate/20130320172303_add_stripe_coupon_id_to_purchases.rb
+++ b/db/migrate/20130320172303_add_stripe_coupon_id_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddStripeCouponIdToPurchases < ActiveRecord::Migration
+class AddStripeCouponIdToPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :stripe_coupon_id, :string
   end

--- a/db/migrate/20130328205442_rename_workshops_public_to_active.rb
+++ b/db/migrate/20130328205442_rename_workshops_public_to_active.rb
@@ -1,4 +1,4 @@
-class RenameWorkshopsPublicToActive < ActiveRecord::Migration
+class RenameWorkshopsPublicToActive < ActiveRecord::Migration[4.2]
   def change
     rename_column :workshops, :public, :active
   end

--- a/db/migrate/20130411143358_create_doorkeeper_tables.rb
+++ b/db/migrate/20130411143358_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         :null => false

--- a/db/migrate/20130419192248_add_notes_to_videos.rb
+++ b/db/migrate/20130419192248_add_notes_to_videos.rb
@@ -1,4 +1,4 @@
-class AddNotesToVideos < ActiveRecord::Migration
+class AddNotesToVideos < ActiveRecord::Migration[4.2]
   def self.up
     add_column :videos, :notes, :text
   end

--- a/db/migrate/20130429011338_add_github_team_to_workshops.rb
+++ b/db/migrate/20130429011338_add_github_team_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddGithubTeamToWorkshops < ActiveRecord::Migration
+class AddGithubTeamToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :github_team, :integer
   end

--- a/db/migrate/20130503054351_rename_readers_to_github_usernames.rb
+++ b/db/migrate/20130503054351_rename_readers_to_github_usernames.rb
@@ -1,4 +1,4 @@
-class RenameReadersToGithubUsernames < ActiveRecord::Migration
+class RenameReadersToGithubUsernames < ActiveRecord::Migration[4.2]
   def up
     rename_column :purchases, :readers, :github_usernames
   end

--- a/db/migrate/20130514175034_add_deactivated_on_to_subscriptions.rb
+++ b/db/migrate/20130514175034_add_deactivated_on_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddDeactivatedOnToSubscriptions < ActiveRecord::Migration
+class AddDeactivatedOnToSubscriptions < ActiveRecord::Migration[4.2]
   def up
     change_table :subscriptions do |t|
       t.date :deactivated_on

--- a/db/migrate/20130516192309_change_events_to_office_hours.rb
+++ b/db/migrate/20130516192309_change_events_to_office_hours.rb
@@ -1,4 +1,4 @@
-class ChangeEventsToOfficeHours < ActiveRecord::Migration
+class ChangeEventsToOfficeHours < ActiveRecord::Migration[4.2]
   def up
     rename_table :events, :office_hours
     add_column :office_hours, :occurs_in_week, :integer

--- a/db/migrate/20130520150934_change_paid_price_in_purchases.rb
+++ b/db/migrate/20130520150934_change_paid_price_in_purchases.rb
@@ -1,4 +1,4 @@
-class ChangePaidPriceInPurchases < ActiveRecord::Migration
+class ChangePaidPriceInPurchases < ActiveRecord::Migration[4.2]
   def up
     change_column :purchases, :paid_price, :decimal
   end

--- a/db/migrate/20130521142245_add_length_in_days_to_workshops.rb
+++ b/db/migrate/20130521142245_add_length_in_days_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddLengthInDaysToWorkshops < ActiveRecord::Migration
+class AddLengthInDaysToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :length_in_days, :integer
   end

--- a/db/migrate/20130521152542_drop_office_hours.rb
+++ b/db/migrate/20130521152542_drop_office_hours.rb
@@ -1,4 +1,4 @@
-class DropOfficeHours < ActiveRecord::Migration
+class DropOfficeHours < ActiveRecord::Migration[4.2]
   def up
     drop_table :office_hours
     add_column :workshops, :office_hours, :string, null: false, default: ''

--- a/db/migrate/20130530010021_add_address_fields_to_users.rb
+++ b/db/migrate/20130530010021_add_address_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddAddressFieldsToUsers < ActiveRecord::Migration
+class AddAddressFieldsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :organization, :string
     add_column :users, :address1, :string

--- a/db/migrate/20130530203918_rename_users_stripe_customer_to_stripe_customer_id.rb
+++ b/db/migrate/20130530203918_rename_users_stripe_customer_to_stripe_customer_id.rb
@@ -1,4 +1,4 @@
-class RenameUsersStripeCustomerToStripeCustomerId < ActiveRecord::Migration
+class RenameUsersStripeCustomerToStripeCustomerId < ActiveRecord::Migration[4.2]
   def up
     rename_column :users, :stripe_customer, :stripe_customer_id
     rename_column :purchases, :stripe_customer, :stripe_customer_id

--- a/db/migrate/20130604202432_add_scheduled_for_cancelation_on_to_subscriptions.rb
+++ b/db/migrate/20130604202432_add_scheduled_for_cancelation_on_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddScheduledForCancelationOnToSubscriptions < ActiveRecord::Migration
+class AddScheduledForCancelationOnToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :scheduled_for_cancelation_on, :date
   end

--- a/db/migrate/20130606011005_add_paid_to_subscriptions.rb
+++ b/db/migrate/20130606011005_add_paid_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddPaidToSubscriptions < ActiveRecord::Migration
+class AddPaidToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :paid, :boolean, default: true, null: false
   end

--- a/db/migrate/20130610210831_allow_null_maximim_students_on_workshops.rb
+++ b/db/migrate/20130610210831_allow_null_maximim_students_on_workshops.rb
@@ -1,4 +1,4 @@
-class AllowNullMaximimStudentsOnWorkshops < ActiveRecord::Migration
+class AllowNullMaximimStudentsOnWorkshops < ActiveRecord::Migration[4.2]
   def up
     change_column :workshops, :maximum_students, :integer, null: true, default: nil
     update 'update workshops set maximum_students = NULL where online = true'

--- a/db/migrate/20130613183030_create_completions.rb
+++ b/db/migrate/20130613183030_create_completions.rb
@@ -1,4 +1,4 @@
-class CreateCompletions < ActiveRecord::Migration
+class CreateCompletions < ActiveRecord::Migration[4.2]
   def change
     create_table :completions do |t|
       t.string :trail_object_id

--- a/db/migrate/20130613191147_create_trails.rb
+++ b/db/migrate/20130613191147_create_trails.rb
@@ -1,4 +1,4 @@
-class CreateTrails < ActiveRecord::Migration
+class CreateTrails < ActiveRecord::Migration[4.2]
   def up
     create_table :trails do |t|
       t.belongs_to :topic

--- a/db/migrate/20130619200800_add_sku_to_workshops.rb
+++ b/db/migrate/20130619200800_add_sku_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddSkuToWorkshops < ActiveRecord::Migration
+class AddSkuToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :sku, :string
   end

--- a/db/migrate/20130620025128_separate_bytes_from_articles.rb
+++ b/db/migrate/20130620025128_separate_bytes_from_articles.rb
@@ -1,4 +1,4 @@
-class SeparateBytesFromArticles < ActiveRecord::Migration
+class SeparateBytesFromArticles < ActiveRecord::Migration[4.2]
   def up
     create_table "bytes", force: true do |t|
       t.datetime "created_at", null: false

--- a/db/migrate/20130620185537_remove_articles_topics_join_table.rb
+++ b/db/migrate/20130620185537_remove_articles_topics_join_table.rb
@@ -1,4 +1,4 @@
-class RemoveArticlesTopicsJoinTable < ActiveRecord::Migration
+class RemoveArticlesTopicsJoinTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :articles_topics
   end

--- a/db/migrate/20130620185831_adjust_articles_and_bytes_allowed_nulls.rb
+++ b/db/migrate/20130620185831_adjust_articles_and_bytes_allowed_nulls.rb
@@ -1,4 +1,4 @@
-class AdjustArticlesAndBytesAllowedNulls < ActiveRecord::Migration
+class AdjustArticlesAndBytesAllowedNulls < ActiveRecord::Migration[4.2]
   def up
     change_column_null :articles, :external_url, false
     change_column_null :bytes, :body, false

--- a/db/migrate/20130627172432_remove_workshops_start_at_and_end_at.rb
+++ b/db/migrate/20130627172432_remove_workshops_start_at_and_end_at.rb
@@ -1,4 +1,4 @@
-class RemoveWorkshopsStartAtAndEndAt < ActiveRecord::Migration
+class RemoveWorkshopsStartAtAndEndAt < ActiveRecord::Migration[4.2]
   def up
     remove_column :workshops, :start_at
     remove_column :workshops, :stop_at

--- a/db/migrate/20130709150002_combine_users_first_name_last_name.rb
+++ b/db/migrate/20130709150002_combine_users_first_name_last_name.rb
@@ -1,4 +1,4 @@
-class CombineUsersFirstNameLastName < ActiveRecord::Migration
+class CombineUsersFirstNameLastName < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :name, :string
     update "update users set name = first_name || ' ' || last_name"

--- a/db/migrate/20130709194915_drop_purchases_billing_email.rb
+++ b/db/migrate/20130709194915_drop_purchases_billing_email.rb
@@ -1,4 +1,4 @@
-class DropPurchasesBillingEmail < ActiveRecord::Migration
+class DropPurchasesBillingEmail < ActiveRecord::Migration[4.2]
   def up
     remove_column :purchases, :billing_email
   end

--- a/db/migrate/20130716205105_add_mentors_to_subscriptions.rb
+++ b/db/migrate/20130716205105_add_mentors_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddMentorsToSubscriptions < ActiveRecord::Migration
+class AddMentorsToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :mentor, :boolean, default: false
     update "update users set mentor=true where email = 'ben@thoughtbot.com'"

--- a/db/migrate/20130719134342_add_attachment_to_episodes.rb
+++ b/db/migrate/20130719134342_add_attachment_to_episodes.rb
@@ -1,4 +1,4 @@
-class AddAttachmentToEpisodes < ActiveRecord::Migration
+class AddAttachmentToEpisodes < ActiveRecord::Migration[4.2]
   def change
     add_attachment :episodes, :mp3
     remove_column :episodes, :file

--- a/db/migrate/20130721190245_add_number_to_episodes.rb
+++ b/db/migrate/20130721190245_add_number_to_episodes.rb
@@ -1,4 +1,4 @@
-class AddNumberToEpisodes < ActiveRecord::Migration
+class AddNumberToEpisodes < ActiveRecord::Migration[4.2]
   def change
     add_column :episodes, :number, :integer
     add_index :episodes, :number

--- a/db/migrate/20130725152531_add_stripe_plan_id_to_subscriptions.rb
+++ b/db/migrate/20130725152531_add_stripe_plan_id_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddStripePlanIdToSubscriptions < ActiveRecord::Migration
+class AddStripePlanIdToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :stripe_plan_id, :string, default: 'prime', null: 'false'
   end

--- a/db/migrate/20130726134140_correctly_spell_cancellation.rb
+++ b/db/migrate/20130726134140_correctly_spell_cancellation.rb
@@ -1,4 +1,4 @@
-class CorrectlySpellCancellation < ActiveRecord::Migration
+class CorrectlySpellCancellation < ActiveRecord::Migration[4.2]
   def up
     rename_column :subscriptions,
       :scheduled_for_cancelation_on,

--- a/db/migrate/20130726173752_add_slug_to_completions.rb
+++ b/db/migrate/20130726173752_add_slug_to_completions.rb
@@ -1,4 +1,4 @@
-class AddSlugToCompletions < ActiveRecord::Migration
+class AddSlugToCompletions < ActiveRecord::Migration[4.2]
   def change
     add_column :completions, :slug, :string
   end

--- a/db/migrate/20130729020308_create_shows.rb
+++ b/db/migrate/20130729020308_create_shows.rb
@@ -1,4 +1,4 @@
-class CreateShows < ActiveRecord::Migration
+class CreateShows < ActiveRecord::Migration[4.2]
   def change
     create_table :shows do |t|
       t.string :slug, null: false

--- a/db/migrate/20130731155600_create_notes.rb
+++ b/db/migrate/20130731155600_create_notes.rb
@@ -1,4 +1,4 @@
-class CreateNotes < ActiveRecord::Migration
+class CreateNotes < ActiveRecord::Migration[4.2]
   def change
     create_table :notes do |t|
       t.references :user, index: true

--- a/db/migrate/20130809144347_create_plans.rb
+++ b/db/migrate/20130809144347_create_plans.rb
@@ -1,4 +1,4 @@
-class CreatePlans < ActiveRecord::Migration
+class CreatePlans < ActiveRecord::Migration[4.2]
   def change
     create_table :plans do |t|
       t.string :name, null: false

--- a/db/migrate/20130812194332_add_bios_to_users.rb
+++ b/db/migrate/20130812194332_add_bios_to_users.rb
@@ -1,4 +1,4 @@
-class AddBiosToUsers < ActiveRecord::Migration
+class AddBiosToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :bio, :text
   end

--- a/db/migrate/20130814143800_change_name_for_github_users.rb
+++ b/db/migrate/20130814143800_change_name_for_github_users.rb
@@ -1,4 +1,4 @@
-class ChangeNameForGithubUsers < ActiveRecord::Migration
+class ChangeNameForGithubUsers < ActiveRecord::Migration[4.2]
   def up
     update <<-SQL
       UPDATE users SET name = users.github_username WHERE name = 'GitHub User'

--- a/db/migrate/20130822152026_remove_prices_from_workshops.rb
+++ b/db/migrate/20130822152026_remove_prices_from_workshops.rb
@@ -1,4 +1,4 @@
-class RemovePricesFromWorkshops < ActiveRecord::Migration
+class RemovePricesFromWorkshops < ActiveRecord::Migration[4.2]
   def up
     remove_column :workshops, :individual_price
     remove_column :workshops, :company_price

--- a/db/migrate/20130822220121_move_mentor_to_users.rb
+++ b/db/migrate/20130822220121_move_mentor_to_users.rb
@@ -1,4 +1,4 @@
-class MoveMentorToUsers < ActiveRecord::Migration
+class MoveMentorToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :mentor_id, :integer
     execute <<-SQL

--- a/db/migrate/20130826172010_rename_mentor_to_available_to_mentor.rb
+++ b/db/migrate/20130826172010_rename_mentor_to_available_to_mentor.rb
@@ -1,4 +1,4 @@
-class RenameMentorToAvailableToMentor < ActiveRecord::Migration
+class RenameMentorToAvailableToMentor < ActiveRecord::Migration[4.2]
   def change
     rename_column :users, :mentor, :available_to_mentor
   end

--- a/db/migrate/20130828185558_create_team_plan.rb
+++ b/db/migrate/20130828185558_create_team_plan.rb
@@ -1,4 +1,4 @@
-class CreateTeamPlan < ActiveRecord::Migration
+class CreateTeamPlan < ActiveRecord::Migration[4.2]
   def change
     create_table :team_plans do |t|
       t.string :sku, null: false

--- a/db/migrate/20130829154129_add_contributor_to_notes.rb
+++ b/db/migrate/20130829154129_add_contributor_to_notes.rb
@@ -1,4 +1,4 @@
-class AddContributorToNotes < ActiveRecord::Migration
+class AddContributorToNotes < ActiveRecord::Migration[4.2]
   def up
     add_column :notes, :contributor_id, :integer
     execute <<-SQL

--- a/db/migrate/20130903173709_create_teams.rb
+++ b/db/migrate/20130903173709_create_teams.rb
@@ -1,4 +1,4 @@
-class CreateTeams < ActiveRecord::Migration
+class CreateTeams < ActiveRecord::Migration[4.2]
   def change
     create_table :teams do |t|
       t.string :name, null: false

--- a/db/migrate/20130903174450_associate_subscriptions_with_teams.rb
+++ b/db/migrate/20130903174450_associate_subscriptions_with_teams.rb
@@ -1,4 +1,4 @@
-class AssociateSubscriptionsWithTeams < ActiveRecord::Migration
+class AssociateSubscriptionsWithTeams < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :team_id, :integer
   end

--- a/db/migrate/20130903181127_make_plans_polymorphic.rb
+++ b/db/migrate/20130903181127_make_plans_polymorphic.rb
@@ -1,4 +1,4 @@
-class MakePlansPolymorphic < ActiveRecord::Migration
+class MakePlansPolymorphic < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :plan_type, :string, null: false, default: 'IndividualPlan'
   end

--- a/db/migrate/20130903181643_rename_plan_to_individual_plan.rb
+++ b/db/migrate/20130903181643_rename_plan_to_individual_plan.rb
@@ -1,4 +1,4 @@
-class RenamePlanToIndividualPlan < ActiveRecord::Migration
+class RenamePlanToIndividualPlan < ActiveRecord::Migration[4.2]
   def change
     rename_table :plans, :individual_plans
   end

--- a/db/migrate/20130904155520_remove_price_from_team_plans.rb
+++ b/db/migrate/20130904155520_remove_price_from_team_plans.rb
@@ -1,4 +1,4 @@
-class RemovePriceFromTeamPlans < ActiveRecord::Migration
+class RemovePriceFromTeamPlans < ActiveRecord::Migration[4.2]
   def change
     remove_column :team_plans, :price
   end

--- a/db/migrate/20130904175521_remove_company_price_from_individual_plans.rb
+++ b/db/migrate/20130904175521_remove_company_price_from_individual_plans.rb
@@ -1,4 +1,4 @@
-class RemoveCompanyPriceFromIndividualPlans < ActiveRecord::Migration
+class RemoveCompanyPriceFromIndividualPlans < ActiveRecord::Migration[4.2]
   def up
     remove_column :individual_plans, :company_price
   end

--- a/db/migrate/20130906183616_change_plan_to_individual_plan_in_purchases.rb
+++ b/db/migrate/20130906183616_change_plan_to_individual_plan_in_purchases.rb
@@ -1,4 +1,4 @@
-class ChangePlanToIndividualPlanInPurchases < ActiveRecord::Migration
+class ChangePlanToIndividualPlanInPurchases < ActiveRecord::Migration[4.2]
   def up
     execute <<-SQL
       UPDATE purchases

--- a/db/migrate/20130925202220_add_index_to_subscriptions.rb
+++ b/db/migrate/20130925202220_add_index_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddIndexToSubscriptions < ActiveRecord::Migration
+class AddIndexToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_index :subscriptions, :user_id
     add_index :subscriptions, :team_id

--- a/db/migrate/20131024150525_add_availability_to_users.rb
+++ b/db/migrate/20131024150525_add_availability_to_users.rb
@@ -1,4 +1,4 @@
-class AddAvailabilityToUsers < ActiveRecord::Migration
+class AddAvailabilityToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column(
       :users,

--- a/db/migrate/20131028033305_remove_externally_fulfilled_product_fields.rb
+++ b/db/migrate/20131028033305_remove_externally_fulfilled_product_fields.rb
@@ -1,4 +1,4 @@
-class RemoveExternallyFulfilledProductFields < ActiveRecord::Migration
+class RemoveExternallyFulfilledProductFields < ActiveRecord::Migration[4.2]
   def up
     remove_column :products, :external_purchase_url
     remove_column :products, :external_purchase_name

--- a/db/migrate/20131028134920_drop_shows_and_episodes.rb
+++ b/db/migrate/20131028134920_drop_shows_and_episodes.rb
@@ -1,4 +1,4 @@
-class DropShowsAndEpisodes < ActiveRecord::Migration
+class DropShowsAndEpisodes < ActiveRecord::Migration[4.2]
   def change
     drop_table :shows
     drop_table :episodes

--- a/db/migrate/20131028233556_remove_reminder_email_from_sections.rb
+++ b/db/migrate/20131028233556_remove_reminder_email_from_sections.rb
@@ -1,4 +1,4 @@
-class RemoveReminderEmailFromSections < ActiveRecord::Migration
+class RemoveReminderEmailFromSections < ActiveRecord::Migration[4.2]
   def up
     remove_column :sections, :reminder_email
   end

--- a/db/migrate/20131031134316_move_team_plan_data_to_database.rb
+++ b/db/migrate/20131031134316_move_team_plan_data_to_database.rb
@@ -1,4 +1,4 @@
-class MoveTeamPlanDataToDatabase < ActiveRecord::Migration
+class MoveTeamPlanDataToDatabase < ActiveRecord::Migration[4.2]
   def change
     add_column :team_plans, :individual_price, :integer, null: true
     add_column :team_plans, :terms, :text

--- a/db/migrate/20131104182934_add_quantity_to_purchases.rb
+++ b/db/migrate/20131104182934_add_quantity_to_purchases.rb
@@ -1,4 +1,4 @@
-class AddQuantityToPurchases < ActiveRecord::Migration
+class AddQuantityToPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :purchases, :quantity, :integer, null: false, default: 1
   end

--- a/db/migrate/20131111023909_remove_videos_active_on_day.rb
+++ b/db/migrate/20131111023909_remove_videos_active_on_day.rb
@@ -1,4 +1,4 @@
-class RemoveVideosActiveOnDay < ActiveRecord::Migration
+class RemoveVideosActiveOnDay < ActiveRecord::Migration[4.2]
   def change
     remove_column :videos, :active_on_day
   end

--- a/db/migrate/20131121221109_add_next_payment_amount_to_subscriptions.rb
+++ b/db/migrate/20131121221109_add_next_payment_amount_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddNextPaymentAmountToSubscriptions < ActiveRecord::Migration
+class AddNextPaymentAmountToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :next_payment_amount, :decimal, null: false, default: 0
   end

--- a/db/migrate/20131123130951_remove_office_hours_and_video_chat_from_workshops.rb
+++ b/db/migrate/20131123130951_remove_office_hours_and_video_chat_from_workshops.rb
@@ -1,4 +1,4 @@
-class RemoveOfficeHoursAndVideoChatFromWorkshops < ActiveRecord::Migration
+class RemoveOfficeHoursAndVideoChatFromWorkshops < ActiveRecord::Migration[4.2]
   def change
     remove_column :workshops, :office_hours
     remove_column :workshops, :video_chat_url

--- a/db/migrate/20131125194326_remove_bytes.rb
+++ b/db/migrate/20131125194326_remove_bytes.rb
@@ -1,4 +1,4 @@
-class RemoveBytes < ActiveRecord::Migration
+class RemoveBytes < ActiveRecord::Migration[4.2]
   def up
     drop_table :bytes
   end

--- a/db/migrate/20131125202014_remove_articles.rb
+++ b/db/migrate/20131125202014_remove_articles.rb
@@ -1,4 +1,4 @@
-class RemoveArticles < ActiveRecord::Migration
+class RemoveArticles < ActiveRecord::Migration[4.2]
   def up
     drop_table :articles
   end

--- a/db/migrate/20131126205201_remove_customer_id_from_users.rb
+++ b/db/migrate/20131126205201_remove_customer_id_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveCustomerIdFromUsers < ActiveRecord::Migration
+class RemoveCustomerIdFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :customer_id, :string
   end

--- a/db/migrate/20131130183532_change_products_to_sti.rb
+++ b/db/migrate/20131130183532_change_products_to_sti.rb
@@ -1,4 +1,4 @@
-class ChangeProductsToSti < ActiveRecord::Migration
+class ChangeProductsToSti < ActiveRecord::Migration[4.2]
   def change
     rename_column :products, :product_type, :type
 

--- a/db/migrate/20131226065452_add_next_payment_on_to_subscriptions.rb
+++ b/db/migrate/20131226065452_add_next_payment_on_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddNextPaymentOnToSubscriptions < ActiveRecord::Migration
+class AddNextPaymentOnToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :next_payment_on, :date
   end

--- a/db/migrate/20131226142103_create_mentors.rb
+++ b/db/migrate/20131226142103_create_mentors.rb
@@ -1,4 +1,4 @@
-class CreateMentors < ActiveRecord::Migration
+class CreateMentors < ActiveRecord::Migration[4.2]
   def up
     create_table :mentors do |t|
       t.belongs_to :user, null: false

--- a/db/migrate/20131227145412_add_available_flag_to_mentors.rb
+++ b/db/migrate/20131227145412_add_available_flag_to_mentors.rb
@@ -1,4 +1,4 @@
-class AddAvailableFlagToMentors < ActiveRecord::Migration
+class AddAvailableFlagToMentors < ActiveRecord::Migration[4.2]
   def change
     add_column :mentors, :accepting_new_mentees, :boolean, null: false, default: true
   end

--- a/db/migrate/20131230094755_remove_external_registration_url_from_workshops.rb
+++ b/db/migrate/20131230094755_remove_external_registration_url_from_workshops.rb
@@ -1,4 +1,4 @@
-class RemoveExternalRegistrationUrlFromWorkshops < ActiveRecord::Migration
+class RemoveExternalRegistrationUrlFromWorkshops < ActiveRecord::Migration[4.2]
   def up
     remove_column :workshops, :external_registration_url
   end

--- a/db/migrate/20131230192546_add_team_id_to_users.rb
+++ b/db/migrate/20131230192546_add_team_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddTeamIdToUsers < ActiveRecord::Migration
+class AddTeamIdToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :team_id, :integer
 

--- a/db/migrate/20131230193510_add_subscription_id_to_teams.rb
+++ b/db/migrate/20131230193510_add_subscription_id_to_teams.rb
@@ -1,4 +1,4 @@
-class AddSubscriptionIdToTeams < ActiveRecord::Migration
+class AddSubscriptionIdToTeams < ActiveRecord::Migration[4.2]
   def up
     add_column :teams, :subscription_id, :integer
 

--- a/db/migrate/20131230195418_remove_team_id_from_subscriptions.rb
+++ b/db/migrate/20131230195418_remove_team_id_from_subscriptions.rb
@@ -1,4 +1,4 @@
-class RemoveTeamIdFromSubscriptions < ActiveRecord::Migration
+class RemoveTeamIdFromSubscriptions < ActiveRecord::Migration[4.2]
   def up
     say_with_time 'Deleting subscriptions for team members' do
       connection.delete(<<-SQL)

--- a/db/migrate/20131231091403_remove_discount_percentage_and_discount_title_from_products.rb
+++ b/db/migrate/20131231091403_remove_discount_percentage_and_discount_title_from_products.rb
@@ -1,4 +1,4 @@
-class RemoveDiscountPercentageAndDiscountTitleFromProducts < ActiveRecord::Migration
+class RemoveDiscountPercentageAndDiscountTitleFromProducts < ActiveRecord::Migration[4.2]
   def change
     remove_column :products, :discount_percentage, :integer
     remove_column :products, :discount_title, :string

--- a/db/migrate/20140106122343_remove_fulfillment_method_from_products.rb
+++ b/db/migrate/20140106122343_remove_fulfillment_method_from_products.rb
@@ -1,4 +1,4 @@
-class RemoveFulfillmentMethodFromProducts < ActiveRecord::Migration
+class RemoveFulfillmentMethodFromProducts < ActiveRecord::Migration[4.2]
   def change
     remove_column :products, :fulfillment_method, :string
   end

--- a/db/migrate/20140113204616_change_mentoring_default_to_false.rb
+++ b/db/migrate/20140113204616_change_mentoring_default_to_false.rb
@@ -1,4 +1,4 @@
-class ChangeMentoringDefaultToFalse < ActiveRecord::Migration
+class ChangeMentoringDefaultToFalse < ActiveRecord::Migration[4.2]
   def up
     change_column_default :individual_plans, :includes_mentor, false
     change_column_default :team_plans, :includes_mentor, false

--- a/db/migrate/20140114195456_add_users_allowed_to_teams.rb
+++ b/db/migrate/20140114195456_add_users_allowed_to_teams.rb
@@ -1,4 +1,4 @@
-class AddUsersAllowedToTeams < ActiveRecord::Migration
+class AddUsersAllowedToTeams < ActiveRecord::Migration[4.2]
   def up
     add_column :teams, :max_users, :integer
 

--- a/db/migrate/20140114195457_create_invitations.rb
+++ b/db/migrate/20140114195457_create_invitations.rb
@@ -1,4 +1,4 @@
-class CreateInvitations < ActiveRecord::Migration
+class CreateInvitations < ActiveRecord::Migration[4.2]
   def change
     create_table :invitations do |table|
       table.string :email, null: false

--- a/db/migrate/20140116184523_remove_inperson_workshops.rb
+++ b/db/migrate/20140116184523_remove_inperson_workshops.rb
@@ -1,4 +1,4 @@
-class RemoveInpersonWorkshops < ActiveRecord::Migration
+class RemoveInpersonWorkshops < ActiveRecord::Migration[4.2]
   def up
     ip_workshops = select_all "SELECT * FROM workshops WHERE online = false"
     ip_workshops.each do |ip_workshop|

--- a/db/migrate/20140117174155_create_teachers_join_table.rb
+++ b/db/migrate/20140117174155_create_teachers_join_table.rb
@@ -1,4 +1,4 @@
-class CreateTeachersJoinTable < ActiveRecord::Migration
+class CreateTeachersJoinTable < ActiveRecord::Migration[4.2]
   def change
     create_table :teachers do |t|
       t.belongs_to :user

--- a/db/migrate/20140123145010_update_team_plans_type.rb
+++ b/db/migrate/20140123145010_update_team_plans_type.rb
@@ -1,4 +1,4 @@
-class UpdateTeamPlansType < ActiveRecord::Migration
+class UpdateTeamPlansType < ActiveRecord::Migration[4.2]
   def up
     update_type :subscriptions, :plan_type, 'TeamPlan', 'Teams::TeamPlan'
     update_type :purchases, :purchaseable_type, 'TeamPlan', 'Teams::TeamPlan'

--- a/db/migrate/20140313201034_create_public_keys.rb
+++ b/db/migrate/20140313201034_create_public_keys.rb
@@ -1,4 +1,4 @@
-class CreatePublicKeys < ActiveRecord::Migration
+class CreatePublicKeys < ActiveRecord::Migration[4.2]
   def change
     create_table :public_keys do |table|
       table.integer :user_id, null: false

--- a/db/migrate/20140326153845_add_published_on_to_videos.rb
+++ b/db/migrate/20140326153845_add_published_on_to_videos.rb
@@ -1,4 +1,4 @@
-class AddPublishedOnToVideos < ActiveRecord::Migration
+class AddPublishedOnToVideos < ActiveRecord::Migration[4.2]
   def up
     add_column :videos, :published_on, :date
     execute <<-SQL

--- a/db/migrate/20140407124208_add_promoted_to_products.rb
+++ b/db/migrate/20140407124208_add_promoted_to_products.rb
@@ -1,4 +1,4 @@
-class AddPromotedToProducts < ActiveRecord::Migration
+class AddPromotedToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :promoted, :boolean, default: false, null: false
   end

--- a/db/migrate/20140407144214_add_promoted_to_workshops.rb
+++ b/db/migrate/20140407144214_add_promoted_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddPromotedToWorkshops < ActiveRecord::Migration
+class AddPromotedToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :promoted, :boolean, default: false, null: false
   end

--- a/db/migrate/20140509152714_add_preview_to_videos.rb
+++ b/db/migrate/20140509152714_add_preview_to_videos.rb
@@ -1,4 +1,4 @@
-class AddPreviewToVideos < ActiveRecord::Migration
+class AddPreviewToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :preview_wistia_id, :string
   end

--- a/db/migrate/20140617152531_add_features_to_individual_plans.rb
+++ b/db/migrate/20140617152531_add_features_to_individual_plans.rb
@@ -1,4 +1,4 @@
-class AddFeaturesToIndividualPlans < ActiveRecord::Migration
+class AddFeaturesToIndividualPlans < ActiveRecord::Migration[4.2]
   def change
     with_options default: true, null: false do |table|
       table.add_column :individual_plans, :includes_exercises, :boolean

--- a/db/migrate/20140617182908_add_features_to_team_plans.rb
+++ b/db/migrate/20140617182908_add_features_to_team_plans.rb
@@ -1,4 +1,4 @@
-class AddFeaturesToTeamPlans < ActiveRecord::Migration
+class AddFeaturesToTeamPlans < ActiveRecord::Migration[4.2]
   def change
     with_options default: true, null: false do |table|
       table.add_column :team_plans, :includes_exercises, :boolean

--- a/db/migrate/20140624141447_add_includes_shows_to_plans.rb
+++ b/db/migrate/20140624141447_add_includes_shows_to_plans.rb
@@ -1,4 +1,4 @@
-class AddIncludesShowsToPlans < ActiveRecord::Migration
+class AddIncludesShowsToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column(
       :individual_plans,

--- a/db/migrate/20140716162547_add_slug_to_products.rb
+++ b/db/migrate/20140716162547_add_slug_to_products.rb
@@ -1,4 +1,4 @@
-class AddSlugToProducts < ActiveRecord::Migration
+class AddSlugToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :slug, :string, null: true
 

--- a/db/migrate/20140718144115_create_licenses.rb
+++ b/db/migrate/20140718144115_create_licenses.rb
@@ -1,4 +1,4 @@
-class CreateLicenses < ActiveRecord::Migration
+class CreateLicenses < ActiveRecord::Migration[4.2]
   def change
     create_table :licenses do |t|
       t.belongs_to :user, null: false, index: true

--- a/db/migrate/20140721190037_create_checkouts.rb
+++ b/db/migrate/20140721190037_create_checkouts.rb
@@ -1,4 +1,4 @@
-class CreateCheckouts < ActiveRecord::Migration
+class CreateCheckouts < ActiveRecord::Migration[4.2]
   def change
     create_table :checkouts do |t|
       t.belongs_to :user, null: false, index: true

--- a/db/migrate/20140723170854_remove_coupons.rb
+++ b/db/migrate/20140723170854_remove_coupons.rb
@@ -1,4 +1,4 @@
-class RemoveCoupons < ActiveRecord::Migration
+class RemoveCoupons < ActiveRecord::Migration[4.2]
   def change
     drop_table :coupons
   end

--- a/db/migrate/20140725142656_remove_notes.rb
+++ b/db/migrate/20140725142656_remove_notes.rb
@@ -1,4 +1,4 @@
-class RemoveNotes < ActiveRecord::Migration
+class RemoveNotes < ActiveRecord::Migration[4.2]
   def up
     drop_table :notes
   end

--- a/db/migrate/20140727180715_drop_purchases.rb
+++ b/db/migrate/20140727180715_drop_purchases.rb
@@ -1,4 +1,4 @@
-class DropPurchases < ActiveRecord::Migration
+class DropPurchases < ActiveRecord::Migration[4.2]
   def change
     drop_table :purchases
   end

--- a/db/migrate/20140808135936_add_slugs_to_workshops.rb
+++ b/db/migrate/20140808135936_add_slugs_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddSlugsToWorkshops < ActiveRecord::Migration
+class AddSlugsToWorkshops < ActiveRecord::Migration[4.2]
   def change
     add_column :workshops, :slug, :string, null: true
 

--- a/db/migrate/20140808165629_add_slugs_to_videos.rb
+++ b/db/migrate/20140808165629_add_slugs_to_videos.rb
@@ -1,4 +1,4 @@
-class AddSlugsToVideos < ActiveRecord::Migration
+class AddSlugsToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :slug, :string, null: true
 

--- a/db/migrate/20140813130414_update_plan_type.rb
+++ b/db/migrate/20140813130414_update_plan_type.rb
@@ -1,4 +1,4 @@
-class UpdatePlanType < ActiveRecord::Migration
+class UpdatePlanType < ActiveRecord::Migration[4.2]
   def up
     update_type :subscriptions, :plan_type, 'Teams::TeamPlan', 'TeamPlan'
   end

--- a/db/migrate/20140819205806_create_exercises.rb
+++ b/db/migrate/20140819205806_create_exercises.rb
@@ -1,4 +1,4 @@
-class CreateExercises < ActiveRecord::Migration
+class CreateExercises < ActiveRecord::Migration[4.2]
   def change
     create_table :exercises do |table|
       table.string :title, null: false

--- a/db/migrate/20140826203235_add_dashboard_to_topics.rb
+++ b/db/migrate/20140826203235_add_dashboard_to_topics.rb
@@ -1,4 +1,4 @@
-class AddDashboardToTopics < ActiveRecord::Migration
+class AddDashboardToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :dashboard, :boolean, null: false, default: false
     add_index :topics, :dashboard

--- a/db/migrate/20140827165919_remove_teams_max_users.rb
+++ b/db/migrate/20140827165919_remove_teams_max_users.rb
@@ -1,4 +1,4 @@
-class RemoveTeamsMaxUsers < ActiveRecord::Migration
+class RemoveTeamsMaxUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :teams, :max_users
   end

--- a/db/migrate/20140905210137_rename_workshops_to_video_tutorials.rb
+++ b/db/migrate/20140905210137_rename_workshops_to_video_tutorials.rb
@@ -1,4 +1,4 @@
-class RenameWorkshopsToVideoTutorials < ActiveRecord::Migration
+class RenameWorkshopsToVideoTutorials < ActiveRecord::Migration[4.2]
   def change
     rename_column :individual_plans, :includes_workshops, :includes_video_tutorials
     rename_column :team_plans, :includes_workshops, :includes_video_tutorials

--- a/db/migrate/20140908153238_update_polymorphic_relations.rb
+++ b/db/migrate/20140908153238_update_polymorphic_relations.rb
@@ -1,4 +1,4 @@
-class UpdatePolymorphicRelations < ActiveRecord::Migration
+class UpdatePolymorphicRelations < ActiveRecord::Migration[4.2]
   def up
     update_polymorphic_references :classifications,
                                   :classifiable_type,

--- a/db/migrate/20140908185015_add_includes_team_to_individual_plans.rb
+++ b/db/migrate/20140908185015_add_includes_team_to_individual_plans.rb
@@ -1,4 +1,4 @@
-class AddIncludesTeamToIndividualPlans < ActiveRecord::Migration
+class AddIncludesTeamToIndividualPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :individual_plans,
                :includes_team,

--- a/db/migrate/20140908185313_move_team_plans_into_plans.rb
+++ b/db/migrate/20140908185313_move_team_plans_into_plans.rb
@@ -1,4 +1,4 @@
-class MoveTeamPlansIntoPlans < ActiveRecord::Migration
+class MoveTeamPlansIntoPlans < ActiveRecord::Migration[4.2]
   def up
     say_with_time "Moving team_plans into plans" do
       # Need to reset the id_seq, because:

--- a/db/migrate/20140909142151_rename_individual_plans_to_plans.rb
+++ b/db/migrate/20140909142151_rename_individual_plans_to_plans.rb
@@ -1,4 +1,4 @@
-class RenameIndividualPlansToPlans < ActiveRecord::Migration
+class RenameIndividualPlansToPlans < ActiveRecord::Migration[4.2]
   def change
     rename_table :individual_plans, :plans
   end

--- a/db/migrate/20140909182638_update_plan_polymorphic_relations.rb
+++ b/db/migrate/20140909182638_update_plan_polymorphic_relations.rb
@@ -1,4 +1,4 @@
-class UpdatePlanPolymorphicRelations < ActiveRecord::Migration
+class UpdatePlanPolymorphicRelations < ActiveRecord::Migration[4.2]
   def up
     update_polymorphic_references :checkouts,
                                   :subscribeable_type,

--- a/db/migrate/20140909182639_drop_team_plans.rb
+++ b/db/migrate/20140909182639_drop_team_plans.rb
@@ -1,4 +1,4 @@
-class DropTeamPlans < ActiveRecord::Migration
+class DropTeamPlans < ActiveRecord::Migration[4.2]
   def up
     drop_table :team_plans
   end

--- a/db/migrate/20140909194237_remove_team_plan_id_from_teams.rb
+++ b/db/migrate/20140909194237_remove_team_plan_id_from_teams.rb
@@ -1,4 +1,4 @@
-class RemoveTeamPlanIdFromTeams < ActiveRecord::Migration
+class RemoveTeamPlanIdFromTeams < ActiveRecord::Migration[4.2]
   def change
     remove_column :teams, :team_plan_id
   end

--- a/db/migrate/20140910153255_add_unique_index_to_github_username.rb
+++ b/db/migrate/20140910153255_add_unique_index_to_github_username.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToGithubUsername < ActiveRecord::Migration
+class AddUniqueIndexToGithubUsername < ActiveRecord::Migration[4.2]
   def change
     update "UPDATE users SET github_username = NULL WHERE github_username = '';"
     add_index :users, :github_username, unique: true

--- a/db/migrate/20140910213739_remove_paid_from_subscriptions.rb
+++ b/db/migrate/20140910213739_remove_paid_from_subscriptions.rb
@@ -1,4 +1,4 @@
-class RemovePaidFromSubscriptions < ActiveRecord::Migration
+class RemovePaidFromSubscriptions < ActiveRecord::Migration[4.2]
   def up
     remove_column :subscriptions, :paid
   end

--- a/db/migrate/20140911184704_add_is_annual_to_plans.rb
+++ b/db/migrate/20140911184704_add_is_annual_to_plans.rb
@@ -1,4 +1,4 @@
-class AddIsAnnualToPlans < ActiveRecord::Migration
+class AddIsAnnualToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :plans, :annual, :boolean, nil: false, default: false
   end

--- a/db/migrate/20140916190948_add_video_attributes_to_products.rb
+++ b/db/migrate/20140916190948_add_video_attributes_to_products.rb
@@ -1,4 +1,4 @@
-class AddVideoAttributesToProducts < ActiveRecord::Migration
+class AddVideoAttributesToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :length_in_days, :integer
     add_column :products, :resources, :text, default: "", null: false

--- a/db/migrate/20140916190949_move_video_tutorials_into_products.rb
+++ b/db/migrate/20140916190949_move_video_tutorials_into_products.rb
@@ -1,4 +1,4 @@
-class MoveVideoTutorialsIntoProducts < ActiveRecord::Migration
+class MoveVideoTutorialsIntoProducts < ActiveRecord::Migration[4.2]
   def up
     say_with_time "Moving video_tutorials into products" do
       # Move team_plans data into individual_plans

--- a/db/migrate/20140916190950_drop_table_video_tutorials.rb
+++ b/db/migrate/20140916190950_drop_table_video_tutorials.rb
@@ -1,4 +1,4 @@
-class DropTableVideoTutorials < ActiveRecord::Migration
+class DropTableVideoTutorials < ActiveRecord::Migration[4.2]
   def up
     drop_table :video_tutorials
   end

--- a/db/migrate/20140916212112_drop_table_announcements.rb
+++ b/db/migrate/20140916212112_drop_table_announcements.rb
@@ -1,4 +1,4 @@
-class DropTableAnnouncements < ActiveRecord::Migration
+class DropTableAnnouncements < ActiveRecord::Migration[4.2]
   def change
     drop_table :announcements
   end

--- a/db/migrate/20140917182800_remove_includes_books_from_plans.rb
+++ b/db/migrate/20140917182800_remove_includes_books_from_plans.rb
@@ -1,4 +1,4 @@
-class RemoveIncludesBooksFromPlans < ActiveRecord::Migration
+class RemoveIncludesBooksFromPlans < ActiveRecord::Migration[4.2]
   def change
     remove_column :plans, :includes_books, :boolean
   end

--- a/db/migrate/20140917203922_remove_book_references.rb
+++ b/db/migrate/20140917203922_remove_book_references.rb
@@ -1,4 +1,4 @@
-class RemoveBookReferences < ActiveRecord::Migration
+class RemoveBookReferences < ActiveRecord::Migration[4.2]
   def up
     remove_book_references_from(:classifications, :classifiable_type, :classifiable_id)
     remove_book_references_from(:downloads, :purchaseable_type, :purchaseable_id)

--- a/db/migrate/20140923173013_update_polymorphic_references.rb
+++ b/db/migrate/20140923173013_update_polymorphic_references.rb
@@ -1,4 +1,4 @@
-class UpdatePolymorphicReferences < ActiveRecord::Migration
+class UpdatePolymorphicReferences < ActiveRecord::Migration[4.2]
   def up
     say_with_time "Converting Screencasts into VideoTutorials (products.type)" do
       update "UPDATE products SET type='VideoTutorial' WHERE type='Screencast'"

--- a/db/migrate/20140923180945_remove_includes_screencasts_from_plans.rb
+++ b/db/migrate/20140923180945_remove_includes_screencasts_from_plans.rb
@@ -1,4 +1,4 @@
-class RemoveIncludesScreencastsFromPlans < ActiveRecord::Migration
+class RemoveIncludesScreencastsFromPlans < ActiveRecord::Migration[4.2]
   def change
     remove_column :plans, :includes_screencasts, :boolean
   end

--- a/db/migrate/20140924174818_enable_pg_stat_statements.rb
+++ b/db/migrate/20140924174818_enable_pg_stat_statements.rb
@@ -1,4 +1,4 @@
-class EnablePgStatStatements < ActiveRecord::Migration
+class EnablePgStatStatements < ActiveRecord::Migration[4.2]
   def change
     enable_extension "pg_stat_statements"
   end

--- a/db/migrate/20140926183202_create_statuses.rb
+++ b/db/migrate/20140926183202_create_statuses.rb
@@ -1,4 +1,4 @@
-class CreateStatuses < ActiveRecord::Migration
+class CreateStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :statuses do |t|
       t.belongs_to :exercise, null: false

--- a/db/migrate/20140930160731_add_uuid_to_exercises.rb
+++ b/db/migrate/20140930160731_add_uuid_to_exercises.rb
@@ -1,4 +1,4 @@
-class AddUuidToExercises < ActiveRecord::Migration
+class AddUuidToExercises < ActiveRecord::Migration[4.2]
   def change
     add_column :exercises, :uuid, :string
   end

--- a/db/migrate/20140930185615_remove_unique_index_from_statuses.rb
+++ b/db/migrate/20140930185615_remove_unique_index_from_statuses.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueIndexFromStatuses < ActiveRecord::Migration
+class RemoveUniqueIndexFromStatuses < ActiveRecord::Migration[4.2]
   def change
     remove_index :statuses, name: :index_statuses_on_exercise_id_and_user_id
   end

--- a/db/migrate/20140930204417_rename_trails.rb
+++ b/db/migrate/20140930204417_rename_trails.rb
@@ -1,4 +1,4 @@
-class RenameTrails < ActiveRecord::Migration
+class RenameTrails < ActiveRecord::Migration[4.2]
   def change
     rename_table :trails, :legacy_trails
   end

--- a/db/migrate/20141001143442_create_trail.rb
+++ b/db/migrate/20141001143442_create_trail.rb
@@ -1,4 +1,4 @@
-class CreateTrail < ActiveRecord::Migration
+class CreateTrail < ActiveRecord::Migration[4.2]
   def change
     create_table :trails do |t|
       t.string :name, null: false

--- a/db/migrate/20141001145943_create_steps.rb
+++ b/db/migrate/20141001145943_create_steps.rb
@@ -1,4 +1,4 @@
-class CreateSteps < ActiveRecord::Migration
+class CreateSteps < ActiveRecord::Migration[4.2]
   def change
     create_table :steps do |t|
       t.references :trail, null: false

--- a/db/migrate/20141001220833_exercises_uuid_not_null.rb
+++ b/db/migrate/20141001220833_exercises_uuid_not_null.rb
@@ -1,4 +1,4 @@
-class ExercisesUuidNotNull < ActiveRecord::Migration
+class ExercisesUuidNotNull < ActiveRecord::Migration[4.2]
   def change
     change_column_null :exercises, :uuid, false
   end

--- a/db/migrate/20141002010032_add_status_indexes.rb
+++ b/db/migrate/20141002010032_add_status_indexes.rb
@@ -1,4 +1,4 @@
-class AddStatusIndexes < ActiveRecord::Migration
+class AddStatusIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :statuses, :exercise_id
     add_index :statuses, :user_id

--- a/db/migrate/20141002154430_index_exercises_uuid.rb
+++ b/db/migrate/20141002154430_index_exercises_uuid.rb
@@ -1,4 +1,4 @@
-class IndexExercisesUuid < ActiveRecord::Migration
+class IndexExercisesUuid < ActiveRecord::Migration[4.2]
   def change
     add_index :exercises, :uuid, unique: true
   end

--- a/db/migrate/20141006190217_rename_source_code_to_repositories.rb
+++ b/db/migrate/20141006190217_rename_source_code_to_repositories.rb
@@ -1,4 +1,4 @@
-class RenameSourceCodeToRepositories < ActiveRecord::Migration
+class RenameSourceCodeToRepositories < ActiveRecord::Migration[4.2]
   def change
     rename_column :plans, :includes_source_code, :includes_repositories
   end

--- a/db/migrate/20141007181740_remove_office_hours_feature.rb
+++ b/db/migrate/20141007181740_remove_office_hours_feature.rb
@@ -1,4 +1,4 @@
-class RemoveOfficeHoursFeature < ActiveRecord::Migration
+class RemoveOfficeHoursFeature < ActiveRecord::Migration[4.2]
   def up
     remove_column :plans, :includes_office_hours
   end

--- a/db/migrate/20141007191034_add_complete_text_to_trails.rb
+++ b/db/migrate/20141007191034_add_complete_text_to_trails.rb
@@ -1,4 +1,4 @@
-class AddCompleteTextToTrails < ActiveRecord::Migration
+class AddCompleteTextToTrails < ActiveRecord::Migration[4.2]
   def up
     add_column :trails, :complete_text, :string
     change_column_null :trails, :complete_text, false, "Nice work!"

--- a/db/migrate/20141007211055_add_published_to_trails.rb
+++ b/db/migrate/20141007211055_add_published_to_trails.rb
@@ -1,4 +1,4 @@
-class AddPublishedToTrails < ActiveRecord::Migration
+class AddPublishedToTrails < ActiveRecord::Migration[4.2]
   def up
     add_column :trails, :published, :boolean, default: false, null: false
     update("UPDATE trails SET published = true")

--- a/db/migrate/20141008154607_add_slug_to_trails.rb
+++ b/db/migrate/20141008154607_add_slug_to_trails.rb
@@ -1,4 +1,4 @@
-class AddSlugToTrails < ActiveRecord::Migration
+class AddSlugToTrails < ActiveRecord::Migration[4.2]
   def up
     add_column :trails, :slug, :string
     generate_slug :trails, :name, :slug

--- a/db/migrate/20141009184356_add_topic_id_to_trails.rb
+++ b/db/migrate/20141009184356_add_topic_id_to_trails.rb
@@ -1,4 +1,4 @@
-class AddTopicIdToTrails < ActiveRecord::Migration
+class AddTopicIdToTrails < ActiveRecord::Migration[4.2]
   def change
     add_column :trails, :topic_id, :integer
   end

--- a/db/migrate/20141009203729_add_public_to_exercises.rb
+++ b/db/migrate/20141009203729_add_public_to_exercises.rb
@@ -1,4 +1,4 @@
-class AddPublicToExercises < ActiveRecord::Migration
+class AddPublicToExercises < ActiveRecord::Migration[4.2]
   def up
     add_column :exercises, :public, :boolean, null: false, default: false
     update("UPDATE exercises SET public = true")

--- a/db/migrate/20141013173406_add_description_to_trails.rb
+++ b/db/migrate/20141013173406_add_description_to_trails.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToTrails < ActiveRecord::Migration
+class AddDescriptionToTrails < ActiveRecord::Migration[4.2]
   def change
     add_column :trails, :description, :text, null: false, default: ""
   end

--- a/db/migrate/20141014183929_fill_trails_descriptions.rb
+++ b/db/migrate/20141014183929_fill_trails_descriptions.rb
@@ -1,4 +1,4 @@
-class FillTrailsDescriptions < ActiveRecord::Migration
+class FillTrailsDescriptions < ActiveRecord::Migration[4.2]
   def change
     update("UPDATE trails SET description = 'A method of improving code quality and minimizing time required to add new features to software by ensuring that each facet of the program works as expected.'")
   end

--- a/db/migrate/20141027064159_drop_public_keys.rb
+++ b/db/migrate/20141027064159_drop_public_keys.rb
@@ -1,4 +1,4 @@
-class DropPublicKeys < ActiveRecord::Migration
+class DropPublicKeys < ActiveRecord::Migration[4.2]
   def change
     drop_table :public_keys do |table|
       table.integer :user_id, null: false

--- a/db/migrate/20141029091101_change_default_state_in_statuses.rb
+++ b/db/migrate/20141029091101_change_default_state_in_statuses.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultStateInStatuses < ActiveRecord::Migration
+class ChangeDefaultStateInStatuses < ActiveRecord::Migration[4.2]
   def up
     change_column_default :statuses, :state, "In Progress"
   end

--- a/db/migrate/20141030171639_make_statuses_polymorphic.rb
+++ b/db/migrate/20141030171639_make_statuses_polymorphic.rb
@@ -1,4 +1,4 @@
-class MakeStatusesPolymorphic < ActiveRecord::Migration
+class MakeStatusesPolymorphic < ActiveRecord::Migration[4.2]
   def change
     rename_column :statuses, :exercise_id, :completeable_id
     add_column :statuses, :completeable_type, :string

--- a/db/migrate/20141111095353_add_edit_url_to_exercises.rb
+++ b/db/migrate/20141111095353_add_edit_url_to_exercises.rb
@@ -1,4 +1,4 @@
-class AddEditUrlToExercises < ActiveRecord::Migration
+class AddEditUrlToExercises < ActiveRecord::Migration[4.2]
   def up
     add_column :exercises, :edit_url, :string
 

--- a/db/migrate/20141111203903_add_stripe_id_to_subscriptions.rb
+++ b/db/migrate/20141111203903_add_stripe_id_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddStripeIdToSubscriptions < ActiveRecord::Migration
+class AddStripeIdToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :stripe_id, :string
     add_index :subscriptions, :stripe_id

--- a/db/migrate/20141112201747_checkout_subscribable_is_plan.rb
+++ b/db/migrate/20141112201747_checkout_subscribable_is_plan.rb
@@ -1,4 +1,4 @@
-class CheckoutSubscribableIsPlan < ActiveRecord::Migration
+class CheckoutSubscribableIsPlan < ActiveRecord::Migration[4.2]
   def change
     remove_column :checkouts, :subscribeable_type
     rename_column :checkouts, :subscribeable_id, :plan_id

--- a/db/migrate/20141119235913_rename_topics_dashboard_to_explorable.rb
+++ b/db/migrate/20141119235913_rename_topics_dashboard_to_explorable.rb
@@ -1,4 +1,4 @@
-class RenameTopicsDashboardToExplorable < ActiveRecord::Migration
+class RenameTopicsDashboardToExplorable < ActiveRecord::Migration[4.2]
   def change
     rename_column :topics, :dashboard, :explorable
   end

--- a/db/migrate/20141120214043_add_position_index.rb
+++ b/db/migrate/20141120214043_add_position_index.rb
@@ -1,4 +1,4 @@
-class AddPositionIndex < ActiveRecord::Migration
+class AddPositionIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :steps, [:trail_id, :position]
   end

--- a/db/migrate/20141124141654_stripe_customer_id_null_false.rb
+++ b/db/migrate/20141124141654_stripe_customer_id_null_false.rb
@@ -1,4 +1,4 @@
-class StripeCustomerIdNullFalse < ActiveRecord::Migration
+class StripeCustomerIdNullFalse < ActiveRecord::Migration[4.2]
   def change
     change_column_default :users, :stripe_customer_id, ""
     change_column_null :users, :stripe_customer_id, false, ""

--- a/db/migrate/20141125212241_update_explorable_topics.rb
+++ b/db/migrate/20141125212241_update_explorable_topics.rb
@@ -1,4 +1,4 @@
-class UpdateExplorableTopics < ActiveRecord::Migration
+class UpdateExplorableTopics < ActiveRecord::Migration[4.2]
   def change
     other_topic = Topic.find_by(slug: "other")
     if other_topic

--- a/db/migrate/20141203190801_update_trails_topics.rb
+++ b/db/migrate/20141203190801_update_trails_topics.rb
@@ -1,4 +1,4 @@
-class UpdateTrailsTopics < ActiveRecord::Migration
+class UpdateTrailsTopics < ActiveRecord::Migration[4.2]
   def up
     create_topic name: "Foundations"
 

--- a/db/migrate/20141205091830_add_annual_plan_id_to_plans.rb
+++ b/db/migrate/20141205091830_add_annual_plan_id_to_plans.rb
@@ -1,4 +1,4 @@
-class AddAnnualPlanIdToPlans < ActiveRecord::Migration
+class AddAnnualPlanIdToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :plans, :annual_plan_id, :integer
     add_index :plans, :annual_plan_id

--- a/db/migrate/20141214172601_add_scopes_to_oauth_applications.rb
+++ b/db/migrate/20141214172601_add_scopes_to_oauth_applications.rb
@@ -1,4 +1,4 @@
-class AddScopesToOauthApplications < ActiveRecord::Migration
+class AddScopesToOauthApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :scopes, :string, null: false, default: ""
   end

--- a/db/migrate/20141216212241_update_topic_colors.rb
+++ b/db/migrate/20141216212241_update_topic_colors.rb
@@ -1,4 +1,4 @@
-class UpdateTopicColors < ActiveRecord::Migration
+class UpdateTopicColors < ActiveRecord::Migration[4.2]
   COLORS = {
     analytics:                   ["#EFFFB3", "#A5C236"],
     "clean+code" =>              ["#E5FEFF", "#1DC8CF"],

--- a/db/migrate/20141217203321_remove_questions_model.rb
+++ b/db/migrate/20141217203321_remove_questions_model.rb
@@ -1,4 +1,4 @@
-class RemoveQuestionsModel < ActiveRecord::Migration
+class RemoveQuestionsModel < ActiveRecord::Migration[4.2]
   def up
     questions = select_all(
       "SELECT * FROM questions WHERE video_tutorial_id IS NOT NULL"

--- a/db/migrate/20150106164342_create_collaborations.rb
+++ b/db/migrate/20150106164342_create_collaborations.rb
@@ -1,4 +1,4 @@
-class CreateCollaborations < ActiveRecord::Migration
+class CreateCollaborations < ActiveRecord::Migration[4.2]
   def up
     create_table :collaborations do |table|
       table.integer :repository_id, null: false

--- a/db/migrate/20150108200739_teachers_tied_to_videos_not_video_tutorials.rb
+++ b/db/migrate/20150108200739_teachers_tied_to_videos_not_video_tutorials.rb
@@ -1,4 +1,4 @@
-class TeachersTiedToVideosNotVideoTutorials < ActiveRecord::Migration
+class TeachersTiedToVideosNotVideoTutorials < ActiveRecord::Migration[4.2]
   # Thom informs: joe has been on every episode of WI except #3
   # (improving-your-workflow-with-chris-toomey) and #35 (landing-a-rails-job)
   # Ben has been present until episode 47, Rubyisms in Swift

--- a/db/migrate/20150108220013_drop_table_licenses.rb
+++ b/db/migrate/20150108220013_drop_table_licenses.rb
@@ -1,4 +1,4 @@
-class DropTableLicenses < ActiveRecord::Migration
+class DropTableLicenses < ActiveRecord::Migration[4.2]
   def change
     drop_table :licenses
   end

--- a/db/migrate/20150115151014_rename_plans_individual_price_to_price.rb
+++ b/db/migrate/20150115151014_rename_plans_individual_price_to_price.rb
@@ -1,4 +1,4 @@
-class RenamePlansIndividualPriceToPrice < ActiveRecord::Migration
+class RenamePlansIndividualPriceToPrice < ActiveRecord::Migration[4.2]
   def change
     rename_column :plans, :individual_price, :price
     remove_column :products, :individual_price, :integer, default: 0

--- a/db/migrate/20150120162640_add_product_id_to_repositories.rb
+++ b/db/migrate/20150120162640_add_product_id_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddProductIdToRepositories < ActiveRecord::Migration
+class AddProductIdToRepositories < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :product_id, :integer
     add_index :products, :product_id

--- a/db/migrate/20150122215447_rename_exercise_title_to_name.rb
+++ b/db/migrate/20150122215447_rename_exercise_title_to_name.rb
@@ -1,4 +1,4 @@
-class RenameExerciseTitleToName < ActiveRecord::Migration
+class RenameExerciseTitleToName < ActiveRecord::Migration[4.2]
   def change
     rename_column :exercises, :title, :name
   end

--- a/db/migrate/20150123153826_rename_video_title_to_name.rb
+++ b/db/migrate/20150123153826_rename_video_title_to_name.rb
@@ -1,4 +1,4 @@
-class RenameVideoTitleToName < ActiveRecord::Migration
+class RenameVideoTitleToName < ActiveRecord::Migration[4.2]
   def change
     rename_column :videos, :title, :name
   end

--- a/db/migrate/20150123174831_remove_checkouts_quantity.rb
+++ b/db/migrate/20150123174831_remove_checkouts_quantity.rb
@@ -1,4 +1,4 @@
-class RemoveCheckoutsQuantity < ActiveRecord::Migration
+class RemoveCheckoutsQuantity < ActiveRecord::Migration[4.2]
   def up
     remove_column :checkouts, :quantity
     add_column :plans, :minimum_quantity, :integer, default: 1, null: false

--- a/db/migrate/20150126161527_add_polymorphic_completeables.rb
+++ b/db/migrate/20150126161527_add_polymorphic_completeables.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicCompleteables < ActiveRecord::Migration
+class AddPolymorphicCompleteables < ActiveRecord::Migration[4.2]
   def change
     rename_column :steps, :exercise_id, :completeable_id
     add_column :steps, :completeable_type, :string

--- a/db/migrate/20150127171316_add_summary_to_videos.rb
+++ b/db/migrate/20150127171316_add_summary_to_videos.rb
@@ -1,4 +1,4 @@
-class AddSummaryToVideos < ActiveRecord::Migration
+class AddSummaryToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :summary, :text
   end

--- a/db/migrate/20150203153815_remove_length_in_days.rb
+++ b/db/migrate/20150203153815_remove_length_in_days.rb
@@ -1,4 +1,4 @@
-class RemoveLengthInDays < ActiveRecord::Migration
+class RemoveLengthInDays < ActiveRecord::Migration[4.2]
   def up
     remove_column :products, :length_in_days
   end

--- a/db/migrate/20150217225342_remove_legacy_trails_and_completions.rb
+++ b/db/migrate/20150217225342_remove_legacy_trails_and_completions.rb
@@ -1,4 +1,4 @@
-class RemoveLegacyTrailsAndCompletions < ActiveRecord::Migration
+class RemoveLegacyTrailsAndCompletions < ActiveRecord::Migration[4.2]
   def up
     drop_table :legacy_trails
     drop_table :completions

--- a/db/migrate/20150218161414_remove_featured_from_topics.rb
+++ b/db/migrate/20150218161414_remove_featured_from_topics.rb
@@ -1,4 +1,4 @@
-class RemoveFeaturedFromTopics < ActiveRecord::Migration
+class RemoveFeaturedFromTopics < ActiveRecord::Migration[4.2]
   def up
     remove_column :topics, :featured
   end

--- a/db/migrate/20150219211138_remove_topic_count.rb
+++ b/db/migrate/20150219211138_remove_topic_count.rb
@@ -1,4 +1,4 @@
-class RemoveTopicCount < ActiveRecord::Migration
+class RemoveTopicCount < ActiveRecord::Migration[4.2]
   def up
     remove_column :topics, :count
   end

--- a/db/migrate/20150225211138_merge_video_tutorial_and_exercise_permissions.rb
+++ b/db/migrate/20150225211138_merge_video_tutorial_and_exercise_permissions.rb
@@ -1,4 +1,4 @@
-class MergeVideoTutorialAndExercisePermissions < ActiveRecord::Migration
+class MergeVideoTutorialAndExercisePermissions < ActiveRecord::Migration[4.2]
   def up
     add_column :plans, :includes_trails, :boolean, default: false, null: false
     connection.update(<<-SQL)

--- a/db/migrate/20150226204426_switch_from_github_teams_to_collaborators.rb
+++ b/db/migrate/20150226204426_switch_from_github_teams_to_collaborators.rb
@@ -1,4 +1,4 @@
-class SwitchFromGithubTeamsToCollaborators < ActiveRecord::Migration
+class SwitchFromGithubTeamsToCollaborators < ActiveRecord::Migration[4.2]
   MAPPINGS = {
     1036719 => "thoughtbot/upcase",
     1036722 => "thoughtbot/upcase-exercises",

--- a/db/migrate/20150303180418_add_trail_id_to_repositories.rb
+++ b/db/migrate/20150303180418_add_trail_id_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddTrailIdToRepositories < ActiveRecord::Migration
+class AddTrailIdToRepositories < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :trail_id, :integer
     add_index :products, :trail_id

--- a/db/migrate/20150407193958_vanity_migration.rb
+++ b/db/migrate/20150407193958_vanity_migration.rb
@@ -1,4 +1,4 @@
-class VanityMigration < ActiveRecord::Migration
+class VanityMigration < ActiveRecord::Migration[4.2]
   def self.up
     create_table :vanity_metrics do |t|
       t.string :metric_id

--- a/db/migrate/20150410153006_rename_price.rb
+++ b/db/migrate/20150410153006_rename_price.rb
@@ -1,4 +1,4 @@
-class RenamePrice < ActiveRecord::Migration
+class RenamePrice < ActiveRecord::Migration[4.2]
   def change
     rename_column :plans, :price, :price_in_dollars
   end

--- a/db/migrate/20150410155813_add_null_constraint_for_github_username.rb
+++ b/db/migrate/20150410155813_add_null_constraint_for_github_username.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintForGithubUsername < ActiveRecord::Migration
+class AddNullConstraintForGithubUsername < ActiveRecord::Migration[4.2]
   def change
     change_column :users, :github_username, :string, null: false
   end

--- a/db/migrate/20150415145819_add_unique_index_to_steps_on_trail_and_completeable.rb
+++ b/db/migrate/20150415145819_add_unique_index_to_steps_on_trail_and_completeable.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToStepsOnTrailAndCompleteable < ActiveRecord::Migration
+class AddUniqueIndexToStepsOnTrailAndCompleteable < ActiveRecord::Migration[4.2]
   def up
     add_index :steps,
               [:trail_id, :completeable_id, :completeable_type],

--- a/db/migrate/20150417173205_dont_make_new_plans_featured.rb
+++ b/db/migrate/20150417173205_dont_make_new_plans_featured.rb
@@ -1,4 +1,4 @@
-class DontMakeNewPlansFeatured < ActiveRecord::Migration
+class DontMakeNewPlansFeatured < ActiveRecord::Migration[4.2]
   def change
     change_column_default :plans, :featured, false
   end

--- a/db/migrate/20150420211708_change_trails_topic_id_to_not_null.rb
+++ b/db/migrate/20150420211708_change_trails_topic_id_to_not_null.rb
@@ -1,4 +1,4 @@
-class ChangeTrailsTopicIdToNotNull < ActiveRecord::Migration
+class ChangeTrailsTopicIdToNotNull < ActiveRecord::Migration[4.2]
   def up
     change_column_null :trails, :topic_id, false
   end

--- a/db/migrate/20150421144230_drop_public_from_exercises.rb
+++ b/db/migrate/20150421144230_drop_public_from_exercises.rb
@@ -1,4 +1,4 @@
-class DropPublicFromExercises < ActiveRecord::Migration
+class DropPublicFromExercises < ActiveRecord::Migration[4.2]
   def change
     remove_column :exercises, :public, :boolean, default: false, null: false
   end

--- a/db/migrate/20150421145526_convert_video_tutorials_to_trails.rb
+++ b/db/migrate/20150421145526_convert_video_tutorials_to_trails.rb
@@ -1,4 +1,4 @@
-class ConvertVideoTutorialsToTrails < ActiveRecord::Migration
+class ConvertVideoTutorialsToTrails < ActiveRecord::Migration[4.2]
   def up
     trail_offset = say_with_time "Calculating ID offset for new trails" do
       select_value("SELECT COUNT(*) FROM trails").to_i

--- a/db/migrate/20150421160114_clean_exercise_classifications.rb
+++ b/db/migrate/20150421160114_clean_exercise_classifications.rb
@@ -1,4 +1,4 @@
-class CleanExerciseClassifications < ActiveRecord::Migration
+class CleanExerciseClassifications < ActiveRecord::Migration[4.2]
   def up
     delete <<-SQL
       DELETE FROM classifications WHERE classifiable_type = 'Exercise';

--- a/db/migrate/20150422152603_remove_video_tutorials.rb
+++ b/db/migrate/20150422152603_remove_video_tutorials.rb
@@ -1,4 +1,4 @@
-class RemoveVideoTutorials < ActiveRecord::Migration
+class RemoveVideoTutorials < ActiveRecord::Migration[4.2]
   def up
     drop_table :downloads
 

--- a/db/migrate/20150512151246_create_quizzes.rb
+++ b/db/migrate/20150512151246_create_quizzes.rb
@@ -1,4 +1,4 @@
-class CreateQuizzes < ActiveRecord::Migration
+class CreateQuizzes < ActiveRecord::Migration[4.2]
   def change
     create_table :quizzes do |t|
       t.string :title, null: false

--- a/db/migrate/20150512154633_create_quiz_questions.rb
+++ b/db/migrate/20150512154633_create_quiz_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuizQuestions < ActiveRecord::Migration
+class CreateQuizQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.text :prompt, null: false

--- a/db/migrate/20150514175710_create_attempts.rb
+++ b/db/migrate/20150514175710_create_attempts.rb
@@ -1,4 +1,4 @@
-class CreateAttempts < ActiveRecord::Migration
+class CreateAttempts < ActiveRecord::Migration[4.2]
   def change
     create_table :attempts do |t|
       t.integer :confidence, null: false

--- a/db/migrate/20150514195804_add_title_to_question.rb
+++ b/db/migrate/20150514195804_add_title_to_question.rb
@@ -1,4 +1,4 @@
-class AddTitleToQuestion < ActiveRecord::Migration
+class AddTitleToQuestion < ActiveRecord::Migration[4.2]
   def up
     add_column :questions, :title, :string
     backfill_existing_question_titles

--- a/db/migrate/20150519201137_add_has_quiz_access_to_users.rb
+++ b/db/migrate/20150519201137_add_has_quiz_access_to_users.rb
@@ -1,4 +1,4 @@
-class AddHasQuizAccessToUsers < ActiveRecord::Migration
+class AddHasQuizAccessToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :has_quiz_access, :boolean, null: false, default: false
   end

--- a/db/migrate/20150520133739_add_published_flag_to_quizzes.rb
+++ b/db/migrate/20150520133739_add_published_flag_to_quizzes.rb
@@ -1,4 +1,4 @@
-class AddPublishedFlagToQuizzes < ActiveRecord::Migration
+class AddPublishedFlagToQuizzes < ActiveRecord::Migration[4.2]
   def change
     add_column :quizzes, :published, :boolean, null: false, default: false
   end

--- a/db/migrate/20150601224106_add_utm_souce_to_users.rb
+++ b/db/migrate/20150601224106_add_utm_souce_to_users.rb
@@ -1,4 +1,4 @@
-class AddUtmSouceToUsers < ActiveRecord::Migration
+class AddUtmSouceToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :utm_source, :string
   end

--- a/db/migrate/20150611144620_rename_questions_to_flashcards.rb
+++ b/db/migrate/20150611144620_rename_questions_to_flashcards.rb
@@ -1,4 +1,4 @@
-class RenameQuestionsToFlashcards < ActiveRecord::Migration
+class RenameQuestionsToFlashcards < ActiveRecord::Migration[4.2]
   def change
     rename_table :questions, :flashcards
     rename_column :attempts, :question_id, :flashcard_id

--- a/db/migrate/20150611152227_rename_quizzes_to_decks.rb
+++ b/db/migrate/20150611152227_rename_quizzes_to_decks.rb
@@ -1,4 +1,4 @@
-class RenameQuizzesToDecks < ActiveRecord::Migration
+class RenameQuizzesToDecks < ActiveRecord::Migration[4.2]
   def change
     rename_table :quizzes, :decks
 

--- a/db/migrate/20150611152856_rename_has_quiz_access.rb
+++ b/db/migrate/20150611152856_rename_has_quiz_access.rb
@@ -1,4 +1,4 @@
-class RenameHasQuizAccess < ActiveRecord::Migration
+class RenameHasQuizAccess < ActiveRecord::Migration[4.2]
   def change
     rename_column :users, :has_quiz_access, :has_deck_access
   end

--- a/db/migrate/20150611171253_add_completed_welcome_to_users.rb
+++ b/db/migrate/20150611171253_add_completed_welcome_to_users.rb
@@ -1,4 +1,4 @@
-class AddCompletedWelcomeToUsers < ActiveRecord::Migration
+class AddCompletedWelcomeToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :completed_welcome, :boolean, default: false
 

--- a/db/migrate/20150612142911_remove_deck_access_flag.rb
+++ b/db/migrate/20150612142911_remove_deck_access_flag.rb
@@ -1,4 +1,4 @@
-class RemoveDeckAccessFlag < ActiveRecord::Migration
+class RemoveDeckAccessFlag < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :has_deck_access
   end

--- a/db/migrate/20150703154842_create_markers.rb
+++ b/db/migrate/20150703154842_create_markers.rb
@@ -1,4 +1,4 @@
-class CreateMarkers < ActiveRecord::Migration
+class CreateMarkers < ActiveRecord::Migration[4.2]
   def change
     create_table :markers do |t|
       t.string :anchor, null: false

--- a/db/migrate/20150720161005_create_pg_search_documents.rb
+++ b/db/migrate/20150720161005_create_pg_search_documents.rb
@@ -1,4 +1,4 @@
-class CreatePgSearchDocuments < ActiveRecord::Migration
+class CreatePgSearchDocuments < ActiveRecord::Migration[4.2]
   def self.up
     say_with_time("Creating table for pg_search multisearch") do
       create_table :pg_search_documents do |t|

--- a/db/migrate/20150911152034_add_date_user_decided_to_cancel_to_subscriptions.rb
+++ b/db/migrate/20150911152034_add_date_user_decided_to_cancel_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddDateUserDecidedToCancelToSubscriptions < ActiveRecord::Migration
+class AddDateUserDecidedToCancelToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :user_clicked_cancel_button_on, :date
   end

--- a/db/migrate/20150911153011_rename_scheduled_for_cancellation.rb
+++ b/db/migrate/20150911153011_rename_scheduled_for_cancellation.rb
@@ -1,4 +1,4 @@
-class RenameScheduledForCancellation < ActiveRecord::Migration
+class RenameScheduledForCancellation < ActiveRecord::Migration[4.2]
   def change
     rename_column(
       :subscriptions,

--- a/db/migrate/20150915203703_remove_topic_colors.rb
+++ b/db/migrate/20150915203703_remove_topic_colors.rb
@@ -1,4 +1,4 @@
-class RemoveTopicColors < ActiveRecord::Migration
+class RemoveTopicColors < ActiveRecord::Migration[4.2]
   def change
     remove_column :topics, :color
     remove_column :topics, :color_accent

--- a/db/migrate/20150916171213_add_length_in_minutes_to_videos.rb
+++ b/db/migrate/20150916171213_add_length_in_minutes_to_videos.rb
@@ -1,4 +1,4 @@
-class AddLengthInMinutesToVideos < ActiveRecord::Migration
+class AddLengthInMinutesToVideos < ActiveRecord::Migration[4.2]
   def up
     add_column :videos, :length_in_minutes, :integer
 

--- a/db/migrate/20150925173023_drop_mentors.rb
+++ b/db/migrate/20150925173023_drop_mentors.rb
@@ -1,4 +1,4 @@
-class DropMentors < ActiveRecord::Migration
+class DropMentors < ActiveRecord::Migration[4.2]
   def change
     drop_table :mentors
     remove_column :plans, :includes_mentor

--- a/db/migrate/20150929171935_create_latest_attempts.rb
+++ b/db/migrate/20150929171935_create_latest_attempts.rb
@@ -1,4 +1,4 @@
-class CreateLatestAttempts < ActiveRecord::Migration
+class CreateLatestAttempts < ActiveRecord::Migration[4.2]
   def change
     create_view :latest_attempts
   end

--- a/db/migrate/20151001183808_create_slugs.rb
+++ b/db/migrate/20151001183808_create_slugs.rb
@@ -1,4 +1,4 @@
-class CreateSlugs < ActiveRecord::Migration
+class CreateSlugs < ActiveRecord::Migration[4.2]
   def change
     create_view :slugs
   end

--- a/db/migrate/20151009144215_add_flashcards_count_to_decks.rb
+++ b/db/migrate/20151009144215_add_flashcards_count_to_decks.rb
@@ -1,4 +1,4 @@
-class AddFlashcardsCountToDecks < ActiveRecord::Migration
+class AddFlashcardsCountToDecks < ActiveRecord::Migration[4.2]
   def up
     add_column :decks, :flashcards_count, :integer, default: 0
 

--- a/db/migrate/20151019151416_add_accessible_without_subscription_to_video.rb
+++ b/db/migrate/20151019151416_add_accessible_without_subscription_to_video.rb
@@ -1,4 +1,4 @@
-class AddAccessibleWithoutSubscriptionToVideo < ActiveRecord::Migration
+class AddAccessibleWithoutSubscriptionToVideo < ActiveRecord::Migration[4.2]
   def change
     add_column(
       :videos,

--- a/db/migrate/20151021150654_add_title_card_url_to_trails.rb
+++ b/db/migrate/20151021150654_add_title_card_url_to_trails.rb
@@ -1,4 +1,4 @@
-class AddTitleCardUrlToTrails < ActiveRecord::Migration
+class AddTitleCardUrlToTrails < ActiveRecord::Migration[4.2]
   def change
     add_column :trails, :title_card_image, :string, default: ""
   end

--- a/db/migrate/20151104191828_create_beta_offers.rb
+++ b/db/migrate/20151104191828_create_beta_offers.rb
@@ -1,4 +1,4 @@
-class CreateBetaOffers < ActiveRecord::Migration
+class CreateBetaOffers < ActiveRecord::Migration[4.2]
   def change
     create_table :beta_offers do |t|
       t.string :name, null: false

--- a/db/migrate/20151104202628_create_beta_replies.rb
+++ b/db/migrate/20151104202628_create_beta_replies.rb
@@ -1,4 +1,4 @@
-class CreateBetaReplies < ActiveRecord::Migration
+class CreateBetaReplies < ActiveRecord::Migration[4.2]
   def change
     create_table :beta_replies do |t|
       t.belongs_to :offer, index: true, null: false

--- a/db/migrate/20151105180146_add_accepted_to_beta_replies.rb
+++ b/db/migrate/20151105180146_add_accepted_to_beta_replies.rb
@@ -1,4 +1,4 @@
-class AddAcceptedToBetaReplies < ActiveRecord::Migration
+class AddAcceptedToBetaReplies < ActiveRecord::Migration[4.2]
   def change
     add_column :beta_replies, :accepted, :boolean
     change_column_null :beta_replies, :accepted, false, true

--- a/db/migrate/20151112165425_add_active_to_beta_offers.rb
+++ b/db/migrate/20151112165425_add_active_to_beta_offers.rb
@@ -1,4 +1,4 @@
-class AddActiveToBetaOffers < ActiveRecord::Migration
+class AddActiveToBetaOffers < ActiveRecord::Migration[4.2]
   def change
     add_column :beta_offers, :active, :boolean, default: true, null: false
   end

--- a/db/migrate/20151118203141_add_page_title_to_topics.rb
+++ b/db/migrate/20151118203141_add_page_title_to_topics.rb
@@ -1,4 +1,4 @@
-class AddPageTitleToTopics < ActiveRecord::Migration
+class AddPageTitleToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :page_title, :string
 

--- a/db/migrate/20160104184621_add_extended_description_to_trails.rb
+++ b/db/migrate/20160104184621_add_extended_description_to_trails.rb
@@ -1,4 +1,4 @@
-class AddExtendedDescriptionToTrails < ActiveRecord::Migration
+class AddExtendedDescriptionToTrails < ActiveRecord::Migration[4.2]
   def change
     add_column :trails, :extended_description, :text
   end

--- a/db/migrate/20160104200900_add_extended_description_to_topics.rb
+++ b/db/migrate/20160104200900_add_extended_description_to_topics.rb
@@ -1,4 +1,4 @@
-class AddExtendedDescriptionToTopics < ActiveRecord::Migration
+class AddExtendedDescriptionToTopics < ActiveRecord::Migration[4.2]
   def change
     add_column :topics, :extended_description, :text
   end

--- a/db/migrate/20160308205404_add_meta_descriptions.rb
+++ b/db/migrate/20160308205404_add_meta_descriptions.rb
@@ -1,4 +1,4 @@
-class AddMetaDescriptions < ActiveRecord::Migration
+class AddMetaDescriptions < ActiveRecord::Migration[4.2]
   def change
     [:products, :trails, :topics, :videos].each do |table_name|
       add_column table_name, :meta_description, :text, default: "", null: false

--- a/db/migrate/20160309033100_add_page_titles_to_content_models.rb
+++ b/db/migrate/20160309033100_add_page_titles_to_content_models.rb
@@ -1,4 +1,4 @@
-class AddPageTitlesToContentModels < ActiveRecord::Migration
+class AddPageTitlesToContentModels < ActiveRecord::Migration[4.2]
   def change
     [:products, :trails, :videos].each do |table_name|
       add_column table_name, :page_title, :text, default: "", null: false

--- a/db/migrate/20160309200016_remove_keywords_from_topics.rb
+++ b/db/migrate/20160309200016_remove_keywords_from_topics.rb
@@ -1,4 +1,4 @@
-class RemoveKeywordsFromTopics < ActiveRecord::Migration
+class RemoveKeywordsFromTopics < ActiveRecord::Migration[4.2]
   def change
     remove_column :topics, :keywords, :string
   end

--- a/db/migrate/20160601181617_add_promoted_to_trails.rb
+++ b/db/migrate/20160601181617_add_promoted_to_trails.rb
@@ -1,4 +1,4 @@
-class AddPromotedToTrails < ActiveRecord::Migration
+class AddPromotedToTrails < ActiveRecord::Migration[4.2]
   def change
     add_column :trails, :promoted, :boolean, null: false, default: false
   end

--- a/db/migrate/20160601215621_remove_topic_from_trails.rb
+++ b/db/migrate/20160601215621_remove_topic_from_trails.rb
@@ -1,4 +1,4 @@
-class RemoveTopicFromTrails < ActiveRecord::Migration
+class RemoveTopicFromTrails < ActiveRecord::Migration[4.2]
   def up
     remove_column :trails, :topic_id
   end

--- a/db/migrate/20160727183445_create_content_recommendations.rb
+++ b/db/migrate/20160727183445_create_content_recommendations.rb
@@ -1,4 +1,4 @@
-class CreateContentRecommendations < ActiveRecord::Migration
+class CreateContentRecommendations < ActiveRecord::Migration[4.2]
   def change
     create_table :content_recommendations do |t|
       t.references :user, index: true, foreign_key: true, null: false

--- a/db/migrate/20160803180148_create_recommendable_contents.rb
+++ b/db/migrate/20160803180148_create_recommendable_contents.rb
@@ -1,4 +1,4 @@
-class CreateRecommendableContents < ActiveRecord::Migration
+class CreateRecommendableContents < ActiveRecord::Migration[4.2]
   def change
     create_table :recommendable_contents do |t|
       t.integer :recommendable_id, null: false

--- a/db/migrate/20160804181146_add_unsubscribed_from_emails_to_user.rb
+++ b/db/migrate/20160804181146_add_unsubscribed_from_emails_to_user.rb
@@ -1,4 +1,4 @@
-class AddUnsubscribedFromEmailsToUser < ActiveRecord::Migration
+class AddUnsubscribedFromEmailsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column(
       :users,

--- a/db/migrate/20161025154304_add_mailer_fields_to_videos.rb
+++ b/db/migrate/20161025154304_add_mailer_fields_to_videos.rb
@@ -1,4 +1,4 @@
-class AddMailerFieldsToVideos < ActiveRecord::Migration
+class AddMailerFieldsToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :email_subject, :string
     add_column :videos, :email_body_text, :string

--- a/db/migrate/20161028180937_change_body_to_text.rb
+++ b/db/migrate/20161028180937_change_body_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeBodyToText < ActiveRecord::Migration
+class ChangeBodyToText < ActiveRecord::Migration[4.2]
   def up
     change_column :videos, :email_body_text, :text
   end

--- a/db/migrate/20170223155849_add_scheduled_for_reactivation_on_to_subscriptions.rb
+++ b/db/migrate/20170223155849_add_scheduled_for_reactivation_on_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddScheduledForReactivationOnToSubscriptions < ActiveRecord::Migration
+class AddScheduledForReactivationOnToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :scheduled_for_reactivation_on, :date
   end

--- a/db/migrate/20170302213159_add_reactivated_on_to_subscriptions.rb
+++ b/db/migrate/20170302213159_add_reactivated_on_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddReactivatedOnToSubscriptions < ActiveRecord::Migration
+class AddReactivatedOnToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :reactivated_on, :date
   end

--- a/db/migrate/20180604170303_add_indexes_to_checkouts.rb
+++ b/db/migrate/20180604170303_add_indexes_to_checkouts.rb
@@ -1,4 +1,4 @@
-class AddIndexesToCheckouts < ActiveRecord::Migration
+class AddIndexesToCheckouts < ActiveRecord::Migration[4.2]
   def change
     add_index :checkouts, :plan_id
   end

--- a/db/migrate/20180604170309_add_indexes_to_classifications.rb
+++ b/db/migrate/20180604170309_add_indexes_to_classifications.rb
@@ -1,4 +1,4 @@
-class AddIndexesToClassifications < ActiveRecord::Migration
+class AddIndexesToClassifications < ActiveRecord::Migration[4.2]
   def change
     add_index :classifications, :topic_id
     add_index :classifications, [:classifiable_id, :classifiable_type]

--- a/db/migrate/20180604170315_add_indexes_to_invitations.rb
+++ b/db/migrate/20180604170315_add_indexes_to_invitations.rb
@@ -1,4 +1,4 @@
-class AddIndexesToInvitations < ActiveRecord::Migration
+class AddIndexesToInvitations < ActiveRecord::Migration[4.2]
   def change
     add_index :invitations, :sender_id
     add_index :invitations, :recipient_id

--- a/db/migrate/20180604170322_add_indexes_to_teams.rb
+++ b/db/migrate/20180604170322_add_indexes_to_teams.rb
@@ -1,4 +1,4 @@
-class AddIndexesToTeams < ActiveRecord::Migration
+class AddIndexesToTeams < ActiveRecord::Migration[4.2]
   def change
     add_index :teams, :subscription_id
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -17,484 +16,451 @@ ActiveRecord::Schema.define(version: 20180604170322) do
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
 
-  create_table "attempts", force: :cascade do |t|
-    t.integer  "confidence",   null: false
-    t.integer  "flashcard_id", null: false
-    t.integer  "user_id",      null: false
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
-  add_index "attempts", ["flashcard_id"], name: "index_attempts_on_flashcard_id", using: :btree
-  add_index "attempts", ["user_id"], name: "index_attempts_on_user_id", using: :btree
-
-  create_table "beta_offers", force: :cascade do |t|
-    t.string   "name",                       null: false
-    t.text     "description",                null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.boolean  "active",      default: true, null: false
-  end
-
-  create_table "beta_replies", force: :cascade do |t|
-    t.integer  "offer_id",   null: false
-    t.integer  "user_id",    null: false
+  create_table "attempts", id: :serial, force: :cascade do |t|
+    t.integer "confidence", null: false
+    t.integer "flashcard_id", null: false
+    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean  "accepted",   null: false
+    t.index ["flashcard_id"], name: "index_attempts_on_flashcard_id"
+    t.index ["user_id"], name: "index_attempts_on_user_id"
   end
 
-  add_index "beta_replies", ["offer_id", "user_id"], name: "index_beta_replies_on_offer_id_and_user_id", unique: true, using: :btree
-  add_index "beta_replies", ["offer_id"], name: "index_beta_replies_on_offer_id", using: :btree
-  add_index "beta_replies", ["user_id"], name: "index_beta_replies_on_user_id", using: :btree
+  create_table "beta_offers", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "active", default: true, null: false
+  end
 
-  create_table "checkouts", force: :cascade do |t|
-    t.integer  "user_id",                      null: false
-    t.integer  "plan_id",                      null: false
-    t.string   "stripe_coupon_id", limit: 255
+  create_table "beta_replies", id: :serial, force: :cascade do |t|
+    t.integer "offer_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "accepted", null: false
+    t.index ["offer_id", "user_id"], name: "index_beta_replies_on_offer_id_and_user_id", unique: true
+    t.index ["offer_id"], name: "index_beta_replies_on_offer_id"
+    t.index ["user_id"], name: "index_beta_replies_on_user_id"
+  end
+
+  create_table "checkouts", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "plan_id", null: false
+    t.string "stripe_coupon_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["plan_id"], name: "index_checkouts_on_plan_id"
+    t.index ["user_id"], name: "index_checkouts_on_user_id"
   end
 
-  add_index "checkouts", ["plan_id"], name: "index_checkouts_on_plan_id", using: :btree
-  add_index "checkouts", ["user_id"], name: "index_checkouts_on_user_id", using: :btree
-
-  create_table "classifications", force: :cascade do |t|
-    t.integer  "topic_id"
-    t.string   "classifiable_type", limit: 255
-    t.integer  "classifiable_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+  create_table "classifications", id: :serial, force: :cascade do |t|
+    t.integer "topic_id"
+    t.string "classifiable_type"
+    t.integer "classifiable_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["classifiable_id", "classifiable_type"], name: "index_classifications_on_classifiable_id_and_classifiable_type"
+    t.index ["topic_id"], name: "index_classifications_on_topic_id"
   end
 
-  add_index "classifications", ["classifiable_id", "classifiable_type"], name: "index_classifications_on_classifiable_id_and_classifiable_type", using: :btree
-  add_index "classifications", ["topic_id"], name: "index_classifications_on_topic_id", using: :btree
-
-  create_table "collaborations", force: :cascade do |t|
-    t.integer  "repository_id", null: false
-    t.integer  "user_id",       null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+  create_table "collaborations", id: :serial, force: :cascade do |t|
+    t.integer "repository_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id", "user_id"], name: "index_collaborations_on_repository_id_and_user_id", unique: true
   end
 
-  add_index "collaborations", ["repository_id", "user_id"], name: "index_collaborations_on_repository_id_and_user_id", unique: true, using: :btree
-
-  create_table "content_recommendations", force: :cascade do |t|
-    t.integer  "user_id",            null: false
-    t.integer  "recommendable_id",   null: false
-    t.string   "recommendable_type", null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+  create_table "content_recommendations", id: :serial, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "recommendable_type", null: false
+    t.integer "recommendable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "recommendable_type", "recommendable_id"], name: "index_content_recommendations_on_recommendable_and_user", unique: true
+    t.index ["user_id"], name: "index_content_recommendations_on_user_id"
   end
 
-  add_index "content_recommendations", ["user_id", "recommendable_type", "recommendable_id"], name: "index_content_recommendations_on_recommendable_and_user", unique: true, using: :btree
-  add_index "content_recommendations", ["user_id"], name: "index_content_recommendations_on_user_id", using: :btree
-
-  create_table "decks", force: :cascade do |t|
-    t.string   "title",                            null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.boolean  "published",        default: false, null: false
-    t.integer  "flashcards_count", default: 0
+  create_table "decks", id: :serial, force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "published", default: false, null: false
+    t.integer "flashcards_count", default: 0
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",               default: 0
-    t.integer  "attempts",               default: 0
-    t.text     "handler"
-    t.text     "last_error"
+  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
+    t.integer "priority", default: 0
+    t.integer "attempts", default: 0
+    t.text "handler"
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by",  limit: 255
-    t.string   "queue",      limit: 255
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-  end
-
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
-
-  create_table "exercises", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.string   "url",        limit: 255, null: false
-    t.text     "summary",                null: false
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "uuid",       limit: 255, null: false
-    t.string   "edit_url",   limit: 255
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  add_index "exercises", ["uuid"], name: "index_exercises_on_uuid", unique: true, using: :btree
+  create_table "exercises", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "url", null: false
+    t.text "summary", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "uuid", null: false
+    t.string "edit_url"
+    t.index ["uuid"], name: "index_exercises_on_uuid", unique: true
+  end
 
-  create_table "flashcards", force: :cascade do |t|
-    t.text     "prompt",     null: false
-    t.text     "answer",     null: false
-    t.integer  "position",   null: false
-    t.integer  "deck_id",    null: false
+  create_table "flashcards", id: :serial, force: :cascade do |t|
+    t.text "prompt", null: false
+    t.text "answer", null: false
+    t.integer "position", null: false
+    t.integer "deck_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "title",      null: false
+    t.string "title", null: false
+    t.index ["deck_id"], name: "index_flashcards_on_deck_id"
   end
 
-  add_index "flashcards", ["deck_id"], name: "index_flashcards_on_deck_id", using: :btree
-
-  create_table "invitations", force: :cascade do |t|
-    t.string   "email",        limit: 255, null: false
-    t.string   "code",         limit: 255, null: false
+  create_table "invitations", id: :serial, force: :cascade do |t|
+    t.string "email", null: false
+    t.string "code", null: false
     t.datetime "accepted_at"
-    t.integer  "sender_id",                null: false
-    t.integer  "recipient_id"
-    t.integer  "team_id",                  null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-  end
-
-  add_index "invitations", ["code"], name: "index_invitations_on_code", using: :btree
-  add_index "invitations", ["recipient_id"], name: "index_invitations_on_recipient_id", using: :btree
-  add_index "invitations", ["sender_id"], name: "index_invitations_on_sender_id", using: :btree
-  add_index "invitations", ["team_id"], name: "index_invitations_on_team_id", using: :btree
-
-  create_table "markers", force: :cascade do |t|
-    t.string   "anchor",     null: false
-    t.integer  "time",       null: false
-    t.integer  "video_id",   null: false
+    t.integer "sender_id", null: false
+    t.integer "recipient_id"
+    t.integer "team_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_invitations_on_code"
+    t.index ["recipient_id"], name: "index_invitations_on_recipient_id"
+    t.index ["sender_id"], name: "index_invitations_on_sender_id"
+    t.index ["team_id"], name: "index_invitations_on_team_id"
   end
 
-  add_index "markers", ["video_id"], name: "index_markers_on_video_id", using: :btree
+  create_table "markers", id: :serial, force: :cascade do |t|
+    t.string "anchor", null: false
+    t.integer "time", null: false
+    t.integer "video_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["video_id"], name: "index_markers_on_video_id"
+  end
 
-  create_table "oauth_access_grants", force: :cascade do |t|
-    t.integer  "resource_owner_id",             null: false
-    t.integer  "application_id",                null: false
-    t.string   "token",             limit: 255, null: false
-    t.integer  "expires_in",                    null: false
-    t.string   "redirect_uri",      limit: 255, null: false
-    t.datetime "created_at",                    null: false
+  create_table "oauth_access_grants", id: :serial, force: :cascade do |t|
+    t.integer "resource_owner_id", null: false
+    t.integer "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.string "redirect_uri", null: false
+    t.datetime "created_at", null: false
     t.datetime "revoked_at"
-    t.string   "scopes",            limit: 255
+    t.string "scopes"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
-
-  create_table "oauth_access_tokens", force: :cascade do |t|
-    t.integer  "resource_owner_id"
-    t.integer  "application_id",                null: false
-    t.string   "token",             limit: 255, null: false
-    t.string   "refresh_token",     limit: 255
-    t.integer  "expires_in"
+  create_table "oauth_access_tokens", id: :serial, force: :cascade do |t|
+    t.integer "resource_owner_id"
+    t.integer "application_id", null: false
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",                    null: false
-    t.string   "scopes",            limit: 255
+    t.datetime "created_at", null: false
+    t.string "scopes"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
-  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
-
-  create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",         limit: 255,              null: false
-    t.string   "uid",          limit: 255,              null: false
-    t.string   "secret",       limit: 255,              null: false
-    t.string   "redirect_uri", limit: 255,              null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.string   "scopes",       limit: 255, default: "", null: false
-  end
-
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
-
-  create_table "pg_search_documents", force: :cascade do |t|
-    t.text     "content"
-    t.integer  "searchable_id"
-    t.string   "searchable_type"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-  end
-
-  add_index "pg_search_documents", ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id", using: :btree
-
-  create_table "plans", force: :cascade do |t|
-    t.string   "name",                  limit: 255,                 null: false
-    t.string   "sku",                   limit: 255,                 null: false
-    t.string   "short_description",     limit: 255,                 null: false
-    t.text     "description",                                       null: false
-    t.boolean  "active",                            default: true,  null: false
-    t.integer  "price_in_dollars",                                  null: false
-    t.text     "terms"
-    t.boolean  "featured",                          default: false, null: false
-    t.datetime "created_at",                                        null: false
-    t.datetime "updated_at",                                        null: false
-    t.boolean  "includes_repositories",             default: true,  null: false
-    t.boolean  "includes_forum",                    default: true,  null: false
-    t.boolean  "includes_shows",                    default: true,  null: false
-    t.boolean  "includes_team",                     default: false, null: false
-    t.boolean  "annual",                            default: false
-    t.integer  "annual_plan_id"
-    t.integer  "minimum_quantity",                  default: 1,     null: false
-    t.boolean  "includes_trails",                   default: false, null: false
-  end
-
-  add_index "plans", ["annual_plan_id"], name: "index_plans_on_annual_plan_id", using: :btree
-
-  create_table "products", force: :cascade do |t|
-    t.string   "name",                       limit: 255
-    t.string   "sku",                        limit: 255
-    t.string   "tagline",                    limit: 255
-    t.string   "call_to_action",             limit: 255
-    t.string   "short_description",          limit: 255
-    t.text     "description"
-    t.string   "type",                       limit: 255,                 null: false
-    t.boolean  "active",                                 default: true,  null: false
+  create_table "oauth_applications", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.string "redirect_uri", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "github_url",                 limit: 255
-    t.text     "questions"
-    t.text     "terms"
-    t.text     "alternative_description"
-    t.string   "product_image_file_name",    limit: 255
-    t.string   "product_image_file_size",    limit: 255
-    t.string   "product_image_content_type", limit: 255
-    t.string   "product_image_updated_at",   limit: 255
-    t.boolean  "promoted",                               default: false, null: false
-    t.string   "slug",                       limit: 255,                 null: false
-    t.text     "resources",                              default: "",    null: false
-    t.string   "github_repository"
-    t.integer  "trail_id"
-    t.text     "meta_description",                       default: "",    null: false
-    t.text     "page_title",                             default: "",    null: false
+    t.string "scopes", default: "", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  add_index "products", ["slug"], name: "index_products_on_slug", unique: true, using: :btree
-  add_index "products", ["trail_id"], name: "index_products_on_trail_id", using: :btree
-
-  create_table "rails_admin_histories", force: :cascade do |t|
-    t.text     "message"
-    t.string   "username",   limit: 255
-    t.integer  "item"
-    t.string   "table",      limit: 255
-    t.integer  "month",      limit: 2
-    t.integer  "year",       limit: 8
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+  create_table "pg_search_documents", id: :serial, force: :cascade do |t|
+    t.text "content"
+    t.string "searchable_type"
+    t.integer "searchable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
   end
 
-  add_index "rails_admin_histories", ["item", "table", "month", "year"], name: "index_rails_admin_histories", using: :btree
-
-  create_table "recommendable_contents", force: :cascade do |t|
-    t.integer  "recommendable_id",   null: false
-    t.string   "recommendable_type", null: false
-    t.integer  "position",           null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-  end
-
-  add_index "recommendable_contents", ["recommendable_type", "recommendable_id"], name: "rec_contents_on_rec_type_rec_id", using: :btree
-
-  create_table "statuses", force: :cascade do |t|
-    t.integer  "completeable_id",                                       null: false
-    t.integer  "user_id",                                               null: false
-    t.string   "state",             limit: 255, default: "In Progress", null: false
+  create_table "plans", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "sku", null: false
+    t.string "short_description", null: false
+    t.text "description", null: false
+    t.boolean "active", default: true, null: false
+    t.integer "price_in_dollars", null: false
+    t.text "terms"
+    t.boolean "featured", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "completeable_type", limit: 255,                         null: false
+    t.boolean "includes_repositories", default: true, null: false
+    t.boolean "includes_forum", default: true, null: false
+    t.boolean "includes_shows", default: true, null: false
+    t.boolean "includes_team", default: false, null: false
+    t.boolean "annual", default: false
+    t.integer "annual_plan_id"
+    t.integer "minimum_quantity", default: 1, null: false
+    t.boolean "includes_trails", default: false, null: false
+    t.index ["annual_plan_id"], name: "index_plans_on_annual_plan_id"
   end
 
-  add_index "statuses", ["completeable_id"], name: "index_statuses_on_completeable_id", using: :btree
-  add_index "statuses", ["completeable_type"], name: "index_statuses_on_completeable_type", using: :btree
-  add_index "statuses", ["user_id"], name: "index_statuses_on_user_id", using: :btree
-
-  create_table "steps", force: :cascade do |t|
-    t.integer  "trail_id",          null: false
-    t.integer  "completeable_id",   null: false
-    t.integer  "position",          null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.string   "completeable_type", null: false
+  create_table "products", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "sku"
+    t.string "tagline"
+    t.string "call_to_action"
+    t.string "short_description"
+    t.text "description"
+    t.string "type", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "github_url"
+    t.text "questions"
+    t.text "terms"
+    t.text "alternative_description"
+    t.string "product_image_file_name"
+    t.string "product_image_file_size"
+    t.string "product_image_content_type"
+    t.string "product_image_updated_at"
+    t.boolean "promoted", default: false, null: false
+    t.string "slug", null: false
+    t.text "resources", default: "", null: false
+    t.string "github_repository"
+    t.integer "trail_id"
+    t.text "meta_description", default: "", null: false
+    t.text "page_title", default: "", null: false
+    t.index ["slug"], name: "index_products_on_slug", unique: true
+    t.index ["trail_id"], name: "index_products_on_trail_id"
   end
 
-  add_index "steps", ["trail_id", "completeable_id", "completeable_type"], name: "index_steps_on_trail_and_completeable_unique", unique: true, using: :btree
-  add_index "steps", ["trail_id", "position"], name: "index_steps_on_trail_id_and_position", using: :btree
-
-  create_table "subscriptions", force: :cascade do |t|
-    t.integer  "user_id"
-    t.datetime "created_at",                                                           null: false
-    t.datetime "updated_at",                                                           null: false
-    t.date     "deactivated_on"
-    t.date     "scheduled_for_deactivation_on"
-    t.integer  "plan_id",                                                              null: false
-    t.string   "plan_type",                     limit: 255, default: "IndividualPlan", null: false
-    t.decimal  "next_payment_amount",                       default: 0.0,              null: false
-    t.date     "next_payment_on"
-    t.string   "stripe_id",                     limit: 255
-    t.date     "user_clicked_cancel_button_on"
-    t.date     "scheduled_for_reactivation_on"
-    t.date     "reactivated_on"
+  create_table "rails_admin_histories", id: :serial, force: :cascade do |t|
+    t.text "message"
+    t.string "username"
+    t.integer "item"
+    t.string "table"
+    t.integer "month", limit: 2
+    t.bigint "year"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["item", "table", "month", "year"], name: "index_rails_admin_histories"
   end
 
-  add_index "subscriptions", ["plan_id", "plan_type"], name: "index_subscriptions_on_plan_id_and_plan_type", using: :btree
-  add_index "subscriptions", ["stripe_id"], name: "index_subscriptions_on_stripe_id", using: :btree
-  add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
+  create_table "recommendable_contents", id: :serial, force: :cascade do |t|
+    t.integer "recommendable_id", null: false
+    t.string "recommendable_type", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recommendable_type", "recommendable_id"], name: "rec_contents_on_rec_type_rec_id"
+  end
 
-  create_table "teachers", force: :cascade do |t|
+  create_table "statuses", id: :serial, force: :cascade do |t|
+    t.integer "completeable_id", null: false
+    t.integer "user_id", null: false
+    t.string "state", default: "In Progress", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "completeable_type", null: false
+    t.index ["completeable_id"], name: "index_statuses_on_completeable_id"
+    t.index ["completeable_type"], name: "index_statuses_on_completeable_type"
+    t.index ["user_id"], name: "index_statuses_on_user_id"
+  end
+
+  create_table "steps", id: :serial, force: :cascade do |t|
+    t.integer "trail_id", null: false
+    t.integer "completeable_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "completeable_type", null: false
+    t.index ["trail_id", "completeable_id", "completeable_type"], name: "index_steps_on_trail_and_completeable_unique", unique: true
+    t.index ["trail_id", "position"], name: "index_steps_on_trail_id_and_position"
+  end
+
+  create_table "subscriptions", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.date "deactivated_on"
+    t.date "scheduled_for_deactivation_on"
+    t.integer "plan_id", null: false
+    t.string "plan_type", default: "IndividualPlan", null: false
+    t.decimal "next_payment_amount", default: "0.0", null: false
+    t.date "next_payment_on"
+    t.string "stripe_id"
+    t.date "user_clicked_cancel_button_on"
+    t.date "scheduled_for_reactivation_on"
+    t.date "reactivated_on"
+    t.index ["plan_id", "plan_type"], name: "index_subscriptions_on_plan_id_and_plan_type"
+    t.index ["stripe_id"], name: "index_subscriptions_on_stripe_id"
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
+  create_table "teachers", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "video_id"
+    t.index ["user_id", "video_id"], name: "index_teachers_on_user_id_and_video_id", unique: true
   end
 
-  add_index "teachers", ["user_id", "video_id"], name: "index_teachers_on_user_id_and_video_id", unique: true, using: :btree
-
-  create_table "teams", force: :cascade do |t|
-    t.string   "name",            limit: 255, null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "subscription_id",             null: false
-  end
-
-  add_index "teams", ["subscription_id"], name: "index_teams_on_subscription_id", using: :btree
-
-  create_table "topics", force: :cascade do |t|
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "name",                 limit: 255,                 null: false
-    t.string   "slug",                 limit: 255,                 null: false
-    t.text     "summary"
-    t.boolean  "explorable",                       default: false, null: false
-    t.string   "page_title",                                       null: false
-    t.text     "extended_description"
-    t.text     "meta_description",                 default: "",    null: false
-  end
-
-  add_index "topics", ["explorable"], name: "index_topics_on_explorable", using: :btree
-  add_index "topics", ["slug"], name: "index_topics_on_slug", unique: true, using: :btree
-
-  create_table "trails", force: :cascade do |t|
-    t.string   "name",                 limit: 255,                 null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "complete_text",        limit: 255,                 null: false
-    t.boolean  "published",                        default: false, null: false
-    t.string   "slug",                 limit: 255,                 null: false
-    t.text     "description",                      default: "",    null: false
-    t.string   "title_card_image",                 default: ""
-    t.text     "extended_description"
-    t.text     "meta_description",                 default: "",    null: false
-    t.text     "page_title",                       default: "",    null: false
-    t.boolean  "promoted",                         default: false, null: false
-  end
-
-  add_index "trails", ["published"], name: "index_trails_on_published", using: :btree
-  add_index "trails", ["slug"], name: "index_trails_on_slug", unique: true, using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                    limit: 255
-    t.string   "encrypted_password",       limit: 128
-    t.string   "salt",                     limit: 128
-    t.string   "confirmation_token",       limit: 128
-    t.string   "remember_token",           limit: 128
-    t.boolean  "email_confirmed",                      default: true,  null: false
+  create_table "teams", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "reference",                limit: 255
-    t.boolean  "admin",                                default: false, null: false
-    t.string   "stripe_customer_id",       limit: 255, default: "",    null: false
-    t.string   "github_username",                                      null: false
-    t.string   "auth_provider",            limit: 255
-    t.integer  "auth_uid"
-    t.string   "organization",             limit: 255
-    t.string   "address1",                 limit: 255
-    t.string   "address2",                 limit: 255
-    t.string   "city",                     limit: 255
-    t.string   "state",                    limit: 255
-    t.string   "zip_code",                 limit: 255
-    t.string   "country",                  limit: 255
-    t.string   "name",                     limit: 255
-    t.text     "bio"
-    t.integer  "team_id"
-    t.string   "utm_source"
-    t.boolean  "completed_welcome",                    default: false, null: false
-    t.boolean  "unsubscribed_from_emails",             default: false, null: false
+    t.integer "subscription_id", null: false
+    t.index ["subscription_id"], name: "index_teams_on_subscription_id"
   end
 
-  add_index "users", ["admin"], name: "index_users_on_admin", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", using: :btree
-  add_index "users", ["github_username"], name: "index_users_on_github_username", unique: true, using: :btree
-  add_index "users", ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token", using: :btree
-  add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
-  add_index "users", ["team_id"], name: "index_users_on_team_id", using: :btree
+  create_table "topics", id: :serial, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.text "summary"
+    t.boolean "explorable", default: false, null: false
+    t.string "page_title", null: false
+    t.text "extended_description"
+    t.text "meta_description", default: "", null: false
+    t.index ["explorable"], name: "index_topics_on_explorable"
+    t.index ["slug"], name: "index_topics_on_slug", unique: true
+  end
 
-  create_table "vanity_conversions", force: :cascade do |t|
+  create_table "trails", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "complete_text", null: false
+    t.boolean "published", default: false, null: false
+    t.string "slug", null: false
+    t.text "description", default: "", null: false
+    t.string "title_card_image", default: ""
+    t.text "extended_description"
+    t.text "meta_description", default: "", null: false
+    t.text "page_title", default: "", null: false
+    t.boolean "promoted", default: false, null: false
+    t.index ["published"], name: "index_trails_on_published"
+    t.index ["slug"], name: "index_trails_on_slug", unique: true
+  end
+
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email"
+    t.string "encrypted_password", limit: 128
+    t.string "salt", limit: 128
+    t.string "confirmation_token", limit: 128
+    t.string "remember_token", limit: 128
+    t.boolean "email_confirmed", default: true, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "reference", default: ""
+    t.boolean "admin", default: false, null: false
+    t.string "stripe_customer_id", default: "", null: false
+    t.string "github_username", null: false
+    t.string "auth_provider"
+    t.integer "auth_uid"
+    t.string "organization"
+    t.string "address1"
+    t.string "address2"
+    t.string "city"
+    t.string "state"
+    t.string "zip_code"
+    t.string "country"
+    t.string "name"
+    t.text "bio"
+    t.integer "team_id"
+    t.string "utm_source"
+    t.boolean "completed_welcome", default: false, null: false
+    t.boolean "unsubscribed_from_emails", default: false, null: false
+    t.index ["admin"], name: "index_users_on_admin"
+    t.index ["email"], name: "index_users_on_email"
+    t.index ["github_username"], name: "index_users_on_github_username", unique: true
+    t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"
+    t.index ["remember_token"], name: "index_users_on_remember_token"
+    t.index ["team_id"], name: "index_users_on_team_id"
+  end
+
+  create_table "vanity_conversions", id: :serial, force: :cascade do |t|
     t.integer "vanity_experiment_id"
     t.integer "alternative"
     t.integer "conversions"
+    t.index ["vanity_experiment_id", "alternative"], name: "by_experiment_id_and_alternative"
   end
 
-  add_index "vanity_conversions", ["vanity_experiment_id", "alternative"], name: "by_experiment_id_and_alternative", using: :btree
-
-  create_table "vanity_experiments", force: :cascade do |t|
-    t.string   "experiment_id"
-    t.integer  "outcome"
+  create_table "vanity_experiments", id: :serial, force: :cascade do |t|
+    t.string "experiment_id"
+    t.integer "outcome"
     t.datetime "created_at"
     t.datetime "completed_at"
+    t.index ["experiment_id"], name: "index_vanity_experiments_on_experiment_id"
   end
 
-  add_index "vanity_experiments", ["experiment_id"], name: "index_vanity_experiments_on_experiment_id", using: :btree
-
-  create_table "vanity_metric_values", force: :cascade do |t|
+  create_table "vanity_metric_values", id: :serial, force: :cascade do |t|
     t.integer "vanity_metric_id"
     t.integer "index"
     t.integer "value"
-    t.string  "date"
+    t.string "date"
+    t.index ["vanity_metric_id"], name: "index_vanity_metric_values_on_vanity_metric_id"
   end
 
-  add_index "vanity_metric_values", ["vanity_metric_id"], name: "index_vanity_metric_values_on_vanity_metric_id", using: :btree
-
-  create_table "vanity_metrics", force: :cascade do |t|
-    t.string   "metric_id"
+  create_table "vanity_metrics", id: :serial, force: :cascade do |t|
+    t.string "metric_id"
     t.datetime "updated_at"
+    t.index ["metric_id"], name: "index_vanity_metrics_on_metric_id"
   end
 
-  add_index "vanity_metrics", ["metric_id"], name: "index_vanity_metrics_on_metric_id", using: :btree
-
-  create_table "vanity_participants", force: :cascade do |t|
-    t.string   "experiment_id"
-    t.string   "identity"
-    t.integer  "shown"
-    t.integer  "seen"
-    t.integer  "converted"
+  create_table "vanity_participants", id: :serial, force: :cascade do |t|
+    t.string "experiment_id"
+    t.string "identity"
+    t.integer "shown"
+    t.integer "seen"
+    t.integer "converted"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["experiment_id", "converted"], name: "by_experiment_id_and_converted"
+    t.index ["experiment_id", "identity"], name: "by_experiment_id_and_identity"
+    t.index ["experiment_id", "seen"], name: "by_experiment_id_and_seen"
+    t.index ["experiment_id", "shown"], name: "by_experiment_id_and_shown"
+    t.index ["experiment_id"], name: "index_vanity_participants_on_experiment_id"
   end
 
-  add_index "vanity_participants", ["experiment_id", "converted"], name: "by_experiment_id_and_converted", using: :btree
-  add_index "vanity_participants", ["experiment_id", "identity"], name: "by_experiment_id_and_identity", using: :btree
-  add_index "vanity_participants", ["experiment_id", "seen"], name: "by_experiment_id_and_seen", using: :btree
-  add_index "vanity_participants", ["experiment_id", "shown"], name: "by_experiment_id_and_shown", using: :btree
-  add_index "vanity_participants", ["experiment_id"], name: "index_vanity_participants_on_experiment_id", using: :btree
-
-  create_table "videos", force: :cascade do |t|
-    t.integer  "watchable_id"
-    t.string   "wistia_id",                       limit: 255
-    t.string   "name",                            limit: 255
-    t.datetime "created_at",                                                  null: false
-    t.datetime "updated_at",                                                  null: false
-    t.string   "watchable_type",                  limit: 255
-    t.integer  "position",                                    default: 0,     null: false
-    t.text     "notes"
-    t.date     "published_on"
-    t.string   "preview_wistia_id",               limit: 255
-    t.string   "slug",                            limit: 255,                 null: false
-    t.text     "summary"
-    t.integer  "length_in_minutes"
-    t.boolean  "accessible_without_subscription",             default: false
-    t.text     "meta_description",                            default: "",    null: false
-    t.text     "page_title",                                  default: "",    null: false
-    t.string   "email_subject"
-    t.text     "email_body_text"
-    t.string   "email_cta_label"
+  create_table "videos", id: :serial, force: :cascade do |t|
+    t.integer "watchable_id"
+    t.string "wistia_id"
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "watchable_type"
+    t.integer "position", default: 0, null: false
+    t.text "notes"
+    t.date "published_on"
+    t.string "preview_wistia_id"
+    t.string "slug", null: false
+    t.text "summary"
+    t.integer "length_in_minutes"
+    t.boolean "accessible_without_subscription", default: false
+    t.text "meta_description", default: "", null: false
+    t.text "page_title", default: "", null: false
+    t.string "email_subject"
+    t.text "email_body_text"
+    t.string "email_cta_label"
+    t.index ["slug"], name: "index_videos_on_slug", unique: true
+    t.index ["watchable_type", "watchable_id"], name: "index_videos_on_watchable_type_and_watchable_id"
   end
-
-  add_index "videos", ["slug"], name: "index_videos_on_slug", unique: true, using: :btree
-  add_index "videos", ["watchable_type", "watchable_id"], name: "index_videos_on_watchable_type_and_watchable_id", using: :btree
 
   add_foreign_key "attempts", "flashcards", on_delete: :cascade
   add_foreign_key "attempts", "users", on_delete: :cascade


### PR DESCRIPTION
As of Rails 5, migrations must specify a version when inheriting from
ActiveRecord::Migration. This change updates all existing migrations to
that syntax.

In addition, the schema.rb has changed significantly related to no
longer trying to line up columns and other syntactic changes. The
updated schema.rb is included here as well. It _should_ be functionally
identical to the previous version.