### PR TITLE
Update Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "recipient_interceptor"
 gem "redcarpet"
 gem "request_store"
 gem "responders", "~> 2.0"
-gem 'sassc'
+gem "sassc"
 gem "scenic"
 gem "sprockets-rails"
 gem "sprockets-redirect"


### PR DESCRIPTION
This PR removes Ruby Sass, which has been deprecated. It replaces it with [sassc](https://github.com/sass/sassc-ruby), which is a Ruby-friendly implementation of libsass maintained by the Sass organization.

I've successfully updated styling with the new gem, but haven't run any extensive tests. The fact that styles compile says to me that the logic does not need any rewriting, however. 