### PR TITLE
WIP overlay CTA over title card

### DIFF
--- a/app/assets/stylesheets/components/_video.scss
+++ b/app/assets/stylesheets/components/_video.scss
@@ -115,6 +115,7 @@
 
 .video-player {
   margin-bottom: $large-spacing;
+  position: relative;
 
   @include body-mobile {
     margin-bottom: $base-spacing;
@@ -143,6 +144,20 @@
 
     @include body-mobile {
       align-items: flex-start;
+    }
+  }
+
+  .video-placeholder {
+    .title-card img {
+      filter: blur(10px);
+      width: 100%;
+    }
+
+    .access-callout {
+      left: 0;
+      margin: 6em 4em;
+      position:absolute;
+      top: 0;
     }
   }
 }

--- a/app/assets/stylesheets/shared/components/_page-header.scss
+++ b/app/assets/stylesheets/shared/components/_page-header.scss
@@ -1,10 +1,10 @@
 .page-header {
   margin: 0 auto;
   max-width: $large-screen;
-  padding: $spacing-large $spacing-base;
+  padding-bottom: $spacing-medium;
 
   @media (min-width: $medium-screen) {
-    @include padding($spacing-x-large null);
+    @include padding($spacing-base null $spacing-medium);
   }
 
   &.media-object {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :capture_campaign_params
 
-  http_basic_authenticate_with(
-    name: ENV["HTTP_NAME"],
-    password: ENV["HTTP_PASSWORD"],
-    if: Proc.new { on_staging? },
-  )
-
   def current_user
     super || Guest.new
   end

--- a/app/views/videos/_preview_clip_or_image.html.erb
+++ b/app/views/videos/_preview_clip_or_image.html.erb
@@ -1,7 +1,11 @@
 <% if video.preview.present? %>
   <%= render video.preview, name: video.name %>
+  <%= render "videos/access_callout", video: video %>
 <% elsif video.part_of_trail? %>
-  <div class="title-card">
-    <%= image_tag video.trail.title_card_image %>
+  <div class="video-placeholder">
+    <div class="title-card">
+      <%= image_tag video.trail.title_card_image %>
+    </div>
+    <%= render "videos/access_callout", video: video %>
   </div>
 <% end %>

--- a/app/views/videos/_video_player.html.erb
+++ b/app/views/videos/_video_player.html.erb
@@ -1,7 +1,3 @@
-<span class="divider">
-  <h4 class="text">Video</h4>
-</span>
-
 <div class="video-player">
   <%= render video.clip %>
 

--- a/app/views/videos/_video_player_placeholder.html.erb
+++ b/app/views/videos/_video_player_placeholder.html.erb
@@ -1,9 +1,3 @@
-<%= render "videos/access_callout", video: video %>
-
-<span class="divider">
-  <h4 class="text">Video</h4>
-</span>
-
 <div class="video-player">
   <%= render "preview_clip_or_image", video: video %>
 </div>


### PR DESCRIPTION
Adds some basic css to have the CTA callout go over the title image for
trails. For weekly iterations, which have a preview video, the CTA
callout is moved below the video.

We also remove some whitespacing and the --video-- line.