### PR TITLE
Change landing links from checkout to practice

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -14,7 +14,7 @@
 
     <%= link_to(
       t(".hero_call_to_action"),
-      professional_checkout_path,
+      practice_path,
       class: "button button--large button--on-dark"
     )%>
   </section>
@@ -110,7 +110,7 @@
 
     <div class="page-content flex-grid">
       <%= link_to(
-        "Join Our Community", professional_checkout_path, class: "button"
+        "Join Our Community", practice_path, class: "button"
       )%>
     </div>
   </section>
@@ -150,7 +150,7 @@
 
     <div class="page-content flex-grid">
       <%= link_to(
-        "Start Learning Today", professional_checkout_path, class: "button"
+        "Start Learning Today", practice_path, class: "button"
       )%>
     </div>
 

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -1,16 +1,5 @@
 <% content_for :page_title, "Learn Ruby and Rails Development" %>
 
-<% if signed_out? %>
-  <div class="access-callout">
-    <p><%= t("trails.sign_up_cta") %></p>
-
-    <%= link_to github_auth_path, class: "pull-right cta-button subscribe-cta light-bg" do %>
-      <%= image_tag("github-black.svg", class: "logo", alt: "") %>
-      <%= t("authenticating.github_signin") %>
-    <% end %>
-  </div>
-<% end %>
-
 <section class="trails-progress">
   <header class="page-header">
     <h1 class="page-header__title">

--- a/spec/features/visitor_creates_subscription_spec.rb
+++ b/spec/features/visitor_creates_subscription_spec.rb
@@ -5,20 +5,6 @@ feature "Visitor signs up for a subscription" do
     create_plan
   end
 
-  scenario "visitor signs up by navigating from landing page", js: true do
-    create(:trail, :published)
-
-    visit root_path(campaign_params)
-    click_link I18n.t("pages.landing.hero_call_to_action")
-    show_email_and_username_form
-    fill_out_account_creation_form
-    fill_out_credit_card_form_with_valid_credit_card
-
-    expect(current_path).to be_the_welcome_page
-    expect_to_see_checkout_success_flash
-    expect_analytics_to_have_received_subscribed_event
-  end
-
   scenario "and creates email/password user", js: true do
     visit new_checkout_path(@plan)
     expect(page).to have_text "Sign up with GitHub"

--- a/spec/views/pages/landing.html.erb_spec.rb
+++ b/spec/views/pages/landing.html.erb_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "pages/landing.html.erb" do
+  it "renders links to the practice page" do
+    render
+
+    expect(rendered).to have_link href: "/upcase/practice", count: 3
+  end
+end

--- a/spec/views/practice/show.html.erb_spec.rb
+++ b/spec/views/practice/show.html.erb_spec.rb
@@ -23,16 +23,6 @@ describe "practice/show.html" do
     end
   end
 
-  context "when a user does not have an active subscription" do
-    it "renders a cta to subscribe" do
-      view_stubs(:github_auth_path).and_return("/auth/github")
-
-      render_show
-
-      expect(rendered).to have_content(I18n.t("trails.sign_up_cta"))
-    end
-  end
-
   context "for a non-admin user" do
     it "does not render the deck links" do
       stub_user_access(subscriber: true)


### PR DESCRIPTION
Why:
When a user reaches the landing page, we would like to redirect them to
the upcase/practice url and not the sign_up or checkout page. We also
don't want them to see the cta to go to signup on the practice page, for
preference in seeing it only on the content that requires signup.

This PR:
Switches over three links on the landing page to point to the practice
url and removes the cta on the practice page. Relevant tests were
removed and a simple view test for the new landing page links were added.