### PR TITLE
Styled about us page with video

### DIFF
--- a/app/assets/stylesheets/components/_welcome-page.scss
+++ b/app/assets/stylesheets/components/_welcome-page.scss
@@ -47,3 +47,107 @@
     margin-top: 20px;
   }
 }
+
+.about-us__video {
+  margin: 0 auto;
+  padding-top: $spacing-large;
+  max-width: 900px;
+}
+
+.about-us__lede {
+  max-width: 560px;
+  margin-bottom: $spacing-large;
+
+  p {
+    color: $color-gray-darker;
+    font-size: 1.4rem;
+    line-height: 1.3;
+    margin-bottom: $spacing-medium;
+    text-align: center;
+
+    &:first-of-type {
+      color: rgba(41, 41, 44, 0.9);;
+      font-family: "calibre-medium", sans-serif;
+      font-size: $large-font-size;
+      font-weight: normal;
+      line-height: 1.2;
+    }
+  }
+}
+
+.about-us__enter-upcase {
+  color: $color-red;
+  font-family: "calibre-medium", sans-serif;
+  font-size: $large-font-size;
+  font-weight: normal;
+  margin-bottom: $spacing-medium;
+  text-align: center;
+}
+
+.about-us__why-upcase {
+  color: rgba(41, 41, 44, 0.9);;
+  font-family: "calibre-medium", sans-serif;
+  font-size: $large-font-size;
+  font-weight: normal;
+  line-height: 1.2;
+  margin-top: -$spacing-base !important;
+  margin-bottom: $spacing-base !important;
+  text-align: center;
+}
+
+.about-us__history {
+  color: #a4a4a4;
+  text-align: center;
+}
+
+.about-us__topics-title {
+  color: $color-red;
+  font-family: "calibre-medium", sans-serif;
+  font-size: 1.5rem;
+  font-weight: normal;
+  margin-bottom: $spacing-base;
+  text-align: center;
+}
+
+.about-us__topic-list {
+  margin-bottom: 4rem;
+
+  @media (min-width: 800px) {
+    align-content: stretch;
+    display: flex;
+  }
+}
+
+.about-us__topic {
+  border-radius: 0 0 3px 3px;
+  border-top: 10px solid #f3f3f3;
+  box-shadow: 0 0 0 1px #ddd;
+  margin: 1em 0.5em;
+  overflow: hidden;
+  padding: 1.5em;
+  text-align: left;
+
+  @media (min-width: 800px) {
+    width: 25%;
+  }
+
+  strong {
+    color: #555;
+    display: block;
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
+}
+
+.about-us__upcase-reppresents {
+  margin: 0 auto 2rem auto;
+  max-width: 560px;
+  padding-left: $spacing-base;
+  padding-right: $spacing-base;
+  text-align: center;
+}
+
+.about-us__cta {
+  display: flex;
+  justify-content: center;
+}

--- a/app/views/pages/about_us.html.erb
+++ b/app/views/pages/about_us.html.erb
@@ -1,49 +1,82 @@
-<div class="welcome-page">
-  <%= content_for(:page_title, "About Us") %>
+<section class="page-section background background--upcase-logo-light">
+  <div class="about-us__video">
+    <%= render "clips/clip", clip: OpenStruct.new(wistia_id: "0nx71cjkbx") %>
+  </div>
+  <div class="page-content page-content--reading">
 
-  <%= render "clips/clip", clip: OpenStruct.new(wistia_id: "0nx71cjkbx") %>
+    <%= content_for(:page_title, "About Us") %>
 
-  <p>
-    Hi! We’re <a href="https://thoughtbot.com">thoughtbot</a>, a design and
-    development consultancy that brings your digital product ideas to life. When
-    we’re not partnering with clients to build or grow their web and mobile
-    apps, you’ll find us out in the community sharing what we’ve learned.
-  </p>
+    <div class="about-us__lede">
+      <p>
+        We’re <a href="https://thoughtbot.com">thoughtbot</a>, a design and
+        development consultancy that brings your digital product ideas to life
+      </p>
+      <p>
+        When we’re not partnering with clients to build or grow their web and
+        mobile apps, you’ll find us out in the community sharing what we’ve
+        learned.
+      </p>
+    <div>
+  </div>
+</section>
 
+<section class="page-section">
+    <div class="page-content page-content--interstitial">
+      <div class="card card--narrow">
+        <div class="card__content">
+          <h2 class="about-us__enter-upcase">Enter Upcase by thoughtbot!</h2>
+          <p class="card__copy card__copy--centered">
+            Since 2012, one way we’ve shared thoughtbot expertise is through the
+            learning platform you find yourself on today - Upcase. With Upcase,
+            we’ve helped thousands of developers level up their skills through
+            workshops, videos, flash cards, and coding exercises.
+          </p>
+        </div>
+      </div>
+    </div>
+</section>
 
-  <p>Enter Upcase by thoughtbot!</p>
+<section class="page-section">
+  <div class="page-content page-content--reading">
+    <h2 class="about-us__why-upcase">Why Upcase?</h2>
 
-  <p>
-    Since 2012, one way we’ve shared thoughtbot expertise is through the
-    learning platform you find yourself on today - Upcase. With Upcase, we’ve
-    helped thousands of developers level up their skills through workshops,
-    videos, flash cards, and coding exercises.
-  </p>
+    <div class="about-us__history">
+      <p>
+        While mentoring client teams, we identified a lack of educational content
+        for intermediate developers. We decided to to fill that gap ourselves with
+        Upcase.
+      </p>
+      <p>
+        The core of the Upcase platform is <mark>hundreds of hours of videos and
+        screencasts</mark>, neatly organized into courses and by topic so that
+        you can find exactly what you need and get to learning.
+      </p>
+    </div>
+  </div>
+</section>
 
-  <h2>Why Upcase?</h2>
+<section class="page-section page-section--dark">
+  <div class="page-content">
+    <h2 class="about-us__topics-title">Some of the topics we feature on Upcase include:</h2>
 
-  <p>While mentoring client teams, we identified a lack of educational content for intermediate developers. We decided to to fill that gap ourselves with Upcase.</p>
+    <ul class="about-us__topic-list">
+      <li class="about-us__topic"><strong>Test Driven Development</strong> in theory and in practice</li>
+      <li class="about-us__topic"><strong>Workflow &amp; developer</strong> tooling like Vim, tmux  and the command line</li>
+      <li class="about-us__topic"><strong>Opinionated</strong> introductions to new frameworks and languages</li>
+      <li class="about-us__topic"><strong>Techniques and patterns</strong> for building maintainable large scale applications</li>
+    </ul>
 
-  <p>The core of the Upcase platform is hundreds of hours of videos and
-  screencasts, neatly organized into courses and by topic so that you can find
-  exactly what you need and get to learning.</p>
+    <p class="about-us__upcase-reppresents">
+      Upcase represents the collective best practices of the team here at
+      thoughtbot. We’re thrilled to have opened it up to the public for free.
+    </p>
 
-  <p>Some of the topics we feature on Upcase include:</p>
-
-  <ul>
-    <li>Test Driven Development in theory and in practice</li>
-    <li>Workflow & developer tooling like Vim, tmux  and the command line</li>
-    <li>Opinionated introductions to new frameworks and languages</li>
-    <li>Techniques and patterns for building maintainable large scale applications</li>
-  </ul>
-
-  <p>
-  Upcase represents the collective best practices of the team here at thoughtbot, and we’re thrilled to have opened it up to the public for free.
-  </p>
-
-  <%= link_to(
-    "Start Learning Today!",
-    practice_path,
-    class: "button button--large button--on-dark"
-  )%>
-</div>
+    <div class="about-us__cta">
+      <%= link_to(
+        "Start Learning Today!",
+        practice_path,
+        class: "button button--large button--on-dark"
+      )%>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
This PR applies styling to the About Us page, as well as incorporating the announcement video for making Upcase free.

@christoomey A couple of things that don't stick well with me, but I'm kinda pressed for time with:

- The About Us styles live in the welcome-page Sass partial. For some reason, `application.scss` won't render a new partial.
- Classes aren't as DRY or use as much project logic as I'd like, but I think there's some weird collisions going on with marketing variables overriding application variables. 

Here's how it looks:

![screencapture-localhost-5000-upcase-about-us-2018-10-13-16_52_57](https://user-images.githubusercontent.com/634191/46909912-7d14c000-cf08-11e8-926c-b83404f913b9.png)
