### PR TITLE
Update link to thoughtbot blog post

### DIFF
--- a/app/views/design_for_developers_resources/index.html.erb
+++ b/app/views/design_for_developers_resources/index.html.erb
@@ -200,7 +200,7 @@
         </a>
       </li>
       <li>
-        <a class="article" href="http://robots.thoughtbot.com/post/12974565313/controlling-color-with-sass-color-functions">
+        <a class="article" href="https://thoughtbot.com/blog/controlling-color-with-sass-color-functions">
           <span>Sass Color Functions</span>
           <p>Article about color about how to purposefully use color functions in Sass.</p>
         </a>


### PR DESCRIPTION
Summary:
The thoughtbot blog has moved from `robots.thoughtbot.com` to
`thoughtbot.com/blog`. This change corrects a link that was broken due
to the recent move.