### PR TITLE
Remove asset_host config from production

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,5 @@
 AIRBRAKE_API_KEY=api_key
 APP_DOMAIN=localhost:3000
-ASSET_HOST=localhost:3000
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_BUCKET=test.books.thoughtbot
 AWS_SECRET_ACCESS_KEY=secret

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,7 +7,6 @@ Rails.application.configure do
 
   config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL") }
 
-  config.action_controller.asset_host = ENV.fetch("ASSET_HOST")
   config.assets.compile = false
   config.assets.digest = true
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
While it was served from it's own domain name, upcase was using cloudfront for a
CDN for stylesheets and other assets. When we moved it to thoughtbot.com/upcase
(which is behind fastly) we left that asset host configuration in place.

This is mostly harmless most of the time, but sometimes leads to an issue where
the html which is returned (via fastly cache) is referencing out of date css
(cached by cloudfront) and things show up as unstyled. This tends to be
triggered by some combination of restarting/deploying/cache-clearing of the two
apps.

This change removes the asset_host config option, which leads to upcase just
using Rails built in assets pipeline - which leads in turn to static assets
eventually being cached by Fastly.

I think that after this change is made we can probably:

- Shut down the cloudfront service related to Upcase?
- Remove the `ASSET_HOST` config var from staging and production heroku