### PR TITLE
Add missing fallback font for code

### DIFF
--- a/app/assets/stylesheets/shared/base/_variables.scss
+++ b/app/assets/stylesheets/shared/base/_variables.scss
@@ -44,7 +44,7 @@ $base-font-family: "calibre-regular", sans-serif;
 $strong-font-family: "calibre-medium", sans-serif;
 $heading-font-family: "calibre-medium", sans-serif;
 $title-font-family: "averta-standard-bold", sans-serif;
-$code-font-family: monaco;
+$code-font-family: "monaco", monospace;
 
 // Font size
 $small-font-size: 0.95rem;


### PR DESCRIPTION
The Monaco font didn't came preinstalled with my OS (Debian Buster) so all the fonts were falling back to a serif font. This, I believe, must be happening with a lot of other users.

So, here I'm proposing adding a fallback font -- the system's default monospace font -- just like how you've done with all the other font-families.

PS. Thank you so much for this awesome platform!