### PR TITLE
Add Visitor Analytics

### DIFF
--- a/app/views/application/_visitor_analytics.html.erb
+++ b/app/views/application/_visitor_analytics.html.erb
@@ -1,0 +1,5 @@
+<% if ENV["VISITOR_ANALYTICS"].present? %>
+  <script>
+  (function(v,i,s,a,t){v[t]=v[t]||function(){(v[t].v=v[t].v||[]).push(arguments)};if(!v._visaSettings){v._visaSettings={}}v._visaSettings[a]={v:'1.0',s:a,a:'1',t:t};var b=i.getElementsByTagName('body')[0];var p=i.createElement('script');p.defer=1;p.async=1;p.src=s+'?s='+a;b.appendChild(p)})(window,document,'//app-worker.visitor-analytics.io/main.js','<%= ENV["VISITOR_ANALYTICS"] %>','va')
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,5 +61,6 @@
 
     <%= render "shared/javascript" %>
     <%= render "layouts/footer" %>
+    <%= render "application/visitor_analytics" %>
   </body>
 </html>


### PR DESCRIPTION
This introduces a new analytics service, Visitor Analytics.
This service is a cookieless service that still respects privacy, but
provides us with a bit more information that Fathom provides.

We're currently keeping Fathom in place, but if Visitor Analytics works
well we plan to remove Fathom.
