### PR TITLE
Use `bin/dev` to start the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ your work.
 
         % bin/setup
 
-3. Start Foreman.
+3. Start the application.
 
-        % foreman start
+        % bin/dev
 
 4. Verify that the app is up and running.
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! foreman version &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start


### PR DESCRIPTION
Previously, we used `foreman start` to start the local application server. This did not give us a smooth experience if `foreman` was not already installed.

This commit adds `bin/dev` to start the local application. `bin/dev` has become a convention. The script checks for `foreman` and installs it if it is not already available.