### PR TITLE
Update the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"


### PR DESCRIPTION
We have been using the Dependabot preview for this project.

This commit updates the project to use the generally available version of Dependabot.

Ref:
- https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts