### PR TITLE
Update the setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,12 @@
 #!/usr/bin/env sh
 
-# Set up Rails app. Run this script immediately after cloning the codebase.
-# https://github.com/thoughtbot/guides/tree/master/protocol
+# Set up asdf if available
+if command -v asdf > /dev/null; then
+  printf 'Setting up tool dependencies via asdf...\n'
+  asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby || true
+  asdf plugin-update --all || true
+  asdf install
+fi
 
 # Set up Ruby dependencies via Bundler
 if ! command -v bundle > /dev/null; then


### PR DESCRIPTION
We are using `.tool-versions` on this project.

This commit updates the setup setup script to install the Ruby version in `.tool-versions` if `asdf` is available.

Ref:
- https://asdf-vm.com/manage/configuration.html#tool-versions
- https://github.com/thoughtbot/guides