### PR TITLE
Switch to `selenium-webdriver`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,10 +94,10 @@ group :test do
   gem "launchy"
   gem "rails-controller-testing"
   gem "rspec_junit_formatter"
+  gem "selenium-webdriver"
   gem "shoulda-matchers", require: false
   gem "simplecov", require: false
   gem "sinatra"
   gem "timecop"
-  gem "webdrivers"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     acts_as_list (1.0.2)
       activerecord (>= 4.2)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     argon2 (2.0.2)
       ffi (~> 1.9)
       ffi-compiler (>= 0.1)
@@ -106,13 +106,14 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
     byebug (11.1.3)
-    capybara (3.34.0)
+    capybara (3.40.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
+      regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     capybara-selenium (0.0.6)
       capybara
@@ -121,7 +122,6 @@ GEM
       capybara (>= 2.7, < 4)
     case_transform (0.2)
       activesupport
-    childprocess (3.0.0)
     clearance (2.3.0)
       actionmailer (>= 5.0)
       activemodel (>= 5.0)
@@ -254,6 +254,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -261,8 +262,8 @@ GEM
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
-    mini_mime (1.0.2)
-    mini_portile2 (2.8.1)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.6)
     minitest (5.21.2)
     msgpack (1.7.0)
     multi_json (1.15.0)
@@ -276,10 +277,10 @@ GEM
     nenv (0.3.0)
     nested_form (0.3.2)
     nio4r (2.7.0)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.16.4)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -321,11 +322,11 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.6)
+    public_suffix (5.0.5)
     puma (5.6.8)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    rack (2.2.8)
+    racc (1.7.3)
+    rack (2.2.9)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-livereload (0.3.17)
@@ -394,7 +395,7 @@ GEM
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
-    regexp_parser (1.8.2)
+    regexp_parser (2.9.0)
     remotipart (1.4.4)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -422,7 +423,7 @@ GEM
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby2_keywords (0.0.2)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -442,9 +443,11 @@ GEM
     scenic (1.5.4)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.19.0)
+      base64 (~> 0.2)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.7.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.7.0)
@@ -496,15 +499,12 @@ GEM
     vanity (3.0.0)
       i18n
     version_gem (1.1.4)
-    webdrivers (4.4.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.11.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
+    websocket (1.2.10)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -581,6 +581,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sassc
   scenic
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   shoulda-matchers
@@ -594,7 +595,6 @@ DEPENDENCIES
   uglifier
   validates_email_format_of
   vanity
-  webdrivers
   webmock
   webrick
   wrapped

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,15 +16,7 @@ require "rspec/rails"
 require "webmock/rspec"
 require "shoulda/matchers"
 
-WebMock.disable_net_connect!(
-  allow_localhost: true,
-  allow: [
-    Webdrivers::Common.subclasses.map(&:base_url),
-    "codeclimate.com",
-  ],
-)
-
-Webdrivers.cache_time = 86_400
+WebMock.disable_net_connect!(allow_localhost: true)
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),"support","**","*.rb"))].each {|f| require f}
 


### PR DESCRIPTION
We have been having issues with the `webdrivers` gem:
```
Webdrivers::VersionError:
 Unable to find latest point release version for 124.0.6367. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version:
 https://chromedriver.storage.googleapis.com/index.html
```

This commit replaces `webdrivers` with `selenium-webdriver` which does the same things "better".

Ref:
- https://github.com/titusfortner/webdrivers/issues/247