### PR TITLE
Add bundler-audit as a GitHub Action

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,0 +1,14 @@
+---
+name: Bundler Audit
+
+on: [push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Bundler Audit"
+        uses: thoughtbot/bundler-audit-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds `bundler-audit` to the project as a GitHub Action.

Ref:
- https://github.com/rubysec/bundler-audit