### PR TITLE
Specify Ruby with `.ruby-version` in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.0.7"
+ruby file: ".ruby-version"
 
 git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"


### PR DESCRIPTION
`Gemfile` allows on to use a `file` argument to specify where to get the Ruby version.

This commit implements this to get the Ruby version from `.ruby-version`. This will reduce the number of edits to make when upgrading the Ruby version in the future.

Ref:
- https://andycroll.com/ruby/read-ruby-version-in-your-gemfile/