### PR TITLE
Update podcast link on landing page

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -32,7 +32,7 @@
           </p>
           <p class="card__copy card__copy--centered">
           Listen to their stories on our
-            <a href="https://medium.com/@upcase">podcast.</a>
+            <a href="https://bikeshed.thoughtbot.com">podcast.</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Currently the podcast link on the lading page
points to medium this commit updates the link
to point to the bike shed website.