### PR TITLE
Revert "Update Bundler to v2.5.9"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,4 +655,4 @@ RUBY VERSION
    ruby 3.0.7p220
 
 BUNDLED WITH
-   2.5.9
+   2.3.9


### PR DESCRIPTION
We are currently unable to deploy Upcase to Heroku (staging). The logs say:

```
       Previously you had a successful deploy with bundler 2.3.25.
```

We will try to incrementally downgrade Bundler until we can deploy Upcase successfully.

Reverts thoughtbot/upcase#2454
