### PR TITLE
Explicitly specify Ruby version in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby file: ".ruby-version"
+ruby "3.0.7"
 
 git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"


### PR DESCRIPTION
This commit reverts to the default configuration of specifying the Ruby version in `Gemfile` instead of reading it from `.ruby-version`.