### PR TITLE
Add Standard

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,0 +1,47 @@
+# Auto generated files with errors to ignore.
+# Remove from this list as you refactor files.
+---
+ignore:
+- ".pryrc":
+  - Security/Eval
+- app/controllers/application_controller.rb:
+  - Style/SafeNavigation
+- app/helpers/videos_helper.rb:
+  - Lint/AssignmentInCondition
+- app/models/trail.rb:
+  - Style/RedundantSort
+- app/services/auth_hash_service.rb:
+  - Style/SafeNavigation
+- config/environments/development.rb:
+  - Lint/ConstantDefinitionInBlock
+- config/environments/production.rb:
+  - Style/GlobalStdStream
+  - Lint/ConstantDefinitionInBlock
+- config/environments/test.rb:
+  - Lint/ConstantDefinitionInBlock
+- config/initializers/time_formats.rb:
+  - Performance/RedundantMerge
+- db/migrate/20141125212241_update_explorable_topics.rb:
+  - Style/SafeNavigation
+- lib/tasks/search.rake:
+  - Lint/ConstantDefinitionInBlock
+- spec/controllers/memberships_controller_spec.rb:
+  - Style/SafeNavigation
+- spec/controllers/videos_controller_spec.rb:
+  - Style/MixinUsage
+- spec/features/clearance/user_signs_out_spec.rb:
+  - Lint/UselessAssignment
+- spec/features/subscriber_uses_flashcards_spec.rb:
+  - Lint/UselessAssignment
+- spec/features/subscriber_views_weekly_iteration_spec.rb:
+  - Style/RedundantInterpolation
+- spec/features/user_manages_team_subscription_spec.rb:
+  - Style/MixinUsage
+- spec/features/user_removes_pending_invitation_spec.rb:
+  - Style/MixinUsage
+- spec/features/user_removes_team_member_spec.rb:
+  - Style/MixinUsage
+- spec/support/fake_wistia.rb:
+  - Style/SlicingWithRange
+- spec/views/practice/show.html.erb_spec.rb:
+  - Lint/ShadowedArgument

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
   gem "bundler-audit", require: false
   gem "dotenv-rails"
   gem "rspec-rails"
+  gem "standard"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     argon2 (2.3.0)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
+    ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
     aws-eventstream (1.3.0)
@@ -230,6 +231,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (7.0.0)
       railties (>= 3.2.16)
+    json (2.7.2)
     jsonapi-renderer (0.2.2)
     jwt (2.8.1)
       base64
@@ -245,8 +247,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    language_server-protocol (3.17.0.3)
     launchy (2.5.0)
       addressable (~> 2.7)
+    lint_roller (1.1.0)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -331,6 +335,10 @@ GEM
       mime-types
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
+    parallel (1.25.1)
+    parser (3.3.3.0)
+      ast (~> 2.4.1)
+      racc
     pg (1.2.3)
     pg_search (2.3.5)
       activerecord (>= 5.2)
@@ -399,6 +407,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
+    rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -437,6 +446,23 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -501,6 +527,18 @@ GEM
     sprockets-redirect (1.0.0)
       activesupport (>= 3.1.0)
       rack
+    standard (1.37.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
     strscan (3.1.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
@@ -520,6 +558,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
+    unicode-display_width (2.5.0)
     uri (0.13.0)
     validates_email_format_of (1.8.2)
       i18n (>= 0.8.0)
@@ -622,6 +661,7 @@ DEPENDENCIES
   spring-commands-rspec
   sprockets-rails
   sprockets-redirect
+  standard
   timecop
   uglifier
   validates_email_format_of


### PR DESCRIPTION
This commit adds [Standard] for code linting and formatting. It also adds `.standard_todo.yml` for us to incrementally apply the formatting rules to the entire codebase.

Ref:
- https://github.com/standardrb/standard?tab=readme-ov-file#ignoring-every-violation-and-converting-them-into-a-todo-list

[Standard]:https://github.com/standardrb/standard