### PR TITLE
Support for inversing belongs_to -> has_many Active Record associations.

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -7,7 +7,7 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Support for inversing belongs_to -> has_many Active Record associations.
-# Rails.application.config.active_record.has_many_inversing = true
+Rails.application.config.active_record.has_many_inversing = true
 
 # Track Active Storage variants in the database.
 # Rails.application.config.active_storage.track_variants = true


### PR DESCRIPTION
This commit enables this Rails 6.1 framework default