### PR TITLE
Apply random variation to the delay when retrying failed jobs

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -13,7 +13,7 @@ Rails.application.config.active_record.has_many_inversing = true
 Rails.application.config.active_storage.track_variants = true
 
 # Apply random variation to the delay when retrying failed jobs.
-# Rails.application.config.active_job.retry_jitter = 0.15
+Rails.application.config.active_job.retry_jitter = 0.15
 
 # Stop executing `after_enqueue`/`after_perform` callbacks if
 # `before_enqueue`/`before_perform` respectively halts with `throw :abort`.


### PR DESCRIPTION
This commit applies this new framework default for Rails 6.1.