### PR TITLE
Make `form_with` generate non-remote forms by default

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -45,7 +45,7 @@ Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
 Rails.application.config.active_record.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
-# Rails.application.config.action_view.form_with_generates_remote_forms = false
+Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
 # Rails.application.config.active_storage.queues.analysis = nil


### PR DESCRIPTION
Apply this Rails 6.1 framework default.