### PR TITLE
Set default queue name for incineration job to queue adapter default

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -54,7 +54,7 @@ Rails.application.config.active_storage.queues.analysis = nil
 Rails.application.config.active_storage.queues.purge = nil
 
 # Set the default queue name for the incineration job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.incineration = nil
+Rails.application.config.action_mailbox.queues.incineration = nil
 
 # Set the default queue name for the routing job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.routing = nil


### PR DESCRIPTION
Apply this Rails 6.1 framework default.