### PR TITLE
Set default queue name for routing job to queue adapter default

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -57,7 +57,7 @@ Rails.application.config.active_storage.queues.purge = nil
 Rails.application.config.action_mailbox.queues.incineration = nil
 
 # Set the default queue name for the routing job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.routing = nil
+Rails.application.config.action_mailbox.queues.routing = nil
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
 # Rails.application.config.action_mailer.deliver_later_queue_name = nil


### PR DESCRIPTION
Apply this Rails 6.1 framework default.