### PR TITLE
Set default queue name for mail deliver job to queue adapter default

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -60,7 +60,7 @@ Rails.application.config.action_mailbox.queues.incineration = nil
 Rails.application.config.action_mailbox.queues.routing = nil
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
-# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+Rails.application.config.action_mailer.deliver_later_queue_name = nil
 
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.


### PR DESCRIPTION
Apply this Rails 6.1 framework default.