### PR TITLE
Load Rails 6.1 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Upcase
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Ref:
- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#configure-framework-defaults