### PR TITLE
Add `x86_64-linux` as a platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
       faraday (~> 2.0)
     ffi (1.17.0)
     ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -315,6 +316,8 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -599,6 +602,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers


### PR DESCRIPTION
We are experiencing an issue where nokogiri `1.16.7` is building on local machines but not on CI. CI is running Linux while most local development environments are on macOS.

This commit adds `x86_64-linux` as a platform in `Gemfile.lock`

Ref:
- https://github.com/thoughtbot/upcase/actions/runs/10453359247/job/28943662010?pr=2595