### PR TITLE
Apply Standard formatting

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,13 @@
 require "active_support/core_ext/integer/time"
 
+GITHUB_KEY = ENV["GITHUB_KEY"]
+GITHUB_SECRET = ENV["GITHUB_SECRET"]
+
+PAPERCLIP_STORAGE_OPTIONS = {
+  storage: :s3,
+  s3_credentials: "#{Rails.root}/config/s3.yml"
+}
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -72,14 +80,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.delivery_method = :test
-
-  PAPERCLIP_STORAGE_OPTIONS = {
-    storage: :s3,
-    s3_credentials: "#{Rails.root}/config/s3.yml"
-  }
-
-  GITHUB_KEY = ENV["GITHUB_KEY"]
-  GITHUB_SECRET = ENV["GITHUB_SECRET"]
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,15 @@
 require Rails.root.join("config/smtp")
 require "active_support/core_ext/integer/time"
 
+GITHUB_KEY = ENV["GITHUB_KEY"]
+GITHUB_SECRET = ENV["GITHUB_SECRET"]
+
+PAPERCLIP_STORAGE_OPTIONS = {
+  storage: :s3,
+  s3_credentials: "#{Rails.root}/config/s3.yml",
+  s3_protocol: "https"
+}
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -131,15 +140,6 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default(charset: "utf-8")
   config.action_mailer.raise_delivery_errors = true
-
-  PAPERCLIP_STORAGE_OPTIONS = {
-    storage: :s3,
-    s3_credentials: "#{Rails.root}/config/s3.yml",
-    s3_protocol: "https"
-  }
-
-  GITHUB_KEY = ENV["GITHUB_KEY"]
-  GITHUB_SECRET = ENV["GITHUB_SECRET"]
 
   config.middleware.insert_before(
     0,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,13 @@
 require "active_support/core_ext/integer/time"
 
+ENV["AWS_ACCESS_KEY_ID"] = "xxxxxxxxxxxxxxxxxxxx"
+ENV["AWS_SECRET_ACCESS_KEY"] = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+GITHUB_KEY = "githubkey"
+GITHUB_SECRET = "githubsecret"
+
+PAPERCLIP_STORAGE_OPTIONS = {}
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped
@@ -68,12 +76,4 @@ Rails.application.configure do
   config.after_initialize do
     Timecop.travel(Time.current)
   end
-
-  ENV["AWS_ACCESS_KEY_ID"] = "xxxxxxxxxxxxxxxxxxxx"
-  ENV["AWS_SECRET_ACCESS_KEY"] = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-  GITHUB_KEY = "githubkey"
-  GITHUB_SECRET = "githubsecret"
-
-  PAPERCLIP_STORAGE_OPTIONS = {}
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,8 +1,8 @@
+SEARCHABLE_MODELS = [Video, Flashcard, Trail]
+
 namespace :search do
   desc "Rebuild search index for all searchables"
   task rebuild: :environment do
-    SEARCHABLE_MODELS = [Video, Flashcard, Trail]
-
     puts "Clearing existing search index entries..."
     PgSearch::Document.delete_all
 


### PR DESCRIPTION
This commit resolves the following Standard warning:

```
Lint/ConstantDefinitionInBlock: Do not define constants this way within a block
```

Ref:
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ConstantDefinitionInBlock
- https://stackoverflow.com/questions/3409931/why-can-you-not-declare-constants-in-methods-with-ruby