### PR TITLE
Fix `rake search:rebuild` task

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,4 +1,4 @@
-SEARCHABLE_MODELS = [Video, Flashcard, Trail]
+SEARCHABLE_MODELS = ["Video", "Flashcard", "Trail"]
 
 namespace :search do
   desc "Rebuild search index for all searchables"
@@ -8,7 +8,7 @@ namespace :search do
 
     puts "Rebuilding index for #{SEARCHABLE_MODELS.join(", ")}."
     SEARCHABLE_MODELS.each do |model|
-      PgSearch::Multisearch.rebuild(model)
+      PgSearch::Multisearch.rebuild(model.constantize)
     end
   end
 end


### PR DESCRIPTION
The previous Standard formatting fixes broke `rake search:rebuild`. In it, we moved the constants to make them global.

This commit fixes the implementation of the rake task by updating how the constants are defined and used.