### PR TITLE
Apply Standard Formatting

### DIFF
--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-include StubCurrentUserHelper
-
 describe VideosController do
+  include StubCurrentUserHelper
+
   describe "#show" do
     context "when the video is part of the weekly iteration" do
       it "renders the view" do

--- a/spec/features/user_manages_team_subscription_spec.rb
+++ b/spec/features/user_manages_team_subscription_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
-include ActionView::Helpers::NumberHelper
 
 feature "User edits a team" do
+  include ActionView::Helpers::NumberHelper
+
   background do
     sign_in
   end

--- a/spec/features/user_removes_pending_invitation_spec.rb
+++ b/spec/features/user_removes_pending_invitation_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
-include ActionView::RecordIdentifier
 
 feature "Remove pending invitations" do
+  include ActionView::RecordIdentifier
+
   scenario "an owner removes a team member" do
     owner = create(:user, :with_attached_team)
     invitation_to_remove = create(:invitation, team: owner.team)

--- a/spec/features/user_removes_team_member_spec.rb
+++ b/spec/features/user_removes_team_member_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
-include ActionView::RecordIdentifier
 
 feature "Remove team members" do
+  include ActionView::RecordIdentifier
+
   scenario "an owner removes a team member" do
     owner = create(:user, :with_attached_team)
     owner.team.update(owner: owner)


### PR DESCRIPTION
This commit resolves the following Standard warning:

```
spec/features/user_removes_team_member_spec.rb:2:1: Style/MixinUsage:`include` is used at the top level. Use inside `class` or `module`.
```