### PR TITLE
Fix `TimeWithZone#to_s(:rfc822)` is deprecated

### DIFF
--- a/app/views/videos/_video.rss.builder
+++ b/app/views/videos/_video.rss.builder
@@ -5,5 +5,5 @@ xml.item do
   end
   xml.guid video_url(video)
   xml.link video_url(video)
-  xml.pubDate video.created_at.to_s(:rfc822)
+  xml.pubDate video.created_at.to_fs(:rfc822)
 end

--- a/spec/features/videos_spec.rb
+++ b/spec/features/videos_spec.rb
@@ -41,7 +41,7 @@ describe "Videos" do
           .to eq(video_url(published_video))
 
         expect(text_in(item, ".//pubDate"))
-          .to eq(published_video.created_at.to_s(:rfc822))
+          .to eq(published_video.created_at.to_fs(:rfc822))
 
         expect(text_in(item, ".//description")).to match(/#{notes}/)
       end


### PR DESCRIPTION
When running `bundle exec rspec`, we are getting:

```
DEPRECATION WARNING: TimeWithZone#to_s(:rfc822) is deprecated. Please use TimeWithZone#to_fs(:rfc822) instead. (called from call at ~/upcase/spec/support/host_map.rb:7)
```

This commit resolves the issue by using `TimeWithZone#to_fs(:rfc822)`.

Resolves #2630