### PR TITLE
Bump redcarpet from 3.5.1 to 3.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
       ffi (~> 1.0)
     recipient_interceptor (0.3.2)
       mail
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
     redis-client (0.22.2)


### PR DESCRIPTION
While running the test suite, we are getting this warning:

```
application_helper.rb:9: warning: undefining the allocator of T_DATA class Redcarpet::Markdown
```

This commit updates Redcarpet and clears the warning.