### PR TITLE
Add `faraday-multipart` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "csv"
 gem "delayed_job_active_record"
 gem "drb"
 gem "dynamic_form"
+gem "faraday-multipart", require: false
 gem "faraday-retry"
 gem "flutie"
 gem "font-awesome-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
       railties (>= 5.0.0)
     faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.1.0)
       net-http
     faraday-retry (2.2.1)
@@ -303,6 +305,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    multipart-post (2.4.1)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
@@ -633,6 +636,7 @@ DEPENDENCIES
   dynamic_form
   email_spec
   factory_bot_rails
+  faraday-multipart
   faraday-retry
   flutie
   font-awesome-rails


### PR DESCRIPTION
We are getting the following notification when running tests:

```
To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses``
```

This commit adds the `faraday-multipart` gem (with `require: false`) to clear the warning.