### PR TITLE
Update the Standard GitHub Action configuration

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: StandardRB Linter
-        uses: testdouble/standard-ruby-action@v1.3.0
+        uses: standardrb/standard-ruby-action@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          ruby-version: "3.2.5"
-          autofix: false


### PR DESCRIPTION
The Standard GitHub Action will now set the Ruby version using the `.ruby-version` file if present.

This commit updates the configuration to take advantage of this new feature.