### PR TITLE
Bump webrick from 1.8.1 to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,7 +597,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)


### PR DESCRIPTION
CI is currently failing because of a security advisory on webrick.

This commit updates webrick to a patched version.

Ref:
- https://github.com/thoughtbot/upcase/security/dependabot/106