### PR TITLE
Temporarily ignore CVE-2024-21510

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,2 @@
+ignore:
+  - CVE-2024-21510 # https://github.com/thoughtbot/upcase/security/dependabot/113


### PR DESCRIPTION
We have a moderate security advisory on Sinatra. There is no patched version currently available.

This commit temporarily ignores bundler audit checking for this issue until a patched version of Sinatra is available.

Ref:
- https://github.com/thoughtbot/upcase/security/dependabot/113