### PR TITLE
Add cta link to nav bar

### DIFF
--- a/app/assets/stylesheets/shared/components/_site-nav.scss
+++ b/app/assets/stylesheets/shared/components/_site-nav.scss
@@ -125,6 +125,12 @@
   }
 }
 
+.site-nav__link_cta {
+  border: 1px solid $color-white;
+  border-radius: $base-border-radius;
+  padding: $spacing-base / 2;
+}
+
 .site-nav__button {
   background-color: $color-gray-darkest;
   border-radius: $base-border-radius;

--- a/app/views/layouts/_header_application_links.html.erb
+++ b/app/views/layouts/_header_application_links.html.erb
@@ -48,6 +48,14 @@
       ) %>
     </li>
 
+    <li>
+      <%= link_to(
+        t("shared.header.hire_us"),
+        "https://thoughtbot.com/services/custom-training-learning-course-upcase",
+        class: "site-nav__link site-nav__link_cta",
+      ) %>
+    </li>
+
     <% if signed_out? %>
       <li>
         <% if landing_page? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
       sign_out: Sign Out
       trails: Trails
       weekly_iteration: Weekly Iteration
+      hire_us: Hire Us
     subscription:
       name: Upcase
     subscriptions:


### PR DESCRIPTION
This commit adds a "Hire us" link to the nav bar.

---
<img width="1029" alt="Screenshot 2025-03-06 at 14 54 20" src="https://github.com/user-attachments/assets/1594077d-d827-4820-bd86-3e44318dda79" />


