### PR TITLE
Send opportunities to hub as Inbound

### DIFF
--- a/app/controllers/marketing_redesign/opportunities_controller.rb
+++ b/app/controllers/marketing_redesign/opportunities_controller.rb
@@ -10,7 +10,8 @@ module MarketingRedesign
       Hub::Opportunities.create({
         **opportunity_params,
         conversion_point: HUB_CONVERSION_POINT,
-        project_type: HUB_PROJECT_TYPE
+        project_type: HUB_PROJECT_TYPE,
+        inbound: true
       })
       redirect_to(
         {action: :show}

--- a/spec/controllers/marketing_redesign/opportunities_controller_spec.rb
+++ b/spec/controllers/marketing_redesign/opportunities_controller_spec.rb
@@ -33,6 +33,7 @@ describe MarketingRedesign::OpportunitiesController do
           "email" => "example@example.com",
           "company_name" => "Example Company",
           "contact_job_title" => "Example Job Title",
+          :inbound => true,
           :conversion_point => be_present,
           :project_type => be_present
         })


### PR DESCRIPTION
Without this flag, additional processing, like Slack notifications
doesn't fire.
